### PR TITLE
feat: time logging for coding agents — tt agent, tt report, and TUI surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,14 @@ The TUI shows the same open phases in its **Agents** panel, on `Shift-A`.
   stored — a smaller figure than the span it was given.
 - **exit 64, no mark** — never marked, or the mark was lost. Use `item` with a
   duration you can justify, or ask. A missing summary is the same exit code.
+- **exit 75, a close left unfinished** — an earlier close started and never finished, so
+  it may already have recorded the entry. `begin` refuses on the same leftover. Read
+  `tt report` first: if the entry is there, `tt agent cancel` the phase to clear the
+  leftover; if it is not, cancel and then close the phase again. Never clear it blind.
+- **exit 74, recorded but not cleared** — the entry **is** in the store and only the
+  mark cleanup failed, an unwritable mark directory being the usual cause. **Do not
+  retry the close**: a retry is exactly what would log the span twice. Say what
+  happened, and `tt agent cancel` the phase once the directory is writable again.
 
 ## Reading back
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,174 @@
+# Time logging contract
+
+For any coding agent working in a repo where the operator tracks time with `tt`.
+Tool-agnostic — this needs a shell and nothing else.
+
+Everything here is `tt` itself. Run
+`cargo install --git https://github.com/linus-skold/timetracker-rs` and the whole
+workflow is on your `PATH`.
+
+## Rules
+
+1. **Only one writer.** If you orchestrate subagents, only the orchestrator logs.
+   Subagents report back; the orchestrator records. This is not about safety —
+   concurrent writes are serialized under an exclusive lock and no entry is lost —
+   it is about the **unit**: if every worker logged its own turn, one issue would
+   produce twenty rows instead of one and the rollup would stop meaning anything.
+2. **The unit is a completed piece of work, not a commit.** Planning is work. So is
+   a review that concludes "don't ship" and an investigation that produces no code.
+   One entry per phase — several passes and a QA loop on one issue is one entry,
+   not five.
+3. **Never batch at day's end.** `tt log` back-dates from now, so entries written in
+   a batch claim overlapping slots. Totals stay right; the timeline stops being
+   true. Log when each phase finishes. `tt report` counts the overlaps so this stays
+   visible rather than quietly rotting.
+
+## Naming
+
+- **project** — resolve in order: **`$TT_PROJECT`** if it is set, else the repo
+  directory name `basename $(git rev-parse --show-toplevel)`, else ask. A directory
+  name is a guess that is usually right; `$TT_PROJECT` is a statement, and the two
+  diverge for clones renamed on disk, for multi-repo projects, and for monorepos
+  whose directory is not what time is billed to. (If the operator uses a per-repo
+  environment manager such as `mise` or `direnv`, `$TT_PROJECT` is a natural thing
+  for them to declare there, so the value travels with the repo.)
+- **issue** — the tracked issue number, or `-` if untracked
+- **phase** — one of `plan` `impl` `qa` `review` `docs` `spike` `ops`; see
+  [Which phase](#which-phase)
+
+**project is a real field** on the entry, not a tag: the agent commands pass it as
+`tt log --project <project>`, so it is stored explicitly rather than guessed. This
+matters when reading rollups back — `tt report` groups on the field.
+
+### Which phase
+
+| Work | Phase |
+|---|---|
+| planning, breaking work down, writing a spec | `plan` |
+| writing or changing code | `impl` |
+| verifying behaviour, running or fixing tests | `qa` |
+| reading code to judge it, whether or not it changes | `review` |
+| documentation | `docs` |
+| investigation that produces no artifact | `spike` |
+| tooling, config, environment, release | `ops` |
+
+## Summary and tags
+
+The **summary** is a short descriptor, **3-6 words**, plain prose. No issue number,
+no phase word, no `#` anything — the fields and tags already carry all three, and a
+`#` in prose becomes a junk tag (`tt` harvests every `#word`; the agent commands
+strip leading ones, so "see #12" logs as "see 12", which reads oddly). Write what
+the work *was*: `"store/links boundary"`, `"pane focus and cursor markers"`,
+`"heartbeat gap threshold"`.
+
+**Tags are deliberately sparse** — three, one per axis the fields cannot express:
+
+| Tag | Axis |
+|---|---|
+| `#<project>/<issue>` | item — per-issue rollups inside a project; omitted when issue is `-` |
+| `#<phase>` | phase |
+| `#agent` | written by an agent, not by hand |
+
+There is **no bare `#<project>` tag**. Project is a real field with its own axis; a
+tag duplicating it only made every project appear twice in the tag list.
+
+`#agent` comes only from `item` and `end`. A plain `tt log …` written by hand stays
+unmarked, which is what makes the two distinguishable at all.
+
+## Commands
+
+```sh
+# time a phase
+tt agent begin <project> <issue|-> <phase>
+tt agent touch <project> <issue|-> <phase>     # work confirmed still happening
+tt agent end   <project> <issue|-> <phase> "<summary>"
+
+# or log a known duration outright
+tt agent item  <project> <issue|-> <phase> "<summary>" <minutes>
+
+tt agent list                                  # what is still open
+tt agent cancel <project> <issue|-> <phase>    # drop without logging
+
+tt report [--week|--all|--since DATE [--until DATE]] [--project NAME] [--json]
+```
+
+Durations are rounded to 15 minutes, floor 15.
+
+A mark's start time survives the agent's context being truncated or compacted, so do
+not hold start times in context. Marks live in the application's own cache directory;
+`TT_MARK_DIR` overrides it.
+
+`touch` matters twice over: `end` measures start → last touch, not start → now, so
+idle time after the work finished is not counted — and the heartbeats it appends are
+what let a long phase log without a question. `end` refuses on a *silent gap*, never
+on length, so a stretch between heartbeats over `TT_MAX_GAP_MINUTES`
+or `agent.max_gap_minutes` (default 45) is what gets flagged.
+
+A phase that produced **no heartbeat at all** is judged on its own threshold instead,
+`TT_MAX_UNVOUCHED_MINUTES` or `agent.max_unvouched_minutes` (default 120). No beats is the absence of instrumentation —
+a session that compacted, or `begin`/`end` without any `touch` — where a hole between
+beats is positive evidence that work stopped, so the unmeasured phase gets the longer
+allowance. Long enough is still refused: 120 minutes with nothing to show for it wants
+a human.
+
+## Working in parallel
+
+Marks are keyed `project/issue/phase`, so any number can be open at once — several
+issues in one repo, several repos, or both. They are independent: ending one never
+touches another.
+
+If you run no subagents, rule 1 costs you nothing, since you are the only writer. Log
+as each phase finishes rather than at the end of the session.
+
+**Never end or cancel a mark you did not open.** `tt agent list` shows every open mark,
+including other sessions'. One you did not open means work is in flight elsewhere, not
+that something broke.
+
+At session start you cannot tell a crashed session's leftover from a live sibling's
+work — not even for your own project and issue. Say what you found and let the operator
+decide.
+
+The TUI shows the same open phases in its **Agents** panel, on `Shift-A`.
+
+## When `end` refuses
+
+- **exit 65, silent gap over threshold** — the heartbeats show a stretch with no sign
+  of work in it, and the message names that stretch's length and clock interval, then
+  quotes what `--full` and what `--trim` would log. Length alone is never the
+  complaint: a long session that kept heartbeating logs silently. Which threshold
+  applied depends on the evidence — 45 minutes between beats, 120 for a phase that
+  never beat at all.
+
+  **Ask the operator about the named gap — never pick between `--full` and `--trim`
+  yourself**, and reach for neither by reflex; only the person who was there knows
+  whether the silence was work or a break. Then re-run with `--full` to accept the
+  measured span, with `--trim` to log it minus **every** flagged gap, or pass the real
+  minutes as a trailing argument — which wins over both flags. `--trim` never fires on
+  its own and is never a default.
+
+  `--full` records the flagged gaps on the entry (`tt log --idle=<start>-<end>`, one
+  per gap), so the evidence survives rather than being discarded, and the intervals
+  can be trimmed later from the TUI's detail popover with `[t]`. `--trim` is
+  **destructive and unconfirmed**: it splits the entry into the pieces between the
+  gaps there and then, so the silence is gone and what it reports back is what it
+  stored — a smaller figure than the span it was given.
+- **exit 64, no mark** — never marked, or the mark was lost. Use `item` with a
+  duration you can justify, or ask. A missing summary is the same exit code.
+
+## Reading back
+
+Use `tt report`, never parse `tt list` — that output is emoji-decorated text for
+humans. `tt report --json` is the machine-readable form.
+
+- With no scope it reports today; `--week` runs from Monday, `--all` is unbounded,
+  `--since DATE` opens a range.
+- `--until DATE` **narrows** one of those, and is a usage error on its own — there
+  would be nothing to narrow but the single default day.
+- Projects come from the **project field**, so `--project NAME` filters on what was
+  stored rather than on a tag.
+
+`tt report` is a pure read: it takes no lock and does not touch the store, so a
+rollup never blocks a close that is happening at the same time.
+
+Its overlap counter is a health check on rule 3: if it climbs, logging has drifted
+away from the moments it should be attached to.

--- a/readme.md
+++ b/readme.md
@@ -209,3 +209,7 @@ max_unvouched_minutes = 120 # how long a phase with no heartbeat at all may run
 
 `TT_MAX_GAP_MINUTES` and `TT_MAX_UNVOUCHED_MINUTES` override the two `[agent]`
 settings for a single invocation.
+
+`TT_DATA_DIR` overrides the directory holding `data.json` and `data.lock`, and
+`TT_CONFIG_FILE` overrides the config file path itself. An empty value for either
+counts as unset, leaving the defaults above in force.

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,34 @@ tt today
 
 ---
 
+### `tt report [--week|--all|--since <date>] [--until <date>] [--project <name>] [--json]`
+
+Roll up logged time by project and item, with a per-phase breakdown.
+
+- `--week` — this week, from Monday
+- `--all` — every entry, unbounded
+- `--since <YYYY-MM-DD>` — from that date onwards
+- `--until <YYYY-MM-DD>` — up to and including that date; narrows one of the three
+  scopes above and is a usage error without one
+- `--project <name>` — only entries whose project is `<name>`
+- `--json` — machine-readable output
+
+With no scope it reports today. Project totals come from each entry's **project
+field** (`--project` on `tt start` / `tt log`), never from its tags.
+
+A trailing `*` marks an item with a running entry. When spans overlap, the report
+says so: `tt log` back-dates from now, so entries logged in a batch claim
+overlapping slots — the totals stay right, the timeline does not.
+
+```sh
+tt report
+tt report --week
+tt report --since 2026-08-01 --until 2026-08-05
+tt report --project timetracker-rs --json
+```
+
+---
+
 ### `tt list [-n <limit>]`
 
 Show the most recent entries across all days (defaults to the last 20).

--- a/readme.md
+++ b/readme.md
@@ -201,4 +201,11 @@ day_med_hours = 4
 
 [list]
 default_limit = 20     # default for `tt list` when -n isn't passed
+
+[agent]
+max_gap_minutes = 45        # silence between heartbeats that `tt agent end` refuses on
+max_unvouched_minutes = 120 # how long a phase with no heartbeat at all may run
 ```
+
+`TT_MAX_GAP_MINUTES` and `TT_MAX_UNVOUCHED_MINUTES` override the two `[agent]`
+settings for a single invocation.

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@ logged = "📝"
 warning = "⚠️"
 calendar = "📅"
 list = "📋"
+agent = "🤖"
 
 [duration]
 entry_high_hours = 4   # single-entry duration coloring

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -14,6 +14,7 @@ use chrono::{DateTime, Local};
 use crate::tracker::IdleInterval;
 
 use crate::cli::{self, AgentCommands};
+use crate::config;
 use crate::icons;
 use crate::marks::{self, Begin, Touch};
 
@@ -359,24 +360,34 @@ fn article(minutes: i64) -> &'static str {
 }
 
 /// How long a silence *between heartbeats* has to be to count, in minutes.
-/// `TT_MAX_GAP_MINUTES`, else 45.
+/// `TT_MAX_GAP_MINUTES`, else `agent.max_gap_minutes`, else 45.
 fn max_gap_minutes() -> i64 {
-    minutes("TT_MAX_GAP_MINUTES", 45)
+    minutes(
+        "TT_MAX_GAP_MINUTES",
+        config::load().agent.max_gap_minutes,
+        45,
+    )
 }
 
 /// How long an **unvouched** phase — a mark with no heartbeat at all — may run
-/// before the close is refused. `TT_MAX_UNVOUCHED_MINUTES`, else 120, longer
-/// than the interior-silence threshold.
+/// before the close is refused. `TT_MAX_UNVOUCHED_MINUTES`, else
+/// `agent.max_unvouched_minutes`, else 120, longer than the interior-silence
+/// threshold.
 fn max_unvouched_minutes() -> i64 {
-    minutes("TT_MAX_UNVOUCHED_MINUTES", 120)
+    minutes(
+        "TT_MAX_UNVOUCHED_MINUTES",
+        config::load().agent.max_unvouched_minutes,
+        120,
+    )
 }
 
-/// A minutes-valued setting: the environment wins over the built-in default.
-/// Set-but-empty and unparseable read as unset.
-fn minutes(name: &str, default: i64) -> i64 {
+/// A minutes-valued setting: the environment wins over the config file, which
+/// wins over the built-in default. Set-but-empty and unparseable read as unset.
+fn minutes(name: &str, configured: Option<i64>, default: i64) -> i64 {
     std::env::var(name)
         .ok()
         .and_then(|value| value.parse().ok())
+        .or(configured)
         .unwrap_or(default)
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -104,8 +104,20 @@ fn begin(project: &str, issue: &str, phase: &str) -> Result<()> {
                 since
             );
         }
+        Begin::Closing => refuse_unfinished_close(project, issue, phase),
     }
     Ok(())
+}
+
+/// Report a close that was started and never finished, and exit 75. The leftover
+/// is named, never cleared: only the operator can tell whether its entry landed.
+fn refuse_unfinished_close(project: &str, issue: &str, phase: &str) -> ! {
+    eprintln!(
+        "tt: {} has an unfinished close — a previous close may already have recorded its entry",
+        phase_name(project, issue, phase)
+    );
+    eprintln!("tt: check tt report, then tt agent cancel {project} {issue} {phase} to clear it.");
+    std::process::exit(75);
 }
 
 /// `tt agent touch <project> <issue|-> <phase>`: record one heartbeat. Exits 64
@@ -239,6 +251,10 @@ fn end(
     };
 
     let dir = mark_dir()?;
+    if marks::is_closing_in(&dir, project, issue, phase) {
+        refuse_unfinished_close(project, issue, phase);
+    }
+
     let mut idle = Vec::new();
     let mut split_at_idle = false;
     // Stays `None` on the explicit-minutes path, which reads no timestamps.
@@ -301,6 +317,9 @@ fn end(
         }
     };
 
+    // Written before the entry, so a mark directory that cannot be written fails
+    // here with nothing logged and the retry safe.
+    marks::start_closing_in(&dir, project, issue, phase)?;
     log_entry(
         project,
         issue,
@@ -313,7 +332,16 @@ fn end(
     )?;
     // Cleared only once the entry is recorded, on every successful close; a
     // refusal returned above with the mark and its beats left in place.
-    marks::cancel_in(&dir, project, issue, phase)?;
+    if let Err(err) = marks::cancel_in(&dir, project, issue, phase) {
+        eprintln!(
+            "tt: {} is recorded, but its mark could not be cleared: {err}",
+            phase_name(project, issue, phase)
+        );
+        eprintln!(
+            "tt: do not retry the close — run tt agent cancel {project} {issue} {phase} once the mark directory is writable."
+        );
+        std::process::exit(74);
+    }
     Ok(())
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,517 @@
+//! The `tt agent` commands: the agent layer's phase marks.
+//!
+//! Presentation only; [`crate::marks`] owns every fact about the mark files.
+//!
+//! **`begin`, `touch`, `cancel` and `list` must touch no store** — `main.rs`
+//! dispatches them ahead of its migrate preamble. `item` and `end` log an entry
+//! through [`crate::cli::log`] and dispatch after it.
+//!
+//! The messages are a contract: their caller is an agent following prose.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local};
+
+use crate::tracker::IdleInterval;
+
+use crate::cli::{self, AgentCommands};
+use crate::icons;
+use crate::marks::{self, Begin, Touch};
+
+/// Run one `tt agent` subcommand.
+pub fn run(command: &AgentCommands) -> Result<()> {
+    match command {
+        AgentCommands::Begin {
+            project,
+            issue,
+            phase,
+        } => begin(project, issue, phase),
+        AgentCommands::Touch {
+            project,
+            issue,
+            phase,
+        } => touch(project, issue, phase),
+        AgentCommands::Cancel {
+            project,
+            issue,
+            phase,
+        } => cancel(project, issue, phase),
+        AgentCommands::List => list(),
+        AgentCommands::Item {
+            project,
+            issue,
+            phase,
+            summary,
+            minutes,
+        } => item(
+            project,
+            issue,
+            phase,
+            summary.as_deref(),
+            minutes.as_deref(),
+        ),
+        AgentCommands::End {
+            project,
+            issue,
+            phase,
+            summary,
+            minutes,
+            full,
+            trim,
+        } => end(
+            project,
+            issue,
+            phase,
+            summary.as_deref(),
+            minutes.as_deref(),
+            *full,
+            *trim,
+        ),
+    }
+}
+
+/// The mark directory, or an error — a `begin` must never silently record
+/// nothing.
+fn mark_dir() -> Result<std::path::PathBuf> {
+    marks::mark_dir().context("could not determine a cache directory for the marks")
+}
+
+/// The phase as the messages name it: `<project>/<issue> <phase>`, with the `-`
+/// sentinel left in place. Only `list` collapses it.
+fn phase_name(project: &str, issue: &str, phase: &str) -> String {
+    format!("{}/{} {}", project, issue, phase)
+}
+
+/// `tt agent begin <project> <issue|-> <phase>`: open a mark, or keep the one
+/// already open. Idempotent: the original start wins, on stderr, exit 0.
+fn begin(project: &str, issue: &str, phase: &str) -> Result<()> {
+    let dir = mark_dir()?;
+    match marks::begin_in(&dir, project, issue, phase)? {
+        Begin::Created(start) => println!(
+            "marked {} at {}",
+            phase_name(project, issue, phase),
+            start.format("%H:%M")
+        ),
+        Begin::AlreadyOpen(start) => {
+            // `??:??` for a mark whose contents are not a timestamp.
+            let since = start.map_or_else(
+                || "??:??".to_string(),
+                |start| start.format("%H:%M").to_string(),
+            );
+            eprintln!(
+                "tt: already marked {} (since {}) — using the original start",
+                phase_name(project, issue, phase),
+                since
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `tt agent touch <project> <issue|-> <phase>`: record one heartbeat. Exits 64
+/// on an unmarked phase; anyhow would exit 1, so the code is set explicitly.
+fn touch(project: &str, issue: &str, phase: &str) -> Result<()> {
+    let dir = mark_dir()?;
+    match marks::touch_in(&dir, project, issue, phase)? {
+        Touch::Recorded => Ok(()),
+        Touch::NoMark => {
+            eprintln!(
+                "tt: no mark for {} — nothing to touch",
+                phase_name(project, issue, phase)
+            );
+            std::process::exit(64);
+        }
+    }
+}
+
+/// `tt agent cancel <project> <issue|-> <phase>`: drop a mark without logging.
+/// Succeeds whether or not there was anything to drop.
+fn cancel(project: &str, issue: &str, phase: &str) -> Result<()> {
+    let dir = mark_dir()?;
+    marks::cancel_in(&dir, project, issue, phase)?;
+    println!("dropped mark for {}", phase_name(project, issue, phase));
+    Ok(())
+}
+
+/// `tt agent list`: every open mark, newest first, in `cli::list`'s shape —
+/// header, blank line, rows at the status-glyph indent, or a bare
+/// `No open marks.`
+fn list() -> Result<()> {
+    let marks = marks::open_marks();
+    if marks.is_empty() {
+        println!("No open marks.");
+        return Ok(());
+    }
+
+    println!("{} Open marks:\n", icons::agent());
+    for row in marks::rows(&marks) {
+        println!("  {}", row);
+    }
+    Ok(())
+}
+
+/// `tt agent item <project> <issue|-> <phase> <summary> <minutes>`: log one
+/// finished piece of work in one call. No mark file is read, written or cleared.
+fn item(
+    project: &str,
+    issue: &str,
+    phase: &str,
+    summary: Option<&str>,
+    minutes: Option<&str>,
+) -> Result<()> {
+    let (Some(summary), Some(minutes)) = (summary, minutes) else {
+        eprintln!("tt: usage: tt agent item <project> <issue|-> <phase> <summary> <minutes>");
+        std::process::exit(64);
+    };
+    let minutes = whole_minutes(minutes);
+    log_entry(
+        project,
+        issue,
+        phase,
+        summary,
+        minutes,
+        Vec::new(),
+        false,
+        None,
+    )
+}
+
+/// A minutes argument, or exit 64 with `minutes must be a whole number, got
+/// '<x>'` — hand-parsed because clap would exit 2 with its own usage block.
+/// Stricter than `parse`: no sign, no whitespace, no `+`.
+fn whole_minutes(raw: &str) -> i64 {
+    let digits = !raw.is_empty() && raw.bytes().all(|byte| byte.is_ascii_digit());
+    match digits.then(|| raw.parse().ok()).flatten() {
+        Some(minutes) => minutes,
+        None => {
+            eprintln!("tt: minutes must be a whole number, got '{raw}'");
+            std::process::exit(64);
+        }
+    }
+}
+
+/// Log the entry both `item` and `end` end at. `extra_tags` stays empty: every
+/// tag is already in the description. `ended_at` is the mark's last heartbeat for
+/// a mark-derived close and `None` where there is no mark timeline to pin to.
+#[allow(clippy::too_many_arguments)]
+fn log_entry(
+    project: &str,
+    issue: &str,
+    phase: &str,
+    summary: &str,
+    minutes: i64,
+    idle: Vec<IdleInterval>,
+    trim: bool,
+    ended_at: Option<DateTime<Local>>,
+) -> Result<()> {
+    cli::log(
+        description(project, issue, phase, summary),
+        format!("{}m", round_quarter(minutes)),
+        Vec::new(),
+        Some(project.to_string()),
+        idle,
+        trim,
+        ended_at,
+    )
+}
+
+/// `tt agent end <project> <issue|-> <phase> <summary> [minutes|--full|--trim]`:
+/// close a marked phase, measured to its **last heartbeat** and never to now. A
+/// flagged silence with nothing said about it **refuses** the close.
+///
+/// Explicit minutes win over both flags and skip the mark's timestamps entirely;
+/// `--full` logs the measured span, `--trim` the span minus every flagged gap.
+fn end(
+    project: &str,
+    issue: &str,
+    phase: &str,
+    summary: Option<&str>,
+    minutes: Option<&str>,
+    full: bool,
+    trim: bool,
+) -> Result<()> {
+    let Some(summary) = summary else {
+        // Hand-checked: a required positional would exit 2, not 64.
+        eprintln!(
+            "tt: need a summary: tt agent end <project> <issue|-> <phase> <summary> [minutes]"
+        );
+        std::process::exit(64);
+    };
+
+    let dir = mark_dir()?;
+    let mut idle = Vec::new();
+    let mut split_at_idle = false;
+    // Stays `None` on the explicit-minutes path, which reads no timestamps.
+    let mut anchor = None;
+
+    let minutes = match minutes {
+        Some(raw) => whole_minutes(raw),
+        None => {
+            let Some(marked) = marks::read_phase_in(&dir, project, issue, phase)? else {
+                eprintln!(
+                    "tt: no mark for {} — pass minutes explicitly",
+                    phase_name(project, issue, phase)
+                );
+                std::process::exit(64);
+            };
+
+            // Clamped, so a heartbeat behind the mark is a zero-length phase.
+            let ended = marked
+                .ended
+                .unwrap_or_else(|| Local::now().timestamp())
+                .max(marked.started);
+            let measured = (ended - marked.started) / 60;
+            // The gaps below are epochs on this timeline, so the entry has to
+            // end where the timeline does.
+            anchor = Some(instant(ended)?);
+
+            // A mark with heartbeats is judged against the interior-silence
+            // threshold, a mark with none against the longer unvouched one.
+            let threshold = if marked.beats.is_empty() {
+                max_unvouched_minutes()
+            } else {
+                max_gap_minutes()
+            };
+            let gaps = marks::gaps_over(marked.started, ended, &marked.beats, threshold);
+            if gaps.is_empty() {
+                measured
+            } else {
+                // One interval per flagged gap, recorded whether or not the
+                // caller trimmed, so the TUI can still trim it later.
+                idle = gaps
+                    .iter()
+                    .map(|&(from, to)| Ok(IdleInterval::new(instant(from)?, instant(to)?)))
+                    .collect::<Result<Vec<_>>>()?;
+                // Every over-threshold gap, not just the worst one the refusal
+                // names. Reported, never logged: `split_at_idle` subtracts.
+                let silent: i64 = gaps.iter().map(|(from, to)| (to - from) / 60).sum();
+                let trimmed = (measured - silent).max(0);
+
+                if full {
+                    measured
+                } else if trim {
+                    // The measured span, not `trimmed`: `split_at_idle` cuts the
+                    // same gaps, and a pre-trimmed span subtracts them twice.
+                    split_at_idle = true;
+                    measured
+                } else {
+                    refuse(project, issue, phase, &gaps, measured, trimmed);
+                }
+            }
+        }
+    };
+
+    log_entry(
+        project,
+        issue,
+        phase,
+        summary,
+        minutes,
+        idle,
+        split_at_idle,
+        anchor,
+    )?;
+    // Cleared only once the entry is recorded, on every successful close; a
+    // refusal returned above with the mark and its beats left in place.
+    marks::cancel_in(&dir, project, issue, phase)?;
+    Ok(())
+}
+
+/// Refuse the close, naming the worst hole, and exit 65. Both the silent total
+/// and the interval go on one line, **unrounded**.
+fn refuse(
+    project: &str,
+    issue: &str,
+    phase: &str,
+    gaps: &[(i64, i64)],
+    measured: i64,
+    trimmed: i64,
+) -> ! {
+    // Strictly greater, so the **first** of two equal holes is the one named.
+    let mut worst = (0, 0, 0);
+    for &(from, to) in gaps {
+        let minutes = (to - from) / 60;
+        if minutes > worst.0 {
+            worst = (minutes, from, to);
+        }
+    }
+
+    eprintln!(
+        "tt: {} has {} {}m gap ({}-{})",
+        phase_name(project, issue, phase),
+        article(worst.0),
+        worst.0,
+        clock(worst.1),
+        clock(worst.2)
+    );
+    eprintln!("tt: --full logs {measured}m, --trim logs {trimmed}m");
+    eprintln!("tt: or pass the real minutes instead.");
+    std::process::exit(65);
+}
+
+/// `"a"` or `"an"` for a minute count, read the way it is spoken: `an` for any
+/// number opening on `8`, and for `11` and `18` exactly.
+fn article(minutes: i64) -> &'static str {
+    if minutes == 11 || minutes == 18 || minutes.abs().to_string().starts_with('8') {
+        "an"
+    } else {
+        "a"
+    }
+}
+
+/// How long a silence *between heartbeats* has to be to count, in minutes.
+/// `TT_MAX_GAP_MINUTES`, else 45.
+fn max_gap_minutes() -> i64 {
+    minutes("TT_MAX_GAP_MINUTES", 45)
+}
+
+/// How long an **unvouched** phase — a mark with no heartbeat at all — may run
+/// before the close is refused. `TT_MAX_UNVOUCHED_MINUTES`, else 120, longer
+/// than the interior-silence threshold.
+fn max_unvouched_minutes() -> i64 {
+    minutes("TT_MAX_UNVOUCHED_MINUTES", 120)
+}
+
+/// A minutes-valued setting: the environment wins over the built-in default.
+/// Set-but-empty and unparseable read as unset.
+fn minutes(name: &str, default: i64) -> i64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn instant(epoch: i64) -> Result<DateTime<Local>> {
+    DateTime::from_timestamp(epoch, 0)
+        .map(|instant| instant.with_timezone(&Local))
+        .with_context(|| format!("{epoch} is not a valid timestamp"))
+}
+
+/// One epoch as `HH:MM`, or `??:??` when it is not a valid instant.
+fn clock(epoch: i64) -> String {
+    instant(epoch).map_or_else(
+        |_| "??:??".to_string(),
+        |instant| instant.format("%H:%M").to_string(),
+    )
+}
+
+// --- the shared convention -------------------------------------------------
+//
+// `item` and `end` must log an entry the same way, so the rounding, the stray-`#`
+// stripping and the three tags live here once.
+
+/// Round minutes to the nearest quarter hour, halfway up, never below 15.
+fn round_quarter(minutes: i64) -> i64 {
+    (((minutes + 7) / 15) * 15).max(15)
+}
+
+/// Strip a `#` run that begins a word, so a summary mentioning "#12" does not
+/// become a tag. A **mid-word** `#` is left alone: `C#` and `F#` are real words.
+///
+/// [`parse_tags`]: crate::tracker::parse_tags
+fn strip_stray_tags(summary: &str) -> String {
+    let mut stripped = String::with_capacity(summary.len());
+    let mut at_word_start = true;
+    for c in summary.chars() {
+        if c == '#' && at_word_start {
+            // The whole run goes, and the position stays a word start.
+            continue;
+        }
+        at_word_start = c.is_ascii_whitespace();
+        stripped.push(c);
+    }
+    stripped
+}
+
+/// The phase vocabulary, in the order the docs list it. `src/report.rs` reads it
+/// back off the stored tags, so it must stay the one list. Not used to validate
+/// the `phase` argument: any word is accepted.
+pub const PHASES: [&str; 7] = ["plan", "impl", "qa", "review", "docs", "spike", "ops"];
+
+/// The description `cli::log` is given: the summary, then one tag per axis the
+/// `project` field cannot express — the item (omitted for the `-` sentinel), the
+/// phase, and `#agent`. There is **no bare `#<project>` tag**; `cli::log` runs
+/// `parse_tags` over this string to build the entry's tags.
+fn description(project: &str, issue: &str, phase: &str, summary: &str) -> String {
+    let mut description = strip_stray_tags(summary);
+    if issue != "-" {
+        description.push_str(&format!(" #{project}/{issue}"));
+    }
+    description.push_str(&format!(" #{phase} #agent"));
+    description
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_article_follows_how_the_number_is_spoken() {
+        // Every number opening on the digit 8, whatever its magnitude.
+        for minutes in [8, 80, 85, 800] {
+            assert_eq!(article(minutes), "an", "{minutes}");
+        }
+        // The two teens read as one vowel-initial word.
+        assert_eq!(article(11), "an");
+        assert_eq!(article(18), "an");
+        // And their multiples, which are not: "a hundred and ten".
+        for minutes in [7, 45, 70, 110, 118, 180, 1, 0] {
+            assert_eq!(article(minutes), "a", "{minutes}");
+        }
+    }
+
+    #[test]
+    fn rounding_goes_up_to_the_nearest_quarter() {
+        assert_eq!(round_quarter(37), 30);
+        assert_eq!(round_quarter(38), 45);
+        assert_eq!(round_quarter(43), 45);
+        assert_eq!(round_quarter(45), 45);
+    }
+
+    #[test]
+    fn rounding_never_goes_below_a_quarter_hour() {
+        // A two-minute errand costs a quarter, and so does zero.
+        assert_eq!(round_quarter(0), 15);
+        assert_eq!(round_quarter(2), 15);
+        assert_eq!(round_quarter(7), 15);
+        assert_eq!(round_quarter(8), 15);
+    }
+
+    #[test]
+    fn a_word_starting_with_a_hash_keeps_the_word_and_loses_the_hash() {
+        // Without the strip, `parse_tags` would harvest `#12` as a tag.
+        assert_eq!(strip_stray_tags("closed #12 at last"), "closed 12 at last");
+        assert_eq!(strip_stray_tags("#12 closed"), "12 closed");
+        // A run goes whole, and the whitespace it followed survives.
+        assert_eq!(strip_stray_tags("closed ##12"), "closed 12");
+        assert_eq!(strip_stray_tags("a\t#12"), "a\t12");
+    }
+
+    #[test]
+    fn a_mid_word_hash_survives() {
+        // `parse_tags` ignores it, and C#/F# are real words.
+        assert_eq!(
+            strip_stray_tags("ported the C# bridge"),
+            "ported the C# bridge"
+        );
+        assert_eq!(strip_stray_tags("F#"), "F#");
+    }
+
+    #[test]
+    fn the_description_carries_the_item_phase_and_agent_tags() {
+        assert_eq!(
+            description("loremind", "77", "impl", "store/links boundary"),
+            "store/links boundary #loremind/77 #impl #agent"
+        );
+    }
+
+    #[test]
+    fn the_sentinel_issue_drops_the_item_tag_and_no_bare_project_tag_is_emitted() {
+        let built = description("loremind", "-", "plan", "sketched the shape");
+        assert_eq!(built, "sketched the shape #plan #agent");
+        // The project is a real field with its own axis — never a tag.
+        assert!(
+            !built.contains("#loremind"),
+            "a bare project tag was emitted: {built:?}"
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -475,8 +475,8 @@ mod tests {
     use super::*;
     use crate::storage;
     use crate::storage::env_guard;
+    use crate::storage::env_sandbox as sandbox;
     use clap::Parser;
-    use std::path::PathBuf;
 
     /// `--until` alone is a usage error, not a silently discarded bound.
     #[test]
@@ -521,21 +521,6 @@ mod tests {
             Cli::try_parse_from(["tt", "report", "--project", "vinge", "--json"]).is_ok(),
             "neither belongs to the scope group"
         );
-    }
-
-    /// Point `HOME` at a fresh scratch dir: the real store is live and must never
-    /// be touched by a test.
-    fn sandbox(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("tt-cli-test-{name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        unsafe { std::env::set_var("HOME", &dir) };
-        let path = storage::get_data_path().unwrap();
-        assert!(
-            path.starts_with(&dir),
-            "sandbox HOME not in effect: {path:?}"
-        );
-        dir
     }
 
     fn parse_log(args: &[&str]) -> Commands {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,87 @@ pub enum Commands {
     Status,
     /// true/false if something is active
     Active,
+    /// Phase marks for the agent layer
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommands,
+    },
+}
+
+/// The agent layer's commands. Most touch mark files only; the ones that log an
+/// entry say so through [`AgentCommands::touches_store`].
+#[derive(Subcommand)]
+pub enum AgentCommands {
+    /// Open a mark for a phase, keeping the start of one already open
+    Begin {
+        project: String,
+        /// Issue number, or `-` for a phase with no issue
+        issue: String,
+        phase: String,
+    },
+    /// Record one heartbeat for an open phase
+    Touch {
+        project: String,
+        /// Issue number, or `-` for a phase with no issue
+        issue: String,
+        phase: String,
+    },
+    /// Drop a phase's mark and heartbeats without logging anything
+    Cancel {
+        project: String,
+        /// Issue number, or `-` for a phase with no issue
+        issue: String,
+        phase: String,
+    },
+    /// List every open mark
+    List,
+    /// Log one finished piece of work, with no mark involved
+    Item {
+        project: String,
+        /// Issue number, or `-` for a phase with no issue
+        issue: String,
+        phase: String,
+        /// 3-6 words of plain prose, with no issue number in them
+        summary: Option<String>,
+        /// Whole minutes, rounded up to the nearest quarter hour
+        minutes: Option<String>,
+    },
+    /// Close a marked phase, measuring it to its last heartbeat
+    End {
+        project: String,
+        /// Issue number, or `-` for a phase with no issue
+        issue: String,
+        phase: String,
+        /// 3-6 words of plain prose, with no issue number in them
+        summary: Option<String>,
+        /// Whole minutes, overriding the mark's own timestamps entirely — and
+        /// winning over both flags below
+        minutes: Option<String>,
+        /// Log the whole measured span, recording the flagged silence without
+        /// removing it
+        #[arg(long, conflicts_with = "trim")]
+        full: bool,
+        /// Log the measured span minus every flagged gap, splitting the entry at
+        /// each one
+        #[arg(long)]
+        trim: bool,
+    },
+}
+
+impl AgentCommands {
+    /// Whether this subcommand creates or reads a `tt` entry, which decides
+    /// which side of the migrate preamble in `main.rs` it dispatches on.
+    ///
+    /// Exhaustive on purpose: a new subcommand must decide.
+    pub fn touches_store(&self) -> bool {
+        match self {
+            AgentCommands::Begin { .. }
+            | AgentCommands::Touch { .. }
+            | AgentCommands::Cancel { .. }
+            | AgentCommands::List => false,
+            AgentCommands::Item { .. } | AgentCommands::End { .. } => true,
+        }
+    }
 }
 
 /// Parse one `--idle` value: `<start>-<end>` in epoch seconds. A malformed value

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use chrono::Local;
+use chrono::{DateTime, Local, TimeZone};
 use clap::{Parser, Subcommand};
 
 use crate::config;
 use crate::duration;
 use crate::icons;
-use crate::storage::{load_data, save_data};
-use crate::tracker::{format_tags, parse_tags};
+use crate::storage::{load_data, with_data};
+use crate::tracker::{IdleInterval, format_tags, parse_tags};
 
 #[derive(Parser)]
 #[command(name = "tt", about = "Simple time tracking CLI")]
@@ -22,6 +22,9 @@ pub enum Commands {
         /// Description of the task
         #[arg(required = true)]
         description: Vec<String>,
+        /// Project this entry belongs to
+        #[arg(long)]
+        project: Option<String>,
     },
     /// Stop the current active task
     Stop,
@@ -36,6 +39,20 @@ pub enum Commands {
         /// Comma-separated tags (e.g. tagA,tagB,tagC)
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
+        /// Project this entry belongs to
+        #[arg(long)]
+        project: Option<String>,
+        /// A silent stretch inside the logged span, as epoch seconds
+        /// `<start>-<end>`. Repeatable; records the interval without changing the
+        /// logged duration.
+        #[arg(long, value_parser = parse_idle)]
+        idle: Vec<IdleInterval>,
+        /// Trim the recorded idle stretches out of the entry, splitting it into the
+        /// pieces between them. Destructive and unconfirmed; requires `--idle`, so
+        /// asking for a trim with nothing to trim is a usage error rather than a
+        /// silent no-op.
+        #[arg(long, requires = "idle")]
+        trim: bool,
     },
     /// Show all entries for today
     Today,
@@ -54,6 +71,34 @@ pub enum Commands {
     Active,
 }
 
+/// Parse one `--idle` value: `<start>-<end>` in epoch seconds. A malformed value
+/// is an error, never a silently dropped interval.
+fn parse_idle(value: &str) -> Result<IdleInterval, String> {
+    let (start, end) = value
+        .split_once('-')
+        .ok_or_else(|| format!("expected <start>-<end> epoch seconds, got `{}`", value))?;
+    let stamp = |field: &str, raw: &str| {
+        raw.trim()
+            .parse::<i64>()
+            .map_err(|_| format!("{} is not epoch seconds: `{}`", field, raw))
+            .and_then(|secs| {
+                Local
+                    .timestamp_opt(secs, 0)
+                    .single()
+                    .ok_or_else(|| format!("{} is not a valid timestamp: `{}`", field, raw))
+            })
+    };
+    let start = stamp("start", start)?;
+    let end = stamp("end", end)?;
+    if end < start {
+        return Err(format!(
+            "idle interval ends before it starts: `{}`",
+            value
+        ));
+    }
+    Ok(IdleInterval::new(start, end))
+}
+
 /// Bracketed, space-prefixed tag display for println! output, e.g. " [#a #b]",
 /// or "" when there are no tags.
 fn tags_display(tags: &[String]) -> String {
@@ -64,30 +109,51 @@ fn tags_display(tags: &[String]) -> String {
     }
 }
 
-pub fn start(description: Vec<String>) -> Result<()> {
-    let mut data = load_data()?;
+/// Render a project for a single-line listing: ` (demo)`, or nothing when unset.
+/// The project is a field, never a tag, so it prints separately from the tags.
+fn project_display(project: Option<&String>) -> String {
+    match project {
+        Some(p) => format!(" ({})", p),
+        None => String::new(),
+    }
+}
 
-    if let Some(active) = data.active_entry() {
+pub fn start(description: Vec<String>, project: Option<String>) -> Result<()> {
+    let raw_desc = description.join(" ");
+    let (desc, tags) = parse_tags(&raw_desc);
+    let start_time = Local::now();
+
+    // One lock for the check and the insert, so two starts cannot both see nothing.
+    let already_tracking = with_data(|data| {
+        if let Some(active) = data.active_entry() {
+            return Ok(Some((active.description.clone(), active.start_time)));
+        }
+        data.add_entry(
+            desc.clone(),
+            project.clone(),
+            tags.clone(),
+            start_time,
+            None,
+        );
+        Ok(None)
+    })?;
+
+    if let Some((active_desc, active_start)) = already_tracking {
         println!(
             "{}  Already tracking: \"{}\" (started at {})",
             icons::warning(),
-            active.description,
-            active.start_time.format("%H:%M")
+            active_desc,
+            active_start.format("%H:%M")
         );
         println!("Stop it first with: tt stop");
         return Ok(());
     }
 
-    let raw_desc = description.join(" ");
-    let (desc, tags) = parse_tags(&raw_desc);
-    let start_time = Local::now();
-    data.add_entry(desc.clone(), tags.clone(), start_time, None);
-    save_data(&data)?;
-
     println!(
-        "{}  Started: \"{}\"{} at {}",
+        "{}  Started: \"{}\"{}{} at {}",
         icons::active(),
         desc,
+        project_display(project.as_ref()),
         tags_display(&tags),
         start_time.format("%H:%M:%S")
     );
@@ -95,16 +161,19 @@ pub fn start(description: Vec<String>) -> Result<()> {
 }
 
 pub fn stop() -> Result<()> {
-    let mut data = load_data()?;
+    let stopped = with_data(|data| {
+        let info = data.active_entry().map(|e| {
+            (e.description.clone(), e.format_duration())
+        });
 
-    // Get info before stopping
-    let info = data.active_entry().map(|e| {
-        (e.description.clone(), e.format_duration())
-    });
+        if data.stop_active() {
+            Ok(info)
+        } else {
+            Ok(None)
+        }
+    })?;
 
-    if data.stop_active() {
-        let (desc, dur) = info.unwrap();
-        save_data(&data)?;
+    if let Some((desc, dur)) = stopped {
         println!("{}  Stopped: \"{}\" - Duration: {}", icons::stopped(), desc, dur);
     } else {
         println!("No active task to stop.");
@@ -112,10 +181,20 @@ pub fn stop() -> Result<()> {
     Ok(())
 }
 
-pub fn log(description: String, time_str: String, extra_tags: Vec<String>) -> Result<()> {
-    let mut data = load_data()?;
+/// Record a finished entry, back-dated from its end. `ended_at` pins the
+/// timeline and must be the mark's last heartbeat whenever `idle` intervals are
+/// passed, or the recorded silence lands outside the entry.
+pub fn log(
+    description: String,
+    time_str: String,
+    extra_tags: Vec<String>,
+    project: Option<String>,
+    idle: Vec<IdleInterval>,
+    trim: bool,
+    ended_at: Option<DateTime<Local>>,
+) -> Result<()> {
     let dur = duration::parse(&time_str);
-    let end_time = Local::now();
+    let end_time = ended_at.unwrap_or_else(Local::now);
     let start_time = end_time - dur;
 
     let (desc, mut tags) = parse_tags(&description);
@@ -124,15 +203,43 @@ pub fn log(description: String, time_str: String, extra_tags: Vec<String>) -> Re
             tags.push(tag);
         }
     }
-    data.add_entry(desc.clone(), tags.clone(), start_time, Some(end_time));
-    save_data(&data)?;
+    // Taken out of the closure, so the figure printed is the one written.
+    let stored = with_data(|data| {
+        let entry_id = data
+            .add_entry(
+                desc.clone(),
+                project.clone(),
+                tags.clone(),
+                start_time,
+                Some(end_time),
+            )
+            .id;
+        if let Some(entry) = data.entries.iter_mut().find(|e| e.id == entry_id) {
+            entry.idle = idle;
+        }
+        // Do not lift this out of the closure: the insert and the split are one
+        // store transaction.
+        if trim {
+            let pieces = data.split_at_idle(entry_id);
+            if !pieces.is_empty() {
+                return Ok(pieces
+                    .iter()
+                    .filter_map(|id| data.get_entry(*id))
+                    .map(|piece| piece.duration())
+                    .sum());
+            }
+            // An empty vec is `trim_spans` declining, which leaves the entry whole.
+        }
+        Ok(dur)
+    })?;
 
     println!(
-        "{} Logged: \"{}\"{} - Duration: {}",
+        "{} Logged: \"{}\"{}{} - Duration: {}",
         icons::logged(),
         desc,
+        project_display(project.as_ref()),
         tags_display(&tags),
-        duration::format(dur)
+        duration::format(stored)
     );
     Ok(())
 }
@@ -155,10 +262,11 @@ pub fn today() -> Result<()> {
             format!(" [{}]", entry.format_tags())
         };
         println!(
-            "{}{} - {}{} ({})",
+            "{}{} - {}{}{} ({})",
             status,
             entry.start_time.format("%H:%M"),
             entry.description,
+            project_display(entry.project.as_ref()),
             tags_display,
             entry.format_duration()
         );
@@ -185,11 +293,12 @@ pub fn list(limit: Option<usize>) -> Result<()> {
             format!(" [{}]", entry.format_tags())
         };
         println!(
-            "{}{} {} - {}{} ({})",
+            "{}{} {} - {}{}{} ({})",
             status,
             entry.start_time.format("%Y-%m-%d"),
             entry.start_time.format("%H:%M"),
             entry.description,
+            project_display(entry.project.as_ref()),
             tags_display,
             entry.format_duration()
         );
@@ -202,6 +311,9 @@ pub fn status() -> Result<()> {
 
     if let Some(active) = data.active_entry() {
         println!("{}  Currently tracking: \"{}\"", icons::active(), active.description);
+        if let Some(project) = &active.project {
+            println!("   Project: {}", project);
+        }
         if !active.tags.is_empty() {
             println!("   Tags: {}", active.format_tags());
         }
@@ -223,4 +335,215 @@ pub fn active() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage;
+    use crate::storage::env_guard;
+    use clap::Parser;
+    use std::path::PathBuf;
+
+    /// Point `HOME` at a fresh scratch dir: the real store is live and must never
+    /// be touched by a test.
+    fn sandbox(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-cli-test-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        unsafe { std::env::set_var("HOME", &dir) };
+        let path = storage::get_data_path().unwrap();
+        assert!(
+            path.starts_with(&dir),
+            "sandbox HOME not in effect: {path:?}"
+        );
+        dir
+    }
+
+    fn parse_log(args: &[&str]) -> Commands {
+        let mut argv = vec!["tt", "log"];
+        argv.extend_from_slice(args);
+        Cli::try_parse_from(argv).expect("log arguments").command
+    }
+
+    fn run_log(command: Commands) {
+        match command {
+            Commands::Log {
+                description,
+                time,
+                tags,
+                project,
+                idle,
+                trim,
+            } => log(description, time, tags, project, idle, trim, None).unwrap(),
+            _ => panic!("parse_log produced something other than a Log command"),
+        }
+    }
+
+    #[test]
+    fn idle_intervals_are_recorded_without_changing_the_logged_duration() {
+        let _guard = env_guard();
+        sandbox("log-idle");
+        let start = Local::now().timestamp() - 3600;
+        let end = start + 900;
+
+        run_log(parse_log(&[
+            "-d",
+            "wrote the thing",
+            "-t",
+            "90m",
+            &format!("--idle={}-{}", start, end),
+        ]));
+
+        let data = storage::load_data().unwrap();
+        assert_eq!(
+            data.entries.len(),
+            1,
+            "--idle alone must not split anything"
+        );
+        let entry = &data.entries[0];
+        assert_eq!(
+            entry.duration(),
+            duration::parse("90m"),
+            "--idle changed the logged duration"
+        );
+        assert_eq!(entry.idle.len(), 1);
+        assert_eq!(entry.idle[0].start.timestamp(), start);
+        assert_eq!(entry.idle[0].end.timestamp(), end);
+    }
+
+    #[test]
+    fn two_idle_arguments_are_both_recorded_in_order() {
+        let _guard = env_guard();
+        sandbox("log-idle-twice");
+        let base = Local::now().timestamp() - 7200;
+
+        run_log(parse_log(&[
+            "-d",
+            "long session",
+            "-t",
+            "2h",
+            &format!("--idle={}-{}", base + 600, base + 900),
+            &format!("--idle={}-{}", base + 3000, base + 3600),
+        ]));
+
+        let data = storage::load_data().unwrap();
+        let stamps: Vec<(i64, i64)> = data.entries[0]
+            .idle
+            .iter()
+            .map(|gap| (gap.start.timestamp(), gap.end.timestamp()))
+            .collect();
+        assert_eq!(
+            stamps,
+            vec![(base + 600, base + 900), (base + 3000, base + 3600)]
+        );
+    }
+
+    #[test]
+    fn a_malformed_idle_value_is_a_parse_error_not_a_dropped_interval() {
+        for bad in ["notanumber", "100", "100-", "abc-200", "100-abc", "300-200"] {
+            let parsed = Cli::try_parse_from([
+                "tt",
+                "log",
+                "-d",
+                "x",
+                "-t",
+                "5m",
+                &format!("--idle={}", bad),
+            ]);
+            assert!(parsed.is_err(), "`{bad}` parsed instead of failing");
+        }
+    }
+
+    #[test]
+    fn trim_splits_the_logged_entry_in_the_same_command() {
+        let _guard = env_guard();
+        let dir = sandbox("log-trim");
+        // Two holes inside a two-hour span, so a correct trim leaves three pieces.
+        let end = Local::now().timestamp();
+        let start = end - 7200;
+        let gaps = [(start + 600, start + 1500), (start + 4000, start + 5800)];
+
+        run_log(parse_log(&[
+            "-d",
+            "long session",
+            "-t",
+            "2h",
+            &format!("--idle={}-{}", gaps[0].0, gaps[0].1),
+            &format!("--idle={}-{}", gaps[1].0, gaps[1].1),
+            "--trim",
+        ]));
+
+        let data = storage::load_data().unwrap();
+        assert_eq!(
+            data.entries.len(),
+            gaps.len() + 1,
+            "one piece per span left"
+        );
+        let idle_total: i64 = gaps.iter().map(|(from, to)| to - from).sum();
+        // Summed as durations: per-piece truncation would lose the sub-second parts.
+        let logged = data
+            .entries
+            .iter()
+            .fold(chrono::Duration::zero(), |acc, e| acc + e.duration());
+        assert_eq!(
+            logged,
+            duration::parse("2h") - chrono::Duration::seconds(idle_total),
+            "the pieces do not sum to the span minus the idle stretches"
+        );
+        let ids: Vec<u64> = data.entries.iter().map(|e| e.id).collect();
+        assert_eq!(ids, vec![0, 1, 2]);
+        assert_eq!(data.next_id, 3, "no id was spent twice");
+        assert!(
+            data.entries.iter().all(|e| e.idle.is_empty()),
+            "a piece kept an interval it excludes"
+        );
+        let store = storage::get_data_path().unwrap();
+        assert!(
+            store.starts_with(&dir) && store.exists(),
+            "the sandbox store"
+        );
+        assert!(
+            !store.with_extension("json.tmp").exists(),
+            "a temp store file survived the command"
+        );
+    }
+
+    #[test]
+    fn idle_without_trim_leaves_a_single_entry() {
+        let _guard = env_guard();
+        sandbox("log-no-trim");
+        let end = Local::now().timestamp();
+        let start = end - 3600;
+
+        run_log(parse_log(&[
+            "-d",
+            "left alone",
+            "-t",
+            "60m",
+            &format!("--idle={}-{}", start + 600, start + 1200),
+        ]));
+
+        let data = storage::load_data().unwrap();
+        assert_eq!(data.entries.len(), 1, "recording is not trimming");
+        assert_eq!(data.entries[0].duration(), duration::parse("60m"));
+        assert_eq!(data.entries[0].idle.len(), 1, "the interval is still there");
+    }
+
+    #[test]
+    fn trim_without_idle_is_a_usage_error() {
+        let parsed = Cli::try_parse_from(["tt", "log", "-d", "x", "-t", "5m", "--trim"]);
+        assert!(
+            parsed.is_err(),
+            "--trim alone parsed, so it would be a silent no-op"
+        );
+    }
+
+    #[test]
+    fn a_well_formed_idle_value_parses_to_the_epoch_seconds_given() {
+        let interval = parse_idle("1700000000-1700000600").unwrap();
+        assert_eq!(interval.start.timestamp(), 1_700_000_000);
+        assert_eq!(interval.end.timestamp(), 1_700_000_600);
+        assert_eq!(interval.duration(), chrono::Duration::minutes(10));
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
-use chrono::{DateTime, Local, TimeZone};
+use chrono::{DateTime, Local, NaiveDate, TimeZone};
 use clap::{Parser, Subcommand};
 
 use crate::config;
 use crate::duration;
 use crate::icons;
+use crate::report;
 use crate::storage::{load_data, with_data};
 use crate::tracker::{IdleInterval, format_tags, parse_tags};
 
@@ -69,6 +70,29 @@ pub enum Commands {
     Status,
     /// true/false if something is active
     Active,
+    /// Roll up logged time by project and item
+    Report {
+        /// Every entry, with no date bound
+        #[arg(long, group = "scope")]
+        all: bool,
+        /// This week, from Monday
+        #[arg(long, group = "scope")]
+        week: bool,
+        /// From this date onwards (YYYY-MM-DD)
+        #[arg(long, group = "scope")]
+        since: Option<NaiveDate>,
+        /// Up to and including this date (YYYY-MM-DD). Narrows a scope, so one of
+        /// --all/--week/--since is required alongside it: on its own it would have
+        /// nothing to narrow but the single default day.
+        #[arg(long, requires = "scope")]
+        until: Option<NaiveDate>,
+        /// Only entries whose project field is this
+        #[arg(long)]
+        project: Option<String>,
+        /// Machine-readable output
+        #[arg(long)]
+        json: bool,
+    },
     /// Phase marks for the agent layer
     Agent {
         #[command(subcommand)]
@@ -417,6 +441,34 @@ pub fn active() -> Result<()> {
 
     Ok(())
 }
+/// `tt report` — the rollup surface; see `src/report.rs` for the maths. Dispatched
+/// ahead of the preamble in `main.rs`, so it migrates its own in-memory copy.
+#[allow(clippy::too_many_arguments)]
+pub fn report(
+    all: bool,
+    week: bool,
+    since: Option<NaiveDate>,
+    until: Option<NaiveDate>,
+    project: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let mut data = load_data()?;
+    crate::tracker::migrate(&mut data);
+    let today = Local::now().date_naive();
+    let scope = report::resolve_scope(today, all, week, since, until, project.as_deref());
+    let selected = report::select(&data, &scope, project.as_deref());
+    let rolled = report::rollup(&selected);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report::to_json(&rolled, &scope.label))?
+        );
+    } else {
+        print!("{}", report::render(&rolled, &scope.label));
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
@@ -425,6 +477,51 @@ mod tests {
     use crate::storage::env_guard;
     use clap::Parser;
     use std::path::PathBuf;
+
+    /// `--until` alone is a usage error, not a silently discarded bound.
+    #[test]
+    fn until_requires_a_scope_to_narrow() {
+        assert!(
+            Cli::try_parse_from(["tt", "report", "--until", "2026-08-05"]).is_err(),
+            "--until alone is a usage error"
+        );
+        assert!(
+            Cli::try_parse_from([
+                "tt",
+                "report",
+                "--since",
+                "2026-08-01",
+                "--until",
+                "2026-08-05"
+            ])
+            .is_ok(),
+            "--until narrows a scope that exists"
+        );
+    }
+
+    #[test]
+    fn the_scope_selectors_are_mutually_exclusive() {
+        assert!(
+            Cli::try_parse_from(["tt", "report", "--week", "--all"]).is_err(),
+            "two scopes contradict each other"
+        );
+        assert!(Cli::try_parse_from(["tt", "report", "--week"]).is_ok());
+        assert!(Cli::try_parse_from(["tt", "report", "--all"]).is_ok());
+    }
+
+    #[test]
+    fn a_malformed_date_is_rejected_rather_than_ignored() {
+        assert!(Cli::try_parse_from(["tt", "report", "--since", "last tuesday"]).is_err());
+        assert!(Cli::try_parse_from(["tt", "report", "--since", "2026-13-01"]).is_err());
+    }
+
+    #[test]
+    fn report_takes_a_project_filter_and_a_json_flag_in_any_scope() {
+        assert!(
+            Cli::try_parse_from(["tt", "report", "--project", "vinge", "--json"]).is_ok(),
+            "neither belongs to the scope group"
+        );
+    }
 
     /// Point `HOME` at a fresh scratch dir: the real store is live and must never
     /// be touched by a test.

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ struct RawConfig {
     icons: Option<IconsConfig>,
     duration: Option<DurationConfig>,
     list: Option<ListConfig>,
+    agent: Option<AgentConfig>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -61,6 +62,12 @@ pub struct ListConfig {
     pub default_limit: Option<usize>,
 }
 
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct AgentConfig {
+    pub max_gap_minutes: Option<i64>,
+    pub max_unvouched_minutes: Option<i64>,
+}
+
 /// Fully-resolved config (after merging any `include` chain).
 #[derive(Debug, Default, Clone)]
 pub struct Config {
@@ -68,6 +75,7 @@ pub struct Config {
     pub icons: IconsConfig,
     pub duration: DurationConfig,
     pub list: ListConfig,
+    pub agent: AgentConfig,
 }
 
 /// Loads the user's config file, if any. Missing file -> defaults. A
@@ -87,6 +95,7 @@ pub fn load() -> Config {
             icons: raw.icons.unwrap_or_default(),
             duration: raw.duration.unwrap_or_default(),
             list: raw.list.unwrap_or_default(),
+            agent: raw.agent.unwrap_or_default(),
         },
         Err(e) => {
             eprintln!("Warning: failed to load config from {}: {e:#}", path.display());
@@ -158,6 +167,7 @@ fn merge_raw(base: RawConfig, overlay: RawConfig) -> RawConfig {
         icons: merge_opt(base.icons, overlay.icons, merge_icons),
         duration: merge_opt(base.duration, overlay.duration, merge_duration),
         list: merge_opt(base.list, overlay.list, merge_list),
+        agent: merge_opt(base.agent, overlay.agent, merge_agent),
     }
 }
 
@@ -210,6 +220,13 @@ fn merge_duration(b: DurationConfig, o: DurationConfig) -> DurationConfig {
 fn merge_list(b: ListConfig, o: ListConfig) -> ListConfig {
     ListConfig {
         default_limit: o.default_limit.or(b.default_limit),
+    }
+}
+
+fn merge_agent(b: AgentConfig, o: AgentConfig) -> AgentConfig {
+    AgentConfig {
+        max_gap_minutes: o.max_gap_minutes.or(b.max_gap_minutes),
+        max_unvouched_minutes: o.max_unvouched_minutes.or(b.max_unvouched_minutes),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct IconsConfig {
     pub warning: Option<String>,
     pub calendar: Option<String>,
     pub list: Option<String>,
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -193,6 +194,7 @@ fn merge_icons(b: IconsConfig, o: IconsConfig) -> IconsConfig {
         warning: o.warning.or(b.warning),
         calendar: o.calendar.or(b.calendar),
         list: o.list.or(b.list),
+        agent: o.agent.or(b.agent),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -104,13 +105,25 @@ pub fn load() -> Config {
     }
 }
 
-#[cfg(windows)]
 fn config_path() -> Option<PathBuf> {
+    resolve_config_path(std::env::var_os("TT_CONFIG_FILE"), default_config_path())
+}
+
+/// The env-free half of [`config_path`], taking the default config file.
+fn resolve_config_path(config_file: Option<OsString>, default: Option<PathBuf>) -> Option<PathBuf> {
+    match config_file {
+        Some(file) if !file.is_empty() => Some(PathBuf::from(file)),
+        _ => default,
+    }
+}
+
+#[cfg(windows)]
+fn default_config_path() -> Option<PathBuf> {
     std::env::var_os("APPDATA").map(|dir| PathBuf::from(dir).join("timetracker-rs").join("config.toml"))
 }
 
 #[cfg(not(windows))]
-fn config_path() -> Option<PathBuf> {
+fn default_config_path() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|base| {
         base.home_dir()
             .join(".config")
@@ -241,4 +254,30 @@ pub fn parse_hex_rgb(s: &str) -> Option<(u8, u8, u8)> {
     let g = u8::from_str_radix(&s[2..4], 16).ok()?;
     let b = u8::from_str_radix(&s[4..6], 16).ok()?;
     Some((r, g, b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tt_config_file_replaces_the_default_config_file() {
+        let default = || Some(PathBuf::from("default"));
+        assert_eq!(resolve_config_path(None, default()), default());
+        // An empty `TT_CONFIG_FILE` is no setting at all.
+        assert_eq!(resolve_config_path(Some("".into()), default()), default());
+        assert_eq!(
+            resolve_config_path(Some("elsewhere".into()), default()),
+            Some(PathBuf::from("elsewhere"))
+        );
+        assert_eq!(
+            resolve_config_path(None, None),
+            None,
+            "no default, no config file"
+        );
+        assert_eq!(
+            resolve_config_path(Some("elsewhere".into()), None),
+            Some(PathBuf::from("elsewhere"))
+        );
+    }
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -11,6 +11,7 @@ struct Icons {
     warning: String,
     calendar: String,
     list: String,
+    agent: String,
 }
 
 impl Icons {
@@ -24,6 +25,7 @@ impl Icons {
             warning: icon(&cfg.warning, "⚠️"),
             calendar: icon(&cfg.calendar, "📅"),
             list: icon(&cfg.list, "📋"),
+            agent: icon(&cfg.agent, "🤖"),
         }
     }
 }
@@ -51,4 +53,7 @@ pub fn calendar() -> &'static str {
 }
 pub fn list() -> &'static str {
     &icons().list
+}
+pub fn agent() -> &'static str {
+    &icons().agent
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod config;
 mod duration;
 mod icons;
 mod marks;
+mod report;
 mod storage;
 mod tracker;
 mod tui;
@@ -16,12 +17,22 @@ use clap::Parser;
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Dispatched ahead of the preamble below because it must not take the store
-    // lock; the preamble runs before the dispatch table, not inside it — see
-    // `AgentCommands::touches_store`.
+    // Dispatched ahead of the preamble below because they must not take the store
+    // lock; the preamble runs before the dispatch table, not inside it. `tt report`
+    // migrates its own in-memory copy instead — see `AgentCommands::touches_store`.
     match &cli.command {
         Commands::Agent { command } if !command.touches_store() => {
             return agent::run(command);
+        }
+        Commands::Report {
+            all,
+            week,
+            since,
+            until,
+            project,
+            json,
+        } => {
+            return cli::report(*all, *week, *since, *until, project.clone(), *json);
         }
         _ => {}
     }
@@ -48,6 +59,14 @@ fn main() -> Result<()> {
             trim,
         } => cli::log(description, time, tags, project, idle, trim, None),
         Commands::Today => cli::today(),
+        Commands::Report {
+            all,
+            week,
+            since,
+            until,
+            project,
+            json,
+        } => cli::report(all, week, since, until, project, json),
         Commands::List { limit } => cli::list(limit),
         Commands::Tui => tui::run_tui(),
         Commands::Status => cli::status(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod config;
 mod duration;
 mod icons;
+mod marks;
 mod storage;
 mod tracker;
 mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+mod agent;
 mod cli;
 mod config;
 mod duration;
@@ -14,6 +15,16 @@ use clap::Parser;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Dispatched ahead of the preamble below because it must not take the store
+    // lock; the preamble runs before the dispatch table, not inside it — see
+    // `AgentCommands::touches_store`.
+    match &cli.command {
+        Commands::Agent { command } if !command.touches_store() => {
+            return agent::run(command);
+        }
+        _ => {}
+    }
 
     // Migrate once under the store lock, never in `load_data`: a write from a
     // loader would surprise every read-only path.
@@ -41,5 +52,6 @@ fn main() -> Result<()> {
         Commands::Tui => tui::run_tui(),
         Commands::Status => cli::status(),
         Commands::Active => cli::active(),
+        Commands::Agent { command } => agent::run(&command),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,27 @@ use clap::Parser;
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Migrate once under the store lock, never in `load_data`: a write from a
+    // loader would surprise every read-only path.
+    storage::with_data(|data| {
+        tracker::migrate(data);
+        Ok(())
+    })?;
+
     match cli.command {
-        Commands::Start { description } => cli::start(description),
+        Commands::Start {
+            description,
+            project,
+        } => cli::start(description, project),
         Commands::Stop => cli::stop(),
-        Commands::Log { description, time, tags } => cli::log(description, time, tags),
+        Commands::Log {
+            description,
+            time,
+            tags,
+            project,
+            idle,
+            trim,
+        } => cli::log(description, time, tags, project, idle, trim, None),
         Commands::Today => cli::today(),
         Commands::List { limit } => cli::list(limit),
         Commands::Tui => tui::run_tui(),

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -535,27 +535,19 @@ mod tests {
 
     #[test]
     fn the_default_directory_is_marks_inside_the_app_cache_dir() {
-        let cache = || {
-            Some(PathBuf::from(
-                "/sandbox/home/Library/Caches/com.timetracker.tt",
-            ))
-        };
+        let cache = || Some(PathBuf::from("cache"));
         assert_eq!(
             resolve_mark_dir(None, cache()),
-            Some(PathBuf::from(
-                "/sandbox/home/Library/Caches/com.timetracker.tt/marks"
-            ))
+            Some(PathBuf::from("cache").join("marks"))
         );
         // An empty `TT_MARK_DIR` is no setting at all.
         assert_eq!(
             resolve_mark_dir(Some("".into()), cache()),
-            Some(PathBuf::from(
-                "/sandbox/home/Library/Caches/com.timetracker.tt/marks"
-            ))
+            Some(PathBuf::from("cache").join("marks"))
         );
         assert_eq!(
-            resolve_mark_dir(Some("/elsewhere".into()), cache()),
-            Some(PathBuf::from("/elsewhere"))
+            resolve_mark_dir(Some("elsewhere".into()), cache()),
+            Some(PathBuf::from("elsewhere"))
         );
         assert_eq!(
             resolve_mark_dir(None, None),
@@ -564,42 +556,8 @@ mod tests {
         );
         // …but an override alone is enough to run.
         assert_eq!(
-            resolve_mark_dir(Some("/elsewhere".into()), None),
-            Some(PathBuf::from("/elsewhere"))
-        );
-    }
-
-    /// The cache directory follows `HOME`, so sandboxing it redirects the marks.
-    #[test]
-    fn the_cache_directory_follows_home() {
-        let _guard = env_guard();
-        let dir = sandbox("cache-follows-home");
-
-        let restore_home = std::env::var_os("HOME");
-        let restore_marks = std::env::var_os("TT_MARK_DIR");
-        unsafe { std::env::set_var("HOME", &dir) };
-        unsafe { std::env::remove_var("TT_MARK_DIR") };
-        let resolved = mark_dir();
-        let begun = resolved.as_deref().map(|d| begin_in(d, "tt", "54", "impl"));
-        let listed = open_marks();
-        match restore_home {
-            Some(value) => unsafe { std::env::set_var("HOME", value) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
-        if let Some(value) = restore_marks {
-            unsafe { std::env::set_var("TT_MARK_DIR", value) };
-        }
-
-        let resolved = resolved.expect("a sandboxed HOME resolves a cache dir");
-        assert!(
-            resolved.starts_with(&dir),
-            "the cache dir ignored HOME: {resolved:?}"
-        );
-        assert_eq!(resolved.file_name().unwrap(), "marks");
-        begun.unwrap().unwrap();
-        assert_eq!(
-            labels(&listed),
-            vec![("tt".into(), Some("54".into()), "impl".into())]
+            resolve_mark_dir(Some("elsewhere".into()), None),
+            Some(PathBuf::from("elsewhere"))
         );
     }
 

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -6,7 +6,7 @@
 //! app's cache directory. The name is sanitised `[^A-Za-z0-9._-]` → `_`, so a
 //! segment may itself contain `.` or `_` and the name is **not** losslessly
 //! splittable. Heartbeats are one append-only file per mark in a `beats/`
-//! subdirectory.
+//! subdirectory, and an unfinished close leaves a `closing/` entry beside them.
 //!
 //! Only the start timestamp is read; see [`open_marks_in`].
 
@@ -140,8 +140,8 @@ pub fn open_marks() -> Vec<Mark> {
 /// Every open mark in `dir`, newest first; a bad file is skipped, never fatal.
 ///
 /// **Read no heartbeat here:** callers refresh on the directory's mtime, which a
-/// beat appended inside `beats/` does not change. The `beats/` subdirectory is
-/// skipped by the file-type filter below, never by its name — see [`beats_path`].
+/// beat appended inside `beats/` does not change. A subdirectory — `beats/` or
+/// `closing/` — is skipped by the file-type filter below, never by its name.
 pub fn open_marks_in(dir: &Path) -> Vec<Mark> {
     let Ok(entries) = fs::read_dir(dir) else {
         return Vec::new();
@@ -218,6 +218,8 @@ pub enum Begin {
     /// A mark was already open and is left byte-identical. `None` when its
     /// contents are not a timestamp, which the caller renders as `??:??`.
     AlreadyOpen(Option<DateTime<Local>>),
+    /// A close for this phase is unfinished, so nothing was written at all.
+    Closing,
 }
 
 /// What [`touch_in`] did: recorded a heartbeat, or refused for want of a mark.
@@ -256,16 +258,31 @@ pub fn beats_path(dir: &Path, key: &str) -> PathBuf {
     dir.join("beats").join(key)
 }
 
+/// The in-progress-close sentinel for `key` inside `dir`: a `closing/`
+/// **subdirectory** entry, so the mark listing's file-type filter skips it
+/// exactly as it skips `beats/`.
+pub fn closing_path(dir: &Path, key: &str) -> PathBuf {
+    dir.join("closing").join(key)
+}
+
 /// Open a mark for one phase, or report the one already open. `create_new` keeps
 /// the check and the write atomic, and an existing mark is never rewritten.
 pub fn begin_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Result<Begin> {
-    let path = mark_path(dir, &mark_key(project, issue, phase));
+    let key = mark_key(project, issue, phase);
+    let path = mark_path(dir, &key);
     fs::create_dir_all(dir)?;
+
+    if closing_path(dir, &key).exists() {
+        return Ok(Begin::Closing);
+    }
 
     let start = Local::now();
     match OpenOptions::new().write(true).create_new(true).open(&path) {
         Ok(mut file) => {
             writeln!(file, "{}", start.timestamp())?;
+            // `create_new` succeeding proves no mark was open, so any beats
+            // still here are a part-way cancel's leftovers.
+            remove_if_present(&beats_path(dir, &key))?;
             Ok(Begin::Created(start))
         }
         Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
@@ -293,16 +310,47 @@ pub fn touch_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Resu
     Ok(Touch::Recorded)
 }
 
-/// Drop a mark and its `beats/` entry, each allowed to be absent. The `beats/`
-/// directory itself stays; other phases' beats live in it.
+/// Record that a close for one phase is under way, holding the mark's start
+/// timestamp so the file names its own phase's span. An existing sentinel is
+/// overwritten; [`is_closing_in`] is what refuses.
+pub fn start_closing_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Result<()> {
+    let key = mark_key(project, issue, phase);
+    let path = closing_path(dir, &key);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    // No mark on the explicit-minutes path, which reads no timestamps.
+    let start = read_start(&mark_path(dir, &key)).unwrap_or_else(Local::now);
+    fs::write(path, format!("{}\n", start.timestamp()))
+}
+
+/// Whether a close for one phase was started and never finished.
+pub fn is_closing_in(dir: &Path, project: &str, issue: &str, phase: &str) -> bool {
+    closing_path(dir, &mark_key(project, issue, phase)).exists()
+}
+
+/// Remove one path, treating an absent one as done.
+fn remove_if_present(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Drop a mark, its `beats/` entry and its `closing/` sentinel, each allowed to
+/// be absent. **Beats go first**, so a failure part-way leaves a mark with no
+/// beats — which [`read_phase_in`] reports as a beat-less phase — rather than
+/// beats a later phase would read back as its own. The `beats/` and `closing/`
+/// directories themselves stay; other phases' files live in them.
 pub fn cancel_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Result<()> {
     let key = mark_key(project, issue, phase);
-    for path in [mark_path(dir, &key), beats_path(dir, &key)] {
-        match fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(err) => return Err(err),
-        }
+    for path in [
+        beats_path(dir, &key),
+        mark_path(dir, &key),
+        closing_path(dir, &key),
+    ] {
+        remove_if_present(&path)?;
     }
     Ok(())
 }
@@ -716,6 +764,17 @@ mod tests {
 
     // --- writer -----------------------------------------------------------
 
+    /// Regular files directly in `dir`, so `beats/` and `closing/` do not count.
+    fn count_files(dir: &Path) -> usize {
+        match fs::read_dir(dir) {
+            Ok(entries) => entries
+                .flatten()
+                .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+                .count(),
+            Err(_) => 0,
+        }
+    }
+
     fn read(dir: &Path, name: &str) -> String {
         fs::read_to_string(dir.join(name)).unwrap()
     }
@@ -838,6 +897,115 @@ mod tests {
 
         cancel_in(&dir, "tt", "8", "impl").unwrap();
         cancel_in(&dir, "never", "1", "begun").unwrap();
+    }
+
+    // --- the closing sentinel ---------------------------------------------
+
+    #[test]
+    fn the_sentinel_holds_the_marks_own_start() {
+        let dir = sandbox("closing-round-trip");
+        let Begin::Created(start) = begin_in(&dir, "tt", "8", "impl").unwrap() else {
+            panic!("a fresh mark is created");
+        };
+        assert!(!is_closing_in(&dir, "tt", "8", "impl"));
+
+        start_closing_in(&dir, "tt", "8", "impl").unwrap();
+        assert!(is_closing_in(&dir, "tt", "8", "impl"));
+        assert_eq!(
+            read(&dir, "closing/tt.8.impl").trim(),
+            start.timestamp().to_string()
+        );
+    }
+
+    #[test]
+    fn cancel_clears_the_sentinel_with_the_mark_and_the_beats() {
+        let dir = sandbox("closing-cancel");
+        begin_in(&dir, "tt", "8", "impl").unwrap();
+        touch_in(&dir, "tt", "8", "impl").unwrap();
+        start_closing_in(&dir, "tt", "8", "impl").unwrap();
+
+        cancel_in(&dir, "tt", "8", "impl").unwrap();
+
+        assert!(!dir.join("tt.8.impl").exists());
+        assert!(!dir.join("beats/tt.8.impl").exists());
+        assert!(!dir.join("closing/tt.8.impl").exists());
+        assert!(
+            dir.join("closing").is_dir(),
+            "the closing directory itself stays"
+        );
+    }
+
+    /// Each of the three paths in turn is the only one present.
+    #[test]
+    fn cancel_tolerates_any_of_the_three_paths_being_absent() {
+        let dir = sandbox("closing-cancel-partial");
+
+        begin_in(&dir, "tt", "8", "impl").unwrap();
+        cancel_in(&dir, "tt", "8", "impl").unwrap();
+
+        fs::create_dir_all(dir.join("beats")).unwrap();
+        write(&dir.join("beats"), "tt.8.impl", "1000200\n");
+        cancel_in(&dir, "tt", "8", "impl").unwrap();
+
+        fs::create_dir_all(dir.join("closing")).unwrap();
+        write(&dir.join("closing"), "tt.8.impl", "1000100\n");
+        cancel_in(&dir, "tt", "8", "impl").unwrap();
+
+        assert_eq!(
+            count_files(&dir),
+            0,
+            "nothing is left in the mark directory"
+        );
+        assert_eq!(count_files(&dir.join("beats")), 0);
+        assert_eq!(count_files(&dir.join("closing")), 0);
+    }
+
+    #[test]
+    fn a_directory_holding_only_a_sentinel_lists_no_marks() {
+        let dir = sandbox("closing-not-a-mark");
+        fs::create_dir_all(dir.join("closing")).unwrap();
+        write(&dir.join("closing"), "tt.8.impl", "1000100\n");
+
+        assert_eq!(open_marks_in(&dir), Vec::new());
+    }
+
+    #[test]
+    fn begin_drops_the_beats_a_part_way_cancel_left_behind() {
+        let dir = sandbox("closing-stale-beats");
+        let stale = "1000100\n1000200\n";
+        fs::create_dir_all(dir.join("beats")).unwrap();
+        write(&dir.join("beats"), "tt.8.impl", stale);
+
+        let Begin::Created(_) = begin_in(&dir, "tt", "8", "impl").unwrap() else {
+            panic!("no mark was open, so one is created");
+        };
+
+        let phase = read_phase_in(&dir, "tt", "8", "impl").unwrap().unwrap();
+        assert_eq!(phase.beats, Vec::<i64>::new(), "the stale beats survived");
+        assert_eq!(phase.ended, None);
+
+        touch_in(&dir, "tt", "8", "impl").unwrap();
+        let beats = read(&dir, "beats/tt.8.impl");
+        assert_eq!(
+            beats.lines().count(),
+            stale.lines().count() - 1,
+            "the new beat is the only line: {beats:?}"
+        );
+    }
+
+    #[test]
+    fn begin_over_a_sentinel_refuses_and_writes_nothing() {
+        let dir = sandbox("closing-refuses-begin");
+        let stale = "1000100\n1000200\n";
+        fs::create_dir_all(dir.join("beats")).unwrap();
+        write(&dir.join("beats"), "tt.8.impl", stale);
+        fs::create_dir_all(dir.join("closing")).unwrap();
+        write(&dir.join("closing"), "tt.8.impl", "1000100\n");
+
+        assert_eq!(begin_in(&dir, "tt", "8", "impl").unwrap(), Begin::Closing);
+        assert!(!dir.join("tt.8.impl").exists(), "a mark was opened");
+        assert_eq!(read(&dir, "beats/tt.8.impl"), stale);
+        assert_eq!(read(&dir, "closing/tt.8.impl"), "1000100\n");
     }
 
     // --- what `end` measures ----------------------------------------------

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -1,0 +1,996 @@
+//! Reader and writer for the agent layer's open phase marks.
+//!
+//! This module owns *every* fact about the format: one file per phase at
+//! `<mark dir>/<project>.<issue>.<phase>` holding a unix-seconds start timestamp,
+//! where the mark directory is `$TT_MARK_DIR` if set, else `marks` inside this
+//! app's cache directory. The name is sanitised `[^A-Za-z0-9._-]` → `_`, so a
+//! segment may itself contain `.` or `_` and the name is **not** losslessly
+//! splittable. Heartbeats are one append-only file per mark in a `beats/`
+//! subdirectory.
+//!
+//! Only the start timestamp is read; see [`open_marks_in`].
+
+use chrono::{DateTime, Local, TimeDelta};
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use crate::duration;
+
+/// One open phase mark.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Mark {
+    pub project: String,
+    /// `None` when the mark was made with the no-issue sentinel `-`.
+    pub issue: Option<String>,
+    pub phase: String,
+    pub start: DateTime<Local>,
+}
+
+impl Mark {
+    /// `project/issue phase`, or bare `project phase` for the `-` sentinel.
+    pub fn label(&self) -> String {
+        let subject = match &self.issue {
+            Some(issue) => format!("{}/{}", self.project, issue),
+            None => self.project.clone(),
+        };
+        if self.phase.is_empty() {
+            return subject;
+        }
+        format!("{} {}", subject, self.phase)
+    }
+
+    /// The clock time the mark was made, `HH:MM`.
+    pub fn started_at(&self) -> String {
+        self.start.format("%H:%M").to_string()
+    }
+
+    /// How long this mark has been open, as `2m` or `2h 6m`. Derived on every
+    /// call and **never cached**: the mark list is only re-read on a directory
+    /// change.
+    pub fn elapsed(&self) -> String {
+        self.elapsed_at(Local::now())
+    }
+
+    /// The `now`-taking half of [`elapsed`](Mark::elapsed), for tests.
+    pub fn elapsed_at(&self, now: DateTime<Local>) -> String {
+        // A start in the future reads as 0m, never as a negative age.
+        let minutes = (now - self.start).num_minutes().max(0);
+        match minutes / 60 {
+            0 => format!("{}m", minutes),
+            hours => format!("{}h {}m", hours, minutes % 60),
+        }
+    }
+
+    /// How long this mark has been open in the house `{h}h {m}m` format, not
+    /// [`elapsed`](Mark::elapsed)'s narrow one. Clamped first, or a start in the
+    /// future would print `0h -5m`.
+    pub fn age_at(&self, now: DateTime<Local>) -> String {
+        duration::format((now - self.start).max(TimeDelta::zero()))
+    }
+}
+
+/// Narrowest label column `tt agent list` will use. `src/tui/render.rs` keeps its
+/// own copy for the surface's rows.
+const LABEL_WIDTH: usize = 18;
+
+/// The rows `tt agent list` prints, without the CLI's indent: one label column,
+/// ` - since HH:MM`, and the house `{h}h {m}m` duration.
+pub fn rows(marks: &[Mark]) -> Vec<String> {
+    rows_at(marks, Local::now())
+}
+
+/// The `now`-taking half of [`rows`], for tests.
+pub fn rows_at(marks: &[Mark], now: DateTime<Local>) -> Vec<String> {
+    // One column for the whole list, so the start times line up.
+    let width = marks
+        .iter()
+        .map(|mark| mark.label().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(LABEL_WIDTH);
+
+    marks
+        .iter()
+        .map(|mark| {
+            let label = mark.label();
+            let pad = " ".repeat(width.saturating_sub(label.chars().count()));
+            format!(
+                "{}{} - since {} ({})",
+                label,
+                pad,
+                mark.started_at(),
+                mark.age_at(now)
+            )
+        })
+        .collect()
+}
+
+/// The directory the marks live in: `$TT_MARK_DIR` when set and non-empty, else
+/// `marks` inside this app's cache directory. `None` only when there is no home
+/// directory to resolve.
+pub fn mark_dir() -> Option<PathBuf> {
+    resolve_mark_dir(std::env::var_os("TT_MARK_DIR"), cache_dir())
+}
+
+/// This app's cache directory, from the same `ProjectDirs` triple
+/// `storage::get_data_path` uses, so a sandboxed `HOME` redirects the marks too.
+fn cache_dir() -> Option<PathBuf> {
+    let dirs = directories::ProjectDirs::from("com", "timetracker", "tt")?;
+    Some(dirs.cache_dir().to_path_buf())
+}
+
+/// The env-free half of [`mark_dir`], taking the resolved cache root.
+fn resolve_mark_dir(mark_dir: Option<OsString>, cache: Option<PathBuf>) -> Option<PathBuf> {
+    match mark_dir {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => Some(cache?.join("marks")),
+    }
+}
+
+/// Every open mark, newest first. A missing mark directory is an empty list.
+pub fn open_marks() -> Vec<Mark> {
+    match mark_dir() {
+        Some(dir) => open_marks_in(&dir),
+        None => Vec::new(),
+    }
+}
+
+/// Every open mark in `dir`, newest first; a bad file is skipped, never fatal.
+///
+/// **Read no heartbeat here:** callers refresh on the directory's mtime, which a
+/// beat appended inside `beats/` does not change. The `beats/` subdirectory is
+/// skipped by the file-type filter below, never by its name — see [`beats_path`].
+pub fn open_marks_in(dir: &Path) -> Vec<Mark> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let names: Vec<OsString> = entries
+        .flatten()
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .map(|e| e.file_name())
+        .collect();
+
+    let mut marks: Vec<Mark> = names
+        .iter()
+        .filter_map(|name| read_mark(dir, name))
+        .collect();
+
+    // Never `read_dir` order.
+    marks.sort_by(|a, b| {
+        b.start
+            .cmp(&a.start)
+            .then_with(|| (&a.project, &a.issue, &a.phase).cmp(&(&b.project, &b.issue, &b.phase)))
+    });
+    marks
+}
+
+/// The instant a mark file holds, or `None` when it holds anything else. The one
+/// place the file's body is interpreted.
+fn read_start(path: &Path) -> Option<DateTime<Local>> {
+    let contents = fs::read_to_string(path).ok()?;
+    let seconds: i64 = contents.trim().parse().ok()?;
+    Some(DateTime::from_timestamp(seconds, 0)?.with_timezone(&Local))
+}
+
+/// Parse one mark file, or `None` if it is not one.
+fn read_mark(dir: &Path, name: &OsString) -> Option<Mark> {
+    let start = read_start(&dir.join(name))?;
+    let (project, issue, phase) = split_key(name.to_str()?);
+    Some(Mark {
+        project,
+        issue,
+        phase,
+        start,
+    })
+}
+
+/// Split a mark filename back into `<project>.<issue>.<phase>`. Lossy: any
+/// segment may contain a `.`, so the split takes the **first** and **last** one
+/// and a pathological name degrades to an imperfect label.
+fn split_key(name: &str) -> (String, Option<String>, String) {
+    let issue = |raw: &str| (raw != "-").then(|| raw.to_string());
+
+    match name.split_once('.') {
+        // Extra dots land in the middle field.
+        Some((project, rest)) => match rest.rsplit_once('.') {
+            Some((mid, phase)) => (project.to_string(), issue(mid), phase.to_string()),
+            // One `.`: an issue-less `<project>.<phase>`, as `-` produces.
+            None => (project.to_string(), None, rest.to_string()),
+        },
+        // Nothing to split: the whole name is the project.
+        None => (name.to_string(), None, String::new()),
+    }
+}
+
+// --- writer ---------------------------------------------------------------
+//
+// Nothing here locks anything: no path below is the store, and `create_new` plus
+// `O_APPEND` cover the only two races there are.
+
+/// What [`begin_in`] found: a mark it created, or one that was already open.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Begin {
+    /// The mark file was created, holding this instant.
+    Created(DateTime<Local>),
+    /// A mark was already open and is left byte-identical. `None` when its
+    /// contents are not a timestamp, which the caller renders as `??:??`.
+    AlreadyOpen(Option<DateTime<Local>>),
+}
+
+/// What [`touch_in`] did: recorded a heartbeat, or refused for want of a mark.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Touch {
+    Recorded,
+    /// No mark file for this phase, so no beats file was created either.
+    NoMark,
+}
+
+/// The sanitised filename for one phase: `<project>.<issue>.<phase>` with every
+/// character outside `[A-Za-z0-9._-]` replaced by `_`, and the `-` sentinel
+/// written literally. Build every mark and beats path from this one key, or a
+/// phase can end up with beats it cannot find again.
+pub fn mark_key(project: &str, issue: &str, phase: &str) -> String {
+    format!("{project}.{issue}.{phase}")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+pub fn mark_path(dir: &Path, key: &str) -> PathBuf {
+    dir.join(key)
+}
+
+/// The heartbeat file for `key` inside `dir`: a `beats/` **subdirectory**, never
+/// a `<mark>.<suffix>` sibling. Every [`mark_key`] holds at least two dots, so no
+/// mark can be named `beats`.
+pub fn beats_path(dir: &Path, key: &str) -> PathBuf {
+    dir.join("beats").join(key)
+}
+
+/// Open a mark for one phase, or report the one already open. `create_new` keeps
+/// the check and the write atomic, and an existing mark is never rewritten.
+pub fn begin_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Result<Begin> {
+    let path = mark_path(dir, &mark_key(project, issue, phase));
+    fs::create_dir_all(dir)?;
+
+    let start = Local::now();
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => {
+            writeln!(file, "{}", start.timestamp())?;
+            Ok(Begin::Created(start))
+        }
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            Ok(Begin::AlreadyOpen(read_start(&path)))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Append one heartbeat for a phase that is already marked. Appended, never
+/// overwritten — the *sequence* of beats is the evidence. A phase nobody began
+/// records nothing at all.
+pub fn touch_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Result<Touch> {
+    let key = mark_key(project, issue, phase);
+    if !mark_path(dir, &key).is_file() {
+        return Ok(Touch::NoMark);
+    }
+
+    let beats = beats_path(dir, &key);
+    if let Some(parent) = beats.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().append(true).create(true).open(&beats)?;
+    writeln!(file, "{}", Local::now().timestamp())?;
+    Ok(Touch::Recorded)
+}
+
+/// Drop a mark and its `beats/` entry, each allowed to be absent. The `beats/`
+/// directory itself stays; other phases' beats live in it.
+pub fn cancel_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Result<()> {
+    let key = mark_key(project, issue, phase);
+    for path in [mark_path(dir, &key), beats_path(dir, &key)] {
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+// --- what `end` measures --------------------------------------------------
+//
+// `agent.rs` gets a [`Phase`] and a list of gaps, and never learns the format.
+
+/// One marked phase as `end` needs to read it back, all in unix seconds.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Phase {
+    /// The instant the mark was opened.
+    pub started: i64,
+    /// Every heartbeat, **in file order**, dropping lines whose first field is
+    /// not a bare timestamp. Never sort or dedup: [`gaps_over`] judges that.
+    pub beats: Vec<i64>,
+    /// The instant the phase is measured to: the beats file's **last line**, not
+    /// its largest beat. `None` when there is no such line, leaving the caller
+    /// nothing better to measure to than now.
+    pub ended: Option<i64>,
+}
+
+/// A line's leading whitespace-delimited field as a bare timestamp, or `None`.
+fn beat_of(line: &str) -> Option<i64> {
+    let field = line.split_whitespace().next()?;
+    all_digits(field).then(|| field.parse().ok())?
+}
+
+/// A non-empty run of ASCII digits: no sign, no whitespace, no `+`.
+fn all_digits(text: &str) -> bool {
+    !text.is_empty() && text.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+/// Read a marked phase back, or `None` when the phase is not marked at all. A
+/// mark holding something other than a timestamp is an error naming the path.
+pub fn read_phase_in(
+    dir: &Path,
+    project: &str,
+    issue: &str,
+    phase: &str,
+) -> io::Result<Option<Phase>> {
+    let key = mark_key(project, issue, phase);
+    let mark = mark_path(dir, &key);
+    if !mark.is_file() {
+        return Ok(None);
+    }
+    let started = read_start(&mark)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{} does not hold a unix timestamp", mark.display()),
+            )
+        })?
+        .timestamp();
+
+    let source = beats_path(dir, &key);
+
+    // No beats file leaves the single start→end interval to judge.
+    let body = fs::read_to_string(&source).unwrap_or_default();
+    let beats = body.lines().filter_map(beat_of).collect();
+    let ended = body.lines().next_back().filter(|line| all_digits(line));
+
+    Ok(Some(Phase {
+        started,
+        beats,
+        ended: ended.and_then(|line| line.parse().ok()),
+    }))
+}
+
+/// Every stretch of silence longer than `threshold_minutes`, as chronological
+/// `(from, to)` epoch pairs.
+///
+/// Pure and total: no I/O, and "no gaps" is an answer rather than an error. The
+/// sequence judged is `start, beats…, end`, so the leading and trailing intervals
+/// count too and a phase with no beats is one stretch across its whole span.
+///
+/// A beat that does not advance the sequence — a duplicate, an out-of-order line,
+/// a beat outside the mark's window — is skipped without advancing `prev`, so it
+/// cannot shorten the gap around it.
+///
+/// The threshold test is `(beat - prev) / 60 > threshold`: **integer-floor
+/// minutes, strictly greater**, so at 45 a 45m59s hole is not a gap and 46m00s
+/// is.
+pub fn gaps_over(start: i64, end: i64, beats: &[i64], threshold_minutes: i64) -> Vec<(i64, i64)> {
+    let mut gaps = Vec::new();
+    let mut prev = start;
+
+    for &beat in beats {
+        if beat <= prev || beat >= end {
+            continue;
+        }
+        if (beat - prev) / 60 > threshold_minutes {
+            gaps.push((prev, beat));
+        }
+        prev = beat;
+    }
+
+    if end > prev && (end - prev) / 60 > threshold_minutes {
+        gaps.push((prev, end));
+    }
+    gaps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    /// Serialises the one test that repoints `TT_MARK_DIR`, since env is
+    /// process-wide; shared with the TUI's tests via `storage::env_guard`.
+    use crate::storage::env_guard;
+
+    /// A fresh scratch mark directory: the real one is live and off limits.
+    fn sandbox(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-marks-test-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(dir: &Path, name: &str, contents: &str) {
+        fs::write(dir.join(name), contents).unwrap();
+    }
+
+    fn at(seconds: i64) -> DateTime<Local> {
+        DateTime::from_timestamp(seconds, 0)
+            .unwrap()
+            .with_timezone(&Local)
+    }
+
+    fn labels(marks: &[Mark]) -> Vec<(String, Option<String>, String)> {
+        marks
+            .iter()
+            .map(|m| (m.project.clone(), m.issue.clone(), m.phase.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn marks_come_back_newest_first() {
+        let dir = sandbox("newest-first");
+        write(&dir, "tt.8.impl", "1000200\n");
+        write(&dir, "loremind.64.plan", "1000300\n");
+        write(&dir, "vinge.-.plan", "1000100\n");
+
+        let marks = open_marks_in(&dir);
+        assert_eq!(
+            labels(&marks),
+            vec![
+                ("loremind".into(), Some("64".into()), "plan".into()),
+                ("tt".into(), Some("8".into()), "impl".into()),
+                ("vinge".into(), None, "plan".into()),
+            ]
+        );
+        assert_eq!(marks[0].start.timestamp(), 1000300);
+    }
+
+    #[test]
+    fn a_phase_literally_called_last_is_a_mark() {
+        let dir = sandbox("phase-last");
+        write(&dir, "proj.-.last", "1000100\n");
+        write(&dir, "tt.8.impl", "1000200\n");
+
+        assert_eq!(
+            labels(&open_marks_in(&dir)),
+            vec![
+                ("tt".into(), Some("8".into()), "impl".into()),
+                ("proj".into(), None, "last".into()),
+            ]
+        );
+    }
+
+    /// The file-type filter excludes `beats/`, so a mark whose *phase* is
+    /// `beats` is still listed.
+    #[test]
+    fn the_beats_subdirectory_is_not_a_mark_but_a_beats_phase_is() {
+        let dir = sandbox("beats");
+        write(&dir, "tt.8.impl", "1000200\n");
+        fs::create_dir_all(dir.join("beats")).unwrap();
+        write(&dir.join("beats"), "tt.8.impl", "1000210\n1000220\n");
+        write(&dir, "proj.-.beats", "1000100\n");
+
+        assert_eq!(
+            labels(&open_marks_in(&dir)),
+            vec![
+                ("tt".into(), Some("8".into()), "impl".into()),
+                ("proj".into(), None, "beats".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unparseable_file_is_skipped_without_failing_its_siblings() {
+        let dir = sandbox("unparseable");
+        write(&dir, "tt.8.impl", "1000200\n");
+        write(&dir, "broken.1.impl", "not a timestamp\n");
+        write(&dir, "empty.1.impl", "");
+
+        assert_eq!(
+            labels(&open_marks_in(&dir)),
+            vec![("tt".into(), Some("8".into()), "impl".into())]
+        );
+    }
+
+    #[test]
+    fn a_missing_or_empty_directory_yields_no_marks() {
+        let dir = sandbox("missing");
+        assert_eq!(open_marks_in(&dir), Vec::new(), "empty directory");
+        fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(open_marks_in(&dir), Vec::new(), "missing directory");
+    }
+
+    #[test]
+    fn tt_mark_dir_is_honoured() {
+        let _guard = env_guard();
+        let dir = sandbox("env");
+        write(&dir, "tt.13.impl", "1000200\n");
+
+        let restore = std::env::var_os("TT_MARK_DIR");
+        unsafe { std::env::set_var("TT_MARK_DIR", &dir) };
+        assert_eq!(mark_dir().as_deref(), Some(dir.as_path()));
+        let marks = open_marks();
+        match restore {
+            Some(value) => unsafe { std::env::set_var("TT_MARK_DIR", value) },
+            None => unsafe { std::env::remove_var("TT_MARK_DIR") },
+        }
+
+        assert_eq!(
+            labels(&marks),
+            vec![("tt".into(), Some("13".into()), "impl".into())]
+        );
+    }
+
+    #[test]
+    fn the_default_directory_is_marks_inside_the_app_cache_dir() {
+        let cache = || {
+            Some(PathBuf::from(
+                "/sandbox/home/Library/Caches/com.timetracker.tt",
+            ))
+        };
+        assert_eq!(
+            resolve_mark_dir(None, cache()),
+            Some(PathBuf::from(
+                "/sandbox/home/Library/Caches/com.timetracker.tt/marks"
+            ))
+        );
+        // An empty `TT_MARK_DIR` is no setting at all.
+        assert_eq!(
+            resolve_mark_dir(Some("".into()), cache()),
+            Some(PathBuf::from(
+                "/sandbox/home/Library/Caches/com.timetracker.tt/marks"
+            ))
+        );
+        assert_eq!(
+            resolve_mark_dir(Some("/elsewhere".into()), cache()),
+            Some(PathBuf::from("/elsewhere"))
+        );
+        assert_eq!(
+            resolve_mark_dir(None, None),
+            None,
+            "no cache dir, no default"
+        );
+        // …but an override alone is enough to run.
+        assert_eq!(
+            resolve_mark_dir(Some("/elsewhere".into()), None),
+            Some(PathBuf::from("/elsewhere"))
+        );
+    }
+
+    /// The cache directory follows `HOME`, so sandboxing it redirects the marks.
+    #[test]
+    fn the_cache_directory_follows_home() {
+        let _guard = env_guard();
+        let dir = sandbox("cache-follows-home");
+
+        let restore_home = std::env::var_os("HOME");
+        let restore_marks = std::env::var_os("TT_MARK_DIR");
+        unsafe { std::env::set_var("HOME", &dir) };
+        unsafe { std::env::remove_var("TT_MARK_DIR") };
+        let resolved = mark_dir();
+        let begun = resolved.as_deref().map(|d| begin_in(d, "tt", "54", "impl"));
+        let listed = open_marks();
+        match restore_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        if let Some(value) = restore_marks {
+            unsafe { std::env::set_var("TT_MARK_DIR", value) };
+        }
+
+        let resolved = resolved.expect("a sandboxed HOME resolves a cache dir");
+        assert!(
+            resolved.starts_with(&dir),
+            "the cache dir ignored HOME: {resolved:?}"
+        );
+        assert_eq!(resolved.file_name().unwrap(), "marks");
+        begun.unwrap().unwrap();
+        assert_eq!(
+            labels(&listed),
+            vec![("tt".into(), Some("54".into()), "impl".into())]
+        );
+    }
+
+    #[test]
+    fn a_row_reads_project_slash_issue_phase_and_drops_a_missing_issue() {
+        let dir = sandbox("row-format");
+        write(&dir, "tt.8.impl", "1000200\n");
+        write(&dir, "loremind.64.plan", "1000300\n");
+        write(&dir, "vinge.-.plan", "1000100\n");
+        write(&dir, "bare", "1000000\n");
+
+        let labels: Vec<String> = open_marks_in(&dir).iter().map(Mark::label).collect();
+        assert_eq!(
+            labels,
+            vec!["loremind/64 plan", "tt/8 impl", "vinge plan", "bare"]
+        );
+
+        let mark = &open_marks_in(&dir)[1];
+        assert_eq!(mark.started_at(), mark.start.format("%H:%M").to_string());
+        assert_eq!(mark.started_at().len(), 5, "HH:MM");
+    }
+
+    #[test]
+    fn elapsed_is_derived_from_the_start_and_counts_up() {
+        let mark = |seconds: i64| Mark {
+            project: "tt".into(),
+            issue: Some("14".into()),
+            phase: "impl".into(),
+            start: DateTime::from_timestamp(seconds, 0)
+                .unwrap()
+                .with_timezone(&Local),
+        };
+        let start = 1_000_000_000;
+        let now = |offset: i64| {
+            DateTime::from_timestamp(start + offset, 0)
+                .unwrap()
+                .with_timezone(&Local)
+        };
+
+        assert_eq!(mark(start).elapsed_at(now(0)), "0m");
+        assert_eq!(mark(start).elapsed_at(now(119)), "1m", "seconds truncate");
+        assert_eq!(mark(start).elapsed_at(now(120)), "2m");
+        assert_eq!(mark(start).elapsed_at(now(60 * 60)), "1h 0m");
+        assert_eq!(mark(start).elapsed_at(now(126 * 60)), "2h 6m");
+        let m = mark(start);
+        assert_eq!(m.elapsed_at(now(60)), "1m");
+        assert_eq!(m.elapsed_at(now(61 * 60)), "1h 1m");
+        // A clock that stepped backwards must not print a negative age.
+        assert_eq!(m.elapsed_at(now(-90)), "0m");
+    }
+
+    #[test]
+    fn a_lossy_name_degrades_to_a_label_instead_of_an_error() {
+        let dir = sandbox("lossy");
+        write(&dir, "my.proj.7.impl", "1000400\n");
+        write(&dir, "tt.8.impl.v2", "1000300\n");
+        write(&dir, "my_proj.-.code_review", "1000200\n");
+        write(&dir, "bare", "1000100\n");
+
+        assert_eq!(
+            labels(&open_marks_in(&dir)),
+            vec![
+                ("my".into(), Some("proj.7".into()), "impl".into()),
+                ("tt".into(), Some("8.impl".into()), "v2".into()),
+                ("my_proj".into(), None, "code_review".into()),
+                ("bare".into(), None, String::new()),
+            ]
+        );
+    }
+
+    /// The house-style row `tt agent list` prints.
+    #[test]
+    fn a_row_is_one_padded_label_column_then_since_and_the_house_duration() {
+        let dir = sandbox("rows");
+        let now = 1_000_000_000;
+        write(
+            &dir,
+            "timetracker-rs.54.plan",
+            &format!("{}\n", now - 15 * 60),
+        );
+        write(&dir, "vinge.12.impl", &format!("{}\n", now - 45 * 60));
+
+        let marks = open_marks_in(&dir);
+        let rows = rows_at(&marks, at(now));
+        let since = |offset: i64| at(now - offset).format("%H:%M").to_string();
+        assert_eq!(
+            rows,
+            vec![
+                format!("timetracker-rs/54 plan - since {} (0h 15m)", since(15 * 60)),
+                format!("vinge/12 impl          - since {} (0h 45m)", since(45 * 60)),
+            ]
+        );
+        let separator = |row: &String| row.find(" - since").unwrap();
+        assert_eq!(separator(&rows[0]), separator(&rows[1]));
+    }
+
+    #[test]
+    fn a_row_reads_the_names_back_the_way_the_reader_does() {
+        let dir = sandbox("rows-names");
+        let now = 1_000_000_000;
+        // The `-` sentinel collapses away entirely — never `vinge/-`.
+        write(&dir, "vinge.-.plan", &format!("{}\n", now));
+        // Nothing to split: a bare project.
+        write(&dir, "solo", &format!("{}\n", now));
+        // A phase literally called `last` is a mark.
+        write(&dir, "proj.-.last", &format!("{}\n", now));
+
+        let rows = rows_at(&open_marks_in(&dir), at(now));
+        assert!(
+            rows.iter().any(|row| row.starts_with("vinge plan ")),
+            "the - sentinel leaked or the row is missing: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|row| row.starts_with("solo ")),
+            "a dotless name should list as a bare project: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|row| row.starts_with("proj last ")),
+            "a phase called `last` should still be listed: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|row| row.contains("vinge/-")),
+            "the - sentinel leaked into a label: {rows:?}"
+        );
+        // All three labels are under the minimum column, so `since` lines up.
+        for row in &rows {
+            assert_eq!(row.find(" - since"), Some(18), "{row:?}");
+        }
+    }
+
+    #[test]
+    fn a_rows_duration_is_the_house_format_and_never_negative() {
+        let dir = sandbox("rows-age");
+        let now = 1_000_000_000;
+        write(&dir, "long.1.impl", &format!("{}\n", now - 126 * 60));
+        write(&dir, "short.2.impl", &format!("{}\n", now - 2 * 60));
+        // A start in the future reads as `0h 0m`, not as `0h -10m`.
+        write(&dir, "future.3.impl", &format!("{}\n", now + 600));
+
+        let rows = rows_at(&open_marks_in(&dir), at(now));
+        let ages: Vec<&str> = rows
+            .iter()
+            .map(|row| &row[row.find('(').unwrap()..])
+            .collect();
+        assert_eq!(ages, vec!["(0h 0m)", "(0h 2m)", "(2h 6m)"], "{rows:?}");
+    }
+
+    #[test]
+    fn no_marks_have_no_rows() {
+        let dir = sandbox("rows-empty");
+        assert_eq!(
+            rows_at(&open_marks_in(&dir), Local::now()),
+            Vec::<String>::new()
+        );
+    }
+
+    // --- writer -----------------------------------------------------------
+
+    fn read(dir: &Path, name: &str) -> String {
+        fs::read_to_string(dir.join(name)).unwrap()
+    }
+
+    #[test]
+    fn a_key_is_sanitised_once_and_keeps_the_no_issue_sentinel() {
+        assert_eq!(mark_key("tt", "8", "impl"), "tt.8.impl");
+        assert_eq!(mark_key("vinge", "-", "plan"), "vinge.-.plan");
+        assert_eq!(
+            mark_key("my proj", "7", "code/review"),
+            "my_proj.7.code_review"
+        );
+        let dir = Path::new("/marks");
+        assert_eq!(
+            mark_path(dir, &mark_key("my proj", "7", "impl")),
+            PathBuf::from("/marks/my_proj.7.impl")
+        );
+        assert_eq!(
+            beats_path(dir, &mark_key("my proj", "7", "impl")),
+            PathBuf::from("/marks/beats/my_proj.7.impl")
+        );
+    }
+
+    #[test]
+    fn begin_writes_the_start_the_reader_reads_back() {
+        let dir = sandbox("begin");
+        let Begin::Created(start) = begin_in(&dir, "tt", "8", "impl").unwrap() else {
+            panic!("a fresh directory should have no mark to find");
+        };
+
+        assert_eq!(read(&dir, "tt.8.impl"), format!("{}\n", start.timestamp()));
+        assert_eq!(
+            labels(&open_marks_in(&dir)),
+            vec![("tt".into(), Some("8".into()), "impl".into())]
+        );
+        assert_eq!(open_marks_in(&dir)[0].start.timestamp(), start.timestamp());
+    }
+
+    #[test]
+    fn a_second_begin_keeps_the_original_start_byte_for_byte() {
+        let dir = sandbox("begin-again");
+        write(&dir, "tt.8.impl", "1000200\n");
+
+        let again = begin_in(&dir, "tt", "8", "impl").unwrap();
+        assert_eq!(
+            read(&dir, "tt.8.impl"),
+            "1000200\n",
+            "the mark was rewritten"
+        );
+        match again {
+            Begin::AlreadyOpen(Some(start)) => assert_eq!(start.timestamp(), 1000200),
+            other => panic!("expected an already-open mark, got {other:?}"),
+        }
+
+        // An unreadable start still reports the mark as open, never a new start.
+        write(&dir, "broken.1.impl", "not a timestamp\n");
+        assert_eq!(
+            begin_in(&dir, "broken", "1", "impl").unwrap(),
+            Begin::AlreadyOpen(None)
+        );
+    }
+
+    #[test]
+    fn each_touch_appends_one_beat_and_leaves_the_mark_alone() {
+        let dir = sandbox("touch");
+        begin_in(&dir, "tt", "8", "impl").unwrap();
+        let mark = read(&dir, "tt.8.impl");
+
+        for _ in 0..3 {
+            assert_eq!(touch_in(&dir, "tt", "8", "impl").unwrap(), Touch::Recorded);
+        }
+
+        let beats = read(&dir, "beats/tt.8.impl");
+        assert_eq!(beats.lines().count(), 3, "one line per touch: {beats:?}");
+        assert!(
+            beats.lines().all(|line| line.parse::<i64>().is_ok()),
+            "every beat is a bare epoch: {beats:?}"
+        );
+        assert_eq!(read(&dir, "tt.8.impl"), mark, "the mark was rewritten");
+        assert!(!dir.join("tt.8.impl.beats").exists());
+        assert!(!dir.join("tt.8.impl.last").exists());
+    }
+
+    #[test]
+    fn touch_on_an_unbegun_phase_writes_nothing_at_all() {
+        let dir = sandbox("touch-unbegun");
+        assert_eq!(touch_in(&dir, "tt", "8", "impl").unwrap(), Touch::NoMark);
+        assert!(
+            !dir.join("beats").exists(),
+            "no beats directory was created"
+        );
+        assert_eq!(
+            fs::read_dir(&dir).unwrap().count(),
+            0,
+            "the directory is untouched"
+        );
+    }
+
+    #[test]
+    fn cancel_clears_the_mark_and_its_beats_but_not_a_sibling_phase() {
+        let dir = sandbox("cancel");
+        begin_in(&dir, "tt", "8", "impl").unwrap();
+        touch_in(&dir, "tt", "8", "impl").unwrap();
+        begin_in(&dir, "other", "9", "plan").unwrap();
+        touch_in(&dir, "other", "9", "plan").unwrap();
+
+        cancel_in(&dir, "tt", "8", "impl").unwrap();
+
+        assert!(!dir.join("tt.8.impl").exists());
+        assert!(!dir.join("beats/tt.8.impl").exists());
+        assert!(
+            dir.join("beats").is_dir(),
+            "the beats directory itself stays"
+        );
+        assert!(
+            dir.join("other.9.plan").is_file(),
+            "a sibling mark was cleared"
+        );
+        assert!(dir.join("beats/other.9.plan").is_file());
+
+        cancel_in(&dir, "tt", "8", "impl").unwrap();
+        cancel_in(&dir, "never", "1", "begun").unwrap();
+    }
+
+    // --- what `end` measures ----------------------------------------------
+
+    #[test]
+    fn a_phase_with_no_beats_is_one_unvouched_stretch() {
+        // No beats: the whole span is one silence, judged like any other.
+        assert_eq!(gaps_over(0, 46 * 60, &[], 45), vec![(0, 46 * 60)]);
+        assert_eq!(gaps_over(0, 10 * 60, &[], 45), vec![]);
+    }
+
+    #[test]
+    fn silence_before_the_first_beat_is_a_gap() {
+        let start = 1_000_000;
+        let first = start + 60 * 60;
+        let gaps = gaps_over(start, first + 300, &[first], 45);
+        assert_eq!(gaps, vec![(start, first)]);
+    }
+
+    #[test]
+    fn silence_after_the_last_beat_is_a_gap() {
+        let start = 1_000_000;
+        let beat = start + 300;
+        let end = beat + 60 * 60;
+        assert_eq!(gaps_over(start, end, &[beat], 45), vec![(beat, end)]);
+    }
+
+    #[test]
+    fn a_beat_that_does_not_advance_the_sequence_is_skipped() {
+        let start = 1_000_000;
+        let beat = start + 10 * 60;
+        let end = start + 70 * 60;
+        // None of the skipped beats advances `prev`, so the hole after `beat`
+        // is still measured from `beat` itself.
+        let beats = [beat, beat, beat - 60, end + 600, end];
+        assert_eq!(gaps_over(start, end, &beats, 45), vec![(beat, end)]);
+    }
+
+    #[test]
+    fn the_threshold_is_floor_minutes_and_strictly_greater() {
+        let start = 1_000_000;
+        // 45m59s floors to 45, which is not *greater* than 45.
+        assert_eq!(gaps_over(start, start + 45 * 60 + 59, &[], 45), vec![]);
+        // 46m00s is.
+        let end = start + 46 * 60;
+        assert_eq!(gaps_over(start, end, &[], 45), vec![(start, end)]);
+    }
+
+    #[test]
+    fn two_holes_come_back_in_chronological_order() {
+        let start = 1_000_000;
+        let beats = [
+            start + 10 * 60,
+            start + 70 * 60,
+            start + 80 * 60,
+            start + 140 * 60,
+        ];
+        let end = start + 150 * 60;
+        assert_eq!(
+            gaps_over(start, end, &beats, 45),
+            vec![(beats[0], beats[1]), (beats[2], beats[3])]
+        );
+    }
+
+    #[test]
+    fn a_phase_reads_back_its_start_beats_and_last_line() {
+        let dir = sandbox("phase-read");
+        write(&dir, "proj.7.impl", "1000000\n");
+        fs::create_dir_all(dir.join("beats")).unwrap();
+        // `end` measures to the last beat recorded, not the highest one.
+        write(&dir, "beats/proj.7.impl", "1000600\n1002000\n1001200\n");
+
+        let phase = read_phase_in(&dir, "proj", "7", "impl").unwrap().unwrap();
+        assert_eq!(phase.started, 1_000_000);
+        assert_eq!(phase.beats, vec![1_000_600, 1_002_000, 1_001_200]);
+        assert_eq!(phase.ended, Some(1_001_200));
+    }
+
+    #[test]
+    fn a_line_that_is_not_a_bare_timestamp_is_dropped() {
+        let dir = sandbox("phase-garbage");
+        write(&dir, "proj.7.impl", "1000000\n");
+        fs::create_dir_all(dir.join("beats")).unwrap();
+        write(
+            &dir,
+            "beats/proj.7.impl",
+            "\nnope\n1000600 note\n-5\nx1000700\n",
+        );
+
+        let phase = read_phase_in(&dir, "proj", "7", "impl").unwrap().unwrap();
+        // `1000600 note` counts as a beat, but is no instant to measure to.
+        assert_eq!(phase.beats, vec![1_000_600]);
+        assert_eq!(phase.ended, None);
+    }
+
+    #[test]
+    fn an_unmarked_phase_reads_back_as_nothing() {
+        let dir = sandbox("phase-unmarked");
+        assert_eq!(read_phase_in(&dir, "proj", "7", "impl").unwrap(), None);
+    }
+
+    #[test]
+    fn a_mark_that_is_not_a_timestamp_is_an_error_naming_the_path() {
+        let dir = sandbox("phase-bad-mark");
+        write(&dir, "proj.7.impl", "not a timestamp\n");
+
+        let err = read_phase_in(&dir, "proj", "7", "impl").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("proj.7.impl"),
+            "the error names the path: {err}"
+        );
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,648 @@
+//! Rollups over the store — the `tt report` surface: a [`TimeEntry::project`] →
+//! item tree with per-phase breakdowns and an overlap count, the scope flags, and
+//! the terminal and `--json` renderings.
+
+use std::collections::BTreeMap;
+
+use chrono::{Duration, Local, NaiveDate};
+use serde::Serialize;
+
+use crate::agent::PHASES;
+use crate::duration as fmt_duration;
+use crate::icons;
+use crate::tracker::{TimeData, TimeEntry};
+
+/// The bucket an entry with no `project` field lands in.
+pub const NO_PROJECT: &str = "(no project)";
+
+/// One item's totals — the item being a `<project>/<issue>` tag, else a description.
+#[derive(Debug, Default)]
+pub struct ItemNode {
+    pub seconds: i64,
+    /// Seconds per phase, for the ` · `-joined breakdown; empty when none carried one.
+    pub phases: BTreeMap<String, i64>,
+    /// The first contributing entry's description, shown when it differs from the key.
+    pub description: String,
+    /// Whether any contributing entry is still running.
+    pub active: bool,
+}
+
+/// One project's totals and its items.
+#[derive(Debug, Default)]
+pub struct ProjectNode {
+    pub seconds: i64,
+    pub items: BTreeMap<String, ItemNode>,
+}
+
+/// A whole rollup: the tree, the grand total, and the overlap count.
+#[derive(Debug, Default)]
+pub struct Rollup {
+    pub projects: BTreeMap<String, ProjectNode>,
+    pub total_seconds: i64,
+    /// Overlapping *pairs*, not entries — see [`count_overlaps`].
+    pub overlaps: usize,
+}
+
+impl Rollup {
+    pub fn is_empty(&self) -> bool {
+        self.projects.is_empty()
+    }
+}
+
+/// Split an entry's tags into its item axis (first tag containing a `/`) and its
+/// phase axis (first tag in [`PHASES`]). Stored tags carry **no** `#`.
+pub fn classify(tags: &[String]) -> (Option<&str>, Option<&str>) {
+    let mut item = None;
+    let mut phase = None;
+    for tag in tags {
+        if tag.contains('/') {
+            if item.is_none() {
+                item = Some(tag.as_str());
+            }
+        } else if phase.is_none() && PHASES.contains(&tag.as_str()) {
+            phase = Some(tag.as_str());
+        }
+    }
+    (item, phase)
+}
+
+/// An entry's billable seconds, clamped at zero so an entry whose end precedes its
+/// start cannot subtract from the totals around it.
+fn entry_seconds(entry: &TimeEntry) -> i64 {
+    entry.duration().num_seconds().max(0)
+}
+
+/// Count overlapping *pairs* of spans, not overlapping entries — `tt log`
+/// back-dates from now, so a batch of entries claims overlapping slots. The early
+/// `break` is sound because the list is sorted by start.
+pub fn count_overlaps(entries: &[&TimeEntry]) -> usize {
+    let mut ordered: Vec<&&TimeEntry> = entries.iter().collect();
+    ordered.sort_by_key(|entry| entry.start_time);
+
+    let mut pairs = 0;
+    for (i, first) in ordered.iter().enumerate() {
+        let first_end = first.end_time.unwrap_or_else(Local::now);
+        for second in &ordered[i + 1..] {
+            if second.start_time >= first_end {
+                break;
+            }
+            pairs += 1;
+        }
+    }
+    pairs
+}
+
+/// Build the rollup for a set of entries.
+pub fn rollup(entries: &[&TimeEntry]) -> Rollup {
+    let mut result = Rollup {
+        overlaps: count_overlaps(entries),
+        ..Default::default()
+    };
+
+    for entry in entries {
+        let seconds = entry_seconds(entry);
+        let (item, phase) = classify(&entry.tags);
+        let project = entry.project.as_deref().unwrap_or(NO_PROJECT);
+        // Else the description, so a hand-written entry still gets its own row.
+        let key = item.unwrap_or(entry.description.as_str());
+
+        result.total_seconds += seconds;
+        let project_node = result.projects.entry(project.to_string()).or_default();
+        project_node.seconds += seconds;
+
+        let item_node = project_node.items.entry(key.to_string()).or_default();
+        if item_node.description.is_empty() {
+            item_node.description = entry.description.clone();
+        }
+        item_node.seconds += seconds;
+        item_node.active |= entry.end_time.is_none();
+        if let Some(phase) = phase {
+            *item_node.phases.entry(phase.to_string()).or_insert(0) += seconds;
+        }
+    }
+
+    result
+}
+
+/// Keys of a map by descending value, the name breaking ties so the order is stable.
+fn by_seconds_desc<T>(map: &BTreeMap<String, T>, seconds: impl Fn(&T) -> i64) -> Vec<&str> {
+    let mut keys: Vec<&str> = map.keys().map(String::as_str).collect();
+    keys.sort_by(|a, b| {
+        seconds(&map[*b])
+            .cmp(&seconds(&map[*a]))
+            .then_with(|| a.cmp(b))
+    });
+    keys
+}
+
+fn seconds_to_duration(seconds: i64) -> Duration {
+    Duration::seconds(seconds)
+}
+
+/// Truncate to `n` **characters** — byte slicing panics on a multi-byte boundary.
+fn truncate(text: &str, n: usize) -> String {
+    text.chars().take(n).collect()
+}
+
+/// The human rollup: a header, then a row per project with its items beneath it.
+pub fn render(rollup: &Rollup, label: &str) -> String {
+    if rollup.is_empty() {
+        return format!("No entries for {label}.\n");
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{} {label} — {}\n\n",
+        icons::calendar(),
+        fmt_duration::format(seconds_to_duration(rollup.total_seconds))
+    ));
+
+    for project in by_seconds_desc(&rollup.projects, |node| node.seconds) {
+        let node = &rollup.projects[project];
+        out.push_str(&format!(
+            "{:<28} {:>8}\n",
+            project,
+            fmt_duration::format(seconds_to_duration(node.seconds))
+        ));
+
+        for key in by_seconds_desc(&node.items, |item| item.seconds) {
+            let item = &node.items[key];
+            let marker = if item.active { " *" } else { "" };
+            out.push_str(&format!(
+                "  {:<26} {:>8}{}\n",
+                truncate(key, 26),
+                fmt_duration::format(seconds_to_duration(item.seconds)),
+                marker
+            ));
+            // Its own line only when it says something the key does not.
+            if item.description != key && !item.description.is_empty() {
+                out.push_str(&format!("      {}\n", truncate(&item.description, 60)));
+            }
+            if !item.phases.is_empty() {
+                let breakdown: Vec<String> = by_seconds_desc(&item.phases, |secs| *secs)
+                    .into_iter()
+                    .map(|phase| {
+                        format!(
+                            "{phase} {}",
+                            fmt_duration::format(seconds_to_duration(item.phases[phase]))
+                        )
+                    })
+                    .collect();
+                out.push_str(&format!("      {}\n", breakdown.join(" · ")));
+            }
+        }
+        out.push('\n');
+    }
+
+    if rollup.overlaps > 0 {
+        out.push_str(&format!(
+            "{} {} overlapping span(s) — retro `tt log` back-dates from now, so\n",
+            icons::warning(),
+            rollup.overlaps
+        ));
+        out.push_str(
+            "totals are right but the timeline is not. Log at each commit, not in batches.\n",
+        );
+    }
+
+    out
+}
+
+/// The `--json` payload: `projects` keyed on the `project` **field** with the
+/// fieldless bucket under [`NO_PROJECT`], integer seconds, and the scope `label`.
+#[derive(Debug, Serialize)]
+pub struct JsonReport {
+    pub label: String,
+    pub total_seconds: i64,
+    pub overlaps: usize,
+    pub projects: BTreeMap<String, JsonProject>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonProject {
+    pub seconds: i64,
+    pub items: BTreeMap<String, JsonItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonItem {
+    pub seconds: i64,
+    pub phases: BTreeMap<String, i64>,
+    pub description: String,
+    pub active: bool,
+}
+
+pub fn to_json(rollup: &Rollup, label: &str) -> JsonReport {
+    JsonReport {
+        label: label.to_string(),
+        total_seconds: rollup.total_seconds,
+        overlaps: rollup.overlaps,
+        projects: rollup
+            .projects
+            .iter()
+            .map(|(name, node)| {
+                (
+                    name.clone(),
+                    JsonProject {
+                        seconds: node.seconds,
+                        items: node
+                            .items
+                            .iter()
+                            .map(|(key, item)| {
+                                (
+                                    key.clone(),
+                                    JsonItem {
+                                        seconds: item.seconds,
+                                        phases: item.phases.clone(),
+                                        description: item.description.clone(),
+                                        active: item.active,
+                                    },
+                                )
+                            })
+                            .collect(),
+                    },
+                )
+            })
+            .collect(),
+    }
+}
+
+/// What period a report covers, and what to call it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Scope {
+    /// Inclusive lower bound; `None` means unbounded (`--all`).
+    pub from: Option<NaiveDate>,
+    /// Inclusive upper bound; `None` means "up to the end of the data".
+    pub until: Option<NaiveDate>,
+    pub label: String,
+}
+
+/// Resolve the scope flags into bounds and a label. `--week` has a lower bound
+/// only, so it includes anything dated after today.
+pub fn resolve_scope(
+    today: NaiveDate,
+    all: bool,
+    week: bool,
+    since: Option<NaiveDate>,
+    until: Option<NaiveDate>,
+    project: Option<&str>,
+) -> Scope {
+    let mut scope = if all {
+        Scope {
+            from: None,
+            until: None,
+            label: "All entries".to_string(),
+        }
+    } else if week {
+        let start = TimeData::week_start(today);
+        Scope {
+            from: Some(start),
+            until: None,
+            label: format!("Week of {start}"),
+        }
+    } else if let Some(since) = since {
+        Scope {
+            from: Some(since),
+            until: None,
+            label: format!("Since {since}"),
+        }
+    } else {
+        Scope {
+            from: Some(today),
+            until: Some(today),
+            label: format!("Today, {today}"),
+        }
+    };
+
+    // `--until` only ever narrows, and clap requires a scope alongside it.
+    if let Some(until) = until {
+        scope.until = Some(until);
+    }
+    if let Some(project) = project {
+        scope.label.push_str(&format!(" — #{project}"));
+    }
+    scope
+}
+
+/// The entries a scope selects: inside its dates, matching `project` on the field.
+pub fn select<'a>(data: &'a TimeData, scope: &Scope, project: Option<&str>) -> Vec<&'a TimeEntry> {
+    data.entries
+        .iter()
+        .filter(|entry| {
+            let date = entry.start_time.date_naive();
+            scope.from.is_none_or(|from| date >= from)
+                && scope.until.is_none_or(|until| date <= until)
+                && project.is_none_or(|wanted| entry.project.as_deref() == Some(wanted))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(hour: u32, minute: u32) -> chrono::DateTime<Local> {
+        Local
+            .with_ymd_and_hms(2026, 8, 18, hour, minute, 0)
+            .single()
+            .expect("a real local time")
+    }
+
+    fn entry(
+        id: u64,
+        project: Option<&str>,
+        tags: &[&str],
+        from: (u32, u32),
+        minutes: i64,
+    ) -> TimeEntry {
+        let start = at(from.0, from.1);
+        TimeEntry {
+            id,
+            description: "did the thing".to_string(),
+            project: project.map(str::to_string),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            start_time: start,
+            end_time: Some(start + Duration::minutes(minutes)),
+            idle: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn an_agent_shaped_entry_rolls_up_under_its_project_not_under_agent() {
+        // `agent` tags every agent-written entry and must never be the project.
+        let e = entry(1, Some("vinge"), &["vinge/6", "plan", "agent"], (9, 0), 30);
+        let rolled = rollup(&[&e]);
+
+        assert!(
+            rolled.projects.contains_key("vinge"),
+            "grouped on the project field"
+        );
+        assert!(
+            !rolled.projects.contains_key("agent"),
+            "the provenance tag is not a project"
+        );
+        let node = &rolled.projects["vinge"];
+        assert_eq!(node.items.keys().collect::<Vec<_>>(), vec!["vinge/6"]);
+        assert_eq!(node.items["vinge/6"].phases["plan"], 30 * 60);
+    }
+
+    #[test]
+    fn an_entry_with_no_item_tag_is_keyed_on_its_description() {
+        let e = entry(1, Some("tt"), &["impl", "agent"], (9, 0), 15);
+        let rolled = rollup(&[&e]);
+        assert_eq!(
+            rolled.projects["tt"].items.keys().collect::<Vec<_>>(),
+            vec!["did the thing"]
+        );
+    }
+
+    #[test]
+    fn an_entry_with_no_project_field_buckets_under_no_project() {
+        let e = entry(1, None, &["plan"], (9, 0), 15);
+        let rolled = rollup(&[&e]);
+        assert_eq!(rolled.projects.keys().collect::<Vec<_>>(), vec![NO_PROJECT]);
+    }
+
+    #[test]
+    fn phase_seconds_sum_across_entries_under_one_item() {
+        let a = entry(1, Some("tt"), &["tt/12", "plan"], (9, 0), 30);
+        let b = entry(2, Some("tt"), &["tt/12", "plan"], (10, 0), 15);
+        let c = entry(3, Some("tt"), &["tt/12", "impl"], (11, 0), 60);
+        let rolled = rollup(&[&a, &b, &c]);
+
+        let item = &rolled.projects["tt"].items["tt/12"];
+        assert_eq!(item.phases["plan"], 45 * 60, "two plan passes add up");
+        assert_eq!(item.phases["impl"], 60 * 60);
+        assert_eq!(item.seconds, 105 * 60);
+        assert_eq!(rolled.total_seconds, 105 * 60);
+    }
+
+    #[test]
+    fn an_active_entry_is_marked_and_measured_to_now() {
+        let mut e = entry(1, Some("tt"), &["tt/12", "impl"], (9, 0), 30);
+        e.start_time = Local::now() - Duration::minutes(20);
+        e.end_time = None;
+
+        let rolled = rollup(&[&e]);
+        let item = &rolled.projects["tt"].items["tt/12"];
+        assert!(item.active, "a running entry is flagged");
+        // Measured against now, so it is about twenty minutes rather than zero.
+        assert!(
+            item.seconds >= 19 * 60 && item.seconds <= 21 * 60,
+            "measured to now, got {}s",
+            item.seconds
+        );
+    }
+
+    #[test]
+    fn overlaps_count_pairs_and_the_early_break_does_not_undercount() {
+        // Two pairs (a×b, b×c) and not a×c — the `break` must not hide b×c.
+        let a = entry(1, Some("tt"), &["tt/1"], (9, 0), 60); // 09:00–10:00
+        let b = entry(2, Some("tt"), &["tt/2"], (9, 30), 60); // 09:30–10:30
+        let c = entry(3, Some("tt"), &["tt/3"], (10, 15), 30); // 10:15–10:45
+
+        assert_eq!(count_overlaps(&[&a, &b, &c]), 2, "a×b and b×c, not a×c");
+        assert_eq!(count_overlaps(&[&a]), 0, "one span overlaps nothing");
+    }
+
+    #[test]
+    fn a_corrupt_backwards_entry_contributes_no_negative_time() {
+        let mut e = entry(1, Some("tt"), &["tt/12", "impl"], (9, 0), 30);
+        e.end_time = Some(at(8, 0));
+        assert_eq!(entry_seconds(&e), 0, "clamped, not negative");
+    }
+
+    #[test]
+    fn classify_ignores_the_provenance_tag_and_takes_the_first_of_each_axis() {
+        let tags: Vec<String> = ["agent", "vinge/6", "vinge/9", "plan", "impl"]
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
+        assert_eq!(classify(&tags), (Some("vinge/6"), Some("plan")));
+        assert_eq!(classify(&[]), (None, None));
+    }
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).expect("a real date")
+    }
+
+    #[test]
+    fn the_default_scope_is_today_bounded_at_both_ends() {
+        let today = date(2026, 8, 18);
+        let scope = resolve_scope(today, false, false, None, None, None);
+        assert_eq!(scope.from, Some(today));
+        assert_eq!(scope.until, Some(today));
+        assert_eq!(scope.label, "Today, 2026-08-18");
+    }
+
+    #[test]
+    fn all_is_unbounded_and_week_starts_on_monday_with_no_upper_bound() {
+        // 2026-08-18 is a Tuesday, so the week starts the day before.
+        let today = date(2026, 8, 18);
+
+        let all = resolve_scope(today, true, false, None, None, None);
+        assert_eq!((all.from, all.until), (None, None));
+        assert_eq!(all.label, "All entries");
+
+        let week = resolve_scope(today, false, true, None, None, None);
+        assert_eq!(week.from, Some(date(2026, 8, 17)), "Monday");
+        assert_eq!(week.until, None, "a week report has no upper bound");
+        assert_eq!(week.label, "Week of 2026-08-17");
+    }
+
+    #[test]
+    fn since_and_until_bound_the_range_and_project_suffixes_any_label() {
+        let today = date(2026, 8, 18);
+        let scope = resolve_scope(
+            today,
+            false,
+            false,
+            Some(date(2026, 8, 1)),
+            Some(date(2026, 8, 5)),
+            Some("vinge"),
+        );
+        assert_eq!(scope.from, Some(date(2026, 8, 1)));
+        assert_eq!(scope.until, Some(date(2026, 8, 5)));
+        assert_eq!(scope.label, "Since 2026-08-01 — #vinge");
+    }
+
+    #[test]
+    fn an_empty_rollup_says_so_and_renders_nothing_else() {
+        let rendered = render(&Rollup::default(), "Today, 2026-08-18");
+        assert_eq!(rendered, "No entries for Today, 2026-08-18.\n");
+    }
+
+    #[test]
+    fn the_human_form_carries_the_header_the_rows_and_the_phase_breakdown() {
+        let a = entry(1, Some("tt"), &["tt/12", "plan", "agent"], (9, 0), 30);
+        let b = entry(2, Some("tt"), &["tt/12", "impl", "agent"], (11, 0), 60);
+        let rendered = render(&rollup(&[&a, &b]), "Today, 2026-08-18");
+
+        assert!(
+            rendered.starts_with(&format!(
+                "{} Today, 2026-08-18 — 1h 30m\n\n",
+                icons::calendar()
+            )),
+            "header carries the icon, the label and the total: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("tt                             1h 30m\n"),
+            "{rendered:?}"
+        );
+        assert!(
+            rendered.contains("  tt/12                        1h 30m\n"),
+            "{rendered:?}"
+        );
+        // Longest phase first, joined with the middot.
+        assert!(
+            rendered.contains("      impl 1h 0m · plan 0h 30m\n"),
+            "{rendered:?}"
+        );
+        // The description line appears because it differs from the item key.
+        assert!(rendered.contains("      did the thing\n"), "{rendered:?}");
+        assert!(
+            !rendered.contains("overlapping"),
+            "two disjoint spans warn about nothing"
+        );
+    }
+
+    #[test]
+    fn the_overlap_warning_appears_only_when_spans_collide() {
+        let a = entry(1, Some("tt"), &["tt/1", "impl"], (9, 0), 60);
+        let b = entry(2, Some("tt"), &["tt/2", "impl"], (9, 30), 60);
+        let rendered = render(&rollup(&[&a, &b]), "Today, 2026-08-18");
+        assert!(
+            rendered.contains(&format!("{} 1 overlapping span(s)", icons::warning())),
+            "{rendered:?}"
+        );
+        assert!(rendered.contains("Log at each commit, not in batches."));
+    }
+
+    #[test]
+    fn an_active_entry_is_starred_in_the_item_row() {
+        let mut e = entry(1, Some("tt"), &["tt/12", "impl"], (9, 0), 30);
+        e.end_time = None;
+        let rendered = render(&rollup(&[&e]), "Today");
+        assert!(
+            rendered
+                .lines()
+                .any(|l| l.starts_with("  tt/12") && l.ends_with(" *")),
+            "{rendered:?}"
+        );
+    }
+
+    #[test]
+    fn a_long_key_and_description_are_truncated_by_characters_not_bytes() {
+        // Multi-byte throughout: byte slicing would panic mid-character.
+        let mut e = entry(1, Some("tt"), &[], (9, 0), 30);
+        e.description = "å".repeat(80);
+        let rendered = render(&rollup(&[&e]), "Today");
+        // The key is the description here, so it is cut at 26 and not repeated.
+        assert!(rendered.contains(&"å".repeat(26)), "{rendered:?}");
+        assert!(!rendered.contains(&"å".repeat(27)), "cut at 26 characters");
+    }
+
+    #[test]
+    fn select_filters_on_the_date_bounds_and_on_the_project_field() {
+        let inside = entry(1, Some("vinge"), &["vinge/6", "plan"], (9, 0), 30);
+        let mut earlier = entry(2, Some("vinge"), &["vinge/7", "plan"], (9, 0), 30);
+        earlier.start_time = at(9, 0) - Duration::days(3);
+        earlier.end_time = Some(earlier.start_time + Duration::minutes(30));
+        let other_project = entry(3, Some("tt"), &["tt/12", "plan"], (10, 0), 30);
+
+        let data = TimeData {
+            entries: vec![inside.clone(), earlier.clone(), other_project.clone()],
+            ..Default::default()
+        };
+
+        let today = date(2026, 8, 18);
+        let day = resolve_scope(today, false, false, None, None, None);
+        assert_eq!(select(&data, &day, None).len(), 2, "the two dated today");
+
+        let all = resolve_scope(today, true, false, None, None, None);
+        assert_eq!(select(&data, &all, None).len(), 3);
+        assert_eq!(
+            select(&data, &all, Some("vinge"))
+                .iter()
+                .map(|e| e.id)
+                .collect::<Vec<_>>(),
+            vec![1, 2],
+            "filtered on the field, not on a tag"
+        );
+    }
+
+    #[test]
+    fn the_json_payload_keys_projects_on_the_field_with_integer_seconds() {
+        let agent_shaped = entry(1, Some("vinge"), &["vinge/6", "plan", "agent"], (9, 0), 30);
+        let fieldless = entry(2, None, &["plan"], (9, 15), 15);
+        let rolled = rollup(&[&agent_shaped, &fieldless]);
+
+        let json = serde_json::to_value(to_json(&rolled, "Today, 2026-08-18"))
+            .expect("the payload serialises");
+
+        assert_eq!(json["total_seconds"], 45 * 60);
+        assert_eq!(json["overlaps"], 1, "the two spans collide");
+        assert_eq!(json["label"], "Today, 2026-08-18");
+
+        // Project keys are the field, and the fieldless entry buckets separately.
+        let projects = json["projects"].as_object().expect("an object");
+        let mut names: Vec<&str> = projects.keys().map(String::as_str).collect();
+        names.sort();
+        assert_eq!(names, vec![NO_PROJECT, "vinge"]);
+        assert!(
+            !projects.contains_key("agent"),
+            "the provenance tag is not a project"
+        );
+
+        let item = &json["projects"]["vinge"]["items"]["vinge/6"];
+        assert_eq!(item["seconds"], 30 * 60);
+        assert_eq!(item["phases"]["plan"], 30 * 60);
+        assert_eq!(item["description"], "did the thing");
+        assert_eq!(item["active"], false);
+
+        // Integers throughout — no `.0` anywhere.
+        assert!(json["total_seconds"].is_i64());
+        assert!(item["seconds"].is_i64());
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use std::{
+    ffi::OsString,
     fs::{self, File},
     path::{Path, PathBuf},
     time::{Duration, SystemTime},
@@ -8,11 +9,20 @@ use std::{
 use crate::tracker;
 
 pub fn get_data_path() -> Result<PathBuf> {
-    let proj_dirs = directories::ProjectDirs::from("com", "timetracker", "tt")
+    let default = directories::ProjectDirs::from("com", "timetracker", "tt")
+        .map(|dirs| dirs.data_dir().to_path_buf());
+    let data_dir = resolve_data_dir(std::env::var_os("TT_DATA_DIR"), default)
         .context("Could not determine config directory")?;
-    let data_dir = proj_dirs.data_dir();
-    fs::create_dir_all(data_dir)?;
+    fs::create_dir_all(&data_dir)?;
     Ok(data_dir.join("data.json"))
+}
+
+/// The env-free half of [`get_data_path`], taking the default store directory.
+fn resolve_data_dir(data_dir: Option<OsString>, default: Option<PathBuf>) -> Option<PathBuf> {
+    match data_dir {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => default,
+    }
 }
 
 /// A cheap staleness fingerprint of a path — a file or a directory alike.
@@ -115,6 +125,30 @@ pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Point `HOME`, `TT_DATA_DIR` and `TT_MARK_DIR` at a fresh scratch directory
+/// named after `name`, and return it. **Tests must never touch the real store or
+/// marks** — live agent sessions write both. Callers hold [`env_guard`].
+#[cfg(test)]
+pub(crate) fn env_sandbox(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tt-sandbox-{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    unsafe { std::env::set_var("HOME", &dir) };
+    unsafe { std::env::set_var("TT_DATA_DIR", dir.join("store")) };
+    unsafe { std::env::set_var("TT_MARK_DIR", dir.join("marks")) };
+    let path = get_data_path().unwrap();
+    assert!(
+        path.starts_with(&dir),
+        "sandbox TT_DATA_DIR not in effect: {path:?}"
+    );
+    let marks = crate::marks::mark_dir().expect("a mark dir");
+    assert!(
+        marks.starts_with(&dir),
+        "sandbox TT_MARK_DIR not in effect: {marks:?}"
+    );
+    dir
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,6 +197,23 @@ mod tests {
         assert!(
             !PathStamp::unchanged(None, PathStamp::read(&file)),
             "appearing is a change"
+        );
+    }
+
+    #[test]
+    fn tt_data_dir_replaces_the_default_store_directory() {
+        let default = || Some(PathBuf::from("default"));
+        assert_eq!(resolve_data_dir(None, default()), default());
+        // An empty `TT_DATA_DIR` is no setting at all.
+        assert_eq!(resolve_data_dir(Some("".into()), default()), default());
+        assert_eq!(
+            resolve_data_dir(Some("elsewhere".into()), default()),
+            Some(PathBuf::from("elsewhere"))
+        );
+        assert_eq!(resolve_data_dir(None, None), None, "no default, no store");
+        assert_eq!(
+            resolve_data_dir(Some("elsewhere".into()), None),
+            Some(PathBuf::from("elsewhere"))
         );
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,9 @@
 use anyhow::{Context, Result};
-use std::{fs, path::PathBuf};
+use std::{
+    fs::{self, File},
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
 
 use crate::tracker;
 
@@ -9,6 +13,64 @@ pub fn get_data_path() -> Result<PathBuf> {
     let data_dir = proj_dirs.data_dir();
     fs::create_dir_all(data_dir)?;
     Ok(data_dir.join("data.json"))
+}
+
+/// A cheap staleness fingerprint of a path — a file or a directory alike.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PathStamp {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+impl PathStamp {
+    /// `None` when `path` does not exist yet, or cannot be stat'd.
+    pub fn read(path: &Path) -> Option<Self> {
+        let meta = fs::metadata(path).ok()?;
+        Some(Self {
+            len: meta.len(),
+            modified: meta.modified().ok(),
+        })
+    }
+
+    /// Whether a caller may skip re-reading the path. Two missing paths are
+    /// unchanged; an existing one must also be settled.
+    pub fn unchanged(previous: Option<Self>, current: Option<Self>) -> bool {
+        match current {
+            Some(stamp) => current == previous && stamp.is_settled(),
+            None => current == previous,
+        }
+    }
+
+    /// False while the mtime is inside the current second, where one-second
+    /// granularity can hide a same-second write from every later comparison.
+    pub fn is_settled(&self) -> bool {
+        let Some(modified) = self.modified else {
+            return false;
+        };
+        match SystemTime::now().duration_since(modified) {
+            Ok(age) => age >= Duration::from_secs(1),
+            // mtime in the future (clock skew): compare stamps rather than
+            // reload on every tick until the clock catches up.
+            Err(_) => true,
+        }
+    }
+}
+
+/// The store file's stamp. `None` when the store does not exist yet.
+pub fn store_stamp() -> Option<PathStamp> {
+    PathStamp::read(&get_data_path().ok()?)
+}
+
+fn get_lock_path() -> Result<PathBuf> {
+    Ok(get_data_path()?.with_extension("lock"))
+}
+
+/// Take an exclusive lock on the store, held until the returned file is dropped
+fn lock_data() -> Result<File> {
+    let path = get_lock_path()?;
+    let lock = File::create(&path).context("Could not open lock file")?;
+    lock.lock().context("Could not lock data file")?;
+    Ok(lock)
 }
 
 pub fn load_data() -> Result<tracker::TimeData> {
@@ -24,6 +86,83 @@ pub fn load_data() -> Result<tracker::TimeData> {
 pub fn save_data(data: &tracker::TimeData) -> Result<()> {
     let path = get_data_path()?;
     let content = serde_json::to_string_pretty(data)?;
-    fs::write(path, content)?;
+
+    // Temp file then rename, so a reader never sees a torn store
+    let temp_path = path.with_extension("json.tmp");
+    fs::write(&temp_path, content)?;
+    fs::rename(&temp_path, &path)?;
     Ok(())
+}
+
+/// Load the data, apply `edit`, and save the result under one exclusive lock —
+/// one store transaction per mutation, which must not be split.
+pub fn with_data<T>(edit: impl FnOnce(&mut tracker::TimeData) -> Result<T>) -> Result<T> {
+    let _lock = lock_data()?;
+    let mut data = load_data()?;
+    let result = edit(&mut data)?;
+    save_data(&data)?;
+    Ok(result)
+}
+
+/// The one lock every test that repoints an env var (`HOME`, `TT_MARK_DIR`)
+/// serialises against — env is process-wide, so do not add a second.
+#[cfg(test)]
+pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch path — never the real store or the real mark directory.
+    fn sandbox(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-stamp-test-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_stamp_taken_within_the_same_second_is_unsettled() {
+        let dir = sandbox("settled");
+        let file = dir.join("data.json");
+        fs::write(&file, "{}").unwrap();
+
+        // Freshly written, so the next write could leave this stamp identical.
+        let fresh = PathStamp::read(&file).unwrap();
+        assert!(!fresh.is_settled(), "a stamp of a just-written path");
+        assert!(
+            !PathStamp::unchanged(Some(fresh), Some(fresh)),
+            "two identical unsettled stamps still mean 'reload'"
+        );
+
+        // The same stamp, once the second it was taken in has passed.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let settled = PathStamp::read(&file).unwrap();
+        assert_eq!(fresh, settled, "the path did not change");
+        assert!(settled.is_settled(), "a stamp older than a second");
+        assert!(PathStamp::unchanged(Some(fresh), Some(settled)));
+    }
+
+    #[test]
+    fn a_missing_path_stamps_as_none_and_compares_equal_to_itself() {
+        let dir = sandbox("missing");
+        let file = dir.join("nope.json");
+        assert_eq!(PathStamp::read(&file), None);
+        assert!(
+            PathStamp::unchanged(None, None),
+            "still missing is still unchanged"
+        );
+
+        fs::write(&file, "{}").unwrap();
+        assert!(
+            !PathStamp::unchanged(None, PathStamp::read(&file)),
+            "appearing is a change"
+        );
+    }
 }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -8,10 +8,43 @@ use crate::icons;
 pub struct TimeEntry {
     pub id: u64,
     pub description: String,
+    /// Project this entry belongs to, if known
+    #[serde(default)]
+    pub project: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     pub start_time: DateTime<Local>,
     pub end_time: Option<DateTime<Local>>,
+    /// Silent stretches inside this entry's span, as `tt log --idle` recorded them.
+    #[serde(default)]
+    pub idle: Vec<IdleInterval>,
+}
+
+/// One silent stretch inside an entry.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct IdleInterval {
+    pub start: DateTime<Local>,
+    pub end: DateTime<Local>,
+}
+
+impl IdleInterval {
+    pub fn new(start: DateTime<Local>, end: DateTime<Local>) -> Self {
+        Self { start, end }
+    }
+
+    pub fn duration(&self) -> Duration {
+        self.end.signed_duration_since(self.start)
+    }
+
+    /// `09:50 – 10:20 (30m)`, as the detail popover lists it.
+    pub fn format_span(&self) -> String {
+        format!(
+            "{} – {} ({})",
+            self.start.format("%H:%M"),
+            self.end.format("%H:%M"),
+            duration::format(self.duration())
+        )
+    }
 }
 
 /// Parse tags (words starting with #) from text and return (clean_text, tags)
@@ -31,6 +64,35 @@ pub fn parse_tags(text: &str) -> (String, Vec<String>) {
     (clean_parts.join(" "), tags)
 }
 
+/// Infer the project from an entry's tags: the tag `X` for which some other tag
+/// starts with `X/`; failing that, the first tag; with no tags, `None`.
+pub fn infer_project(tags: &[String]) -> Option<String> {
+    let with_child = tags.iter().enumerate().find(|(i, candidate)| {
+        let prefix = format!("{}/", candidate);
+        tags.iter()
+            .enumerate()
+            .any(|(j, other)| j != *i && other.starts_with(&prefix))
+    });
+
+    with_child
+        .map(|(_, candidate)| candidate)
+        .or_else(|| tags.first())
+        .cloned()
+}
+
+/// One-time migration: infer any missing `project`, then stamp schema version 1.
+pub fn migrate(data: &mut TimeData) {
+    if data.schema_version >= 1 {
+        return;
+    }
+    for entry in &mut data.entries {
+        if entry.project.is_none() {
+            entry.project = infer_project(&entry.tags);
+        }
+    }
+    data.schema_version = 1;
+}
+
 /// Format tags for display (with # prefix), e.g. "#backend #bug"
 pub fn format_tags(tags: &[String]) -> String {
     tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(" ")
@@ -44,6 +106,22 @@ impl TimeEntry {
 
     pub fn format_duration(&self) -> String {
         duration::format(self.duration())
+    }
+
+    /// The date column, as the entries table prints it.
+    pub fn format_date(&self) -> String {
+        self.start_time.format("%Y-%m-%d").to_string()
+    }
+
+    pub fn format_start_time(&self) -> String {
+        self.start_time.format("%H:%M").to_string()
+    }
+
+    /// The end-time column: a clock time, or an em dash while the entry runs.
+    pub fn format_end_time(&self) -> String {
+        self.end_time
+            .map(|t| t.format("%H:%M").to_string())
+            .unwrap_or_else(|| "—".to_string())
     }
 
     pub fn is_active(&self) -> bool {
@@ -74,12 +152,105 @@ impl TimeEntry {
     pub fn has_any_tag(&self, tags: &[String]) -> bool {
         tags.iter().any(|t| self.has_tag(t))
     }
+
+    /// Whether the entry's project is one of `projects` (case-insensitive). An
+    /// entry with no project matches nothing.
+    pub fn has_any_project(&self, projects: &[String]) -> bool {
+        let Some(project) = self
+            .project
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        else {
+            return false;
+        };
+        let project = project.to_lowercase();
+        projects.iter().any(|p| p.trim().to_lowercase() == project)
+    }
+
+    /// The haystack `/` searches: everything a row or the popover can show, built
+    /// from the same formatters the table renders with. Keep the two in step.
+    pub fn search_haystack(&self) -> String {
+        [
+            self.id.to_string(),
+            self.description.clone(),
+            self.project.clone().unwrap_or_default(),
+            self.format_tags(),
+            self.format_date(),
+            self.format_start_time(),
+            self.format_end_time(),
+            self.format_duration(),
+        ]
+        .join(" ")
+        .to_lowercase()
+    }
+
+    /// Whether `needle` (already lower-cased) appears anywhere in this entry.
+    pub fn matches_search(&self, needle_lower: &str) -> bool {
+        self.search_haystack().contains(needle_lower)
+    }
+
+    /// The spans this entry would be left as if its idle stretches were trimmed
+    /// away, earliest first. Pure, so the trim prompt can state the outcome before
+    /// [`TimeData::split_at_idle`](TimeData::split_at_idle) writes exactly these
+    /// spans; do not copy the arithmetic elsewhere.
+    ///
+    /// Each interval is clamped to the entry's span and dropped if that empties it;
+    /// the rest are sorted and overlapping or touching neighbours merged, so such a
+    /// pair cuts **one** hole. The result is the complement of those holes, so a
+    /// hole at an endpoint contributes nothing.
+    ///
+    /// Empty means no trim: no `end_time`, nothing left after clamping, or idle
+    /// covering the whole span, which leaves the entry as it is.
+    pub fn trim_spans(&self) -> Vec<(DateTime<Local>, DateTime<Local>)> {
+        let span_start = self.start_time;
+        let Some(span_end) = self.end_time else {
+            return Vec::new();
+        };
+
+        let mut gaps: Vec<IdleInterval> = self
+            .idle
+            .iter()
+            .map(|gap| IdleInterval {
+                start: gap.start.clamp(span_start, span_end),
+                end: gap.end.clamp(span_start, span_end),
+            })
+            .filter(|gap| gap.end > gap.start)
+            .collect();
+        gaps.sort_by_key(|gap| gap.start);
+        let mut holes: Vec<IdleInterval> = Vec::new();
+        for gap in gaps {
+            match holes.last_mut() {
+                Some(last) if gap.start <= last.end => last.end = last.end.max(gap.end),
+                _ => holes.push(gap),
+            }
+        }
+        if holes.is_empty() {
+            return Vec::new();
+        }
+
+        let mut spans: Vec<(DateTime<Local>, DateTime<Local>)> = Vec::new();
+        let mut cursor = span_start;
+        for hole in &holes {
+            if hole.start > cursor {
+                spans.push((cursor, hole.start));
+            }
+            cursor = hole.end;
+        }
+        if span_end > cursor {
+            spans.push((cursor, span_end));
+        }
+        spans
+    }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct TimeData {
     pub entries: Vec<TimeEntry>,
     pub next_id: u64,
+    /// Store schema version; an unversioned file reads as 0 and migrates to 1
+    #[serde(default)]
+    pub schema_version: u32,
 }
 
 impl TimeData {
@@ -118,6 +289,7 @@ impl TimeData {
     pub fn add_entry(
         &mut self,
         description: String,
+        project: Option<String>,
         tags: Vec<String>,
         start_time: DateTime<Local>,
         end_time: Option<DateTime<Local>>,
@@ -125,9 +297,11 @@ impl TimeData {
         let entry = TimeEntry {
             id: self.next_id,
             description,
+            project,
             tags,
             start_time,
             end_time,
+            idle: Vec::new(),
         };
         self.next_id += 1;
         self.entries.push(entry);
@@ -189,12 +363,14 @@ impl TimeData {
         &mut self,
         id: u64,
         description: String,
+        project: Option<String>,
         tags: Vec<String>,
         start_time: DateTime<Local>,
         end_time: Option<DateTime<Local>>,
     ) -> bool {
         if let Some(entry) = self.entries.iter_mut().find(|e| e.id == id) {
             entry.description = description;
+            entry.project = project;
             entry.tags = tags;
             entry.start_time = start_time;
             entry.end_time = end_time;
@@ -207,5 +383,401 @@ impl TimeData {
     /// Get an entry by ID
     pub fn get_entry(&self, id: u64) -> Option<&TimeEntry> {
         self.entries.iter().find(|e| e.id == id)
+    }
+
+    /// Split the entry with `id` on every idle interval it carries — the store
+    /// mechanic behind the user-facing trim. Returns the pieces' ids, earliest
+    /// first, or an empty vec when nothing changed.
+    ///
+    /// The earliest piece keeps the original id in place, later pieces take fresh
+    /// ids from `next_id`, and every piece inherits description, project and tags.
+    ///
+    /// [`TimeEntry::trim_spans`] owns the arithmetic; this is the mutation and the
+    /// id policy only, pure over `&mut self` so the caller owns the transaction.
+    pub fn split_at_idle(&mut self, id: u64) -> Vec<u64> {
+        let Some(entry) = self.get_entry(id) else {
+            return Vec::new();
+        };
+        let pieces = entry.trim_spans();
+        if pieces.is_empty() {
+            return Vec::new();
+        }
+        let template = entry.clone();
+
+        let mut ids = Vec::with_capacity(pieces.len());
+        for (i, (piece_start, piece_end)) in pieces.into_iter().enumerate() {
+            let inside: Vec<IdleInterval> = template
+                .idle
+                .iter()
+                .copied()
+                .filter(|gap| gap.start >= piece_start && gap.end <= piece_end)
+                .collect();
+            if i == 0 {
+                // In place, so the earliest piece keeps the original id.
+                let first = self
+                    .entries
+                    .iter_mut()
+                    .find(|e| e.id == id)
+                    .expect("the entry resolved above");
+                first.start_time = piece_start;
+                first.end_time = Some(piece_end);
+                first.idle = inside;
+                ids.push(id);
+            } else {
+                let new_id = self.next_id;
+                self.next_id += 1;
+                self.entries.push(TimeEntry {
+                    id: new_id,
+                    description: template.description.clone(),
+                    project: template.project.clone(),
+                    tags: template.tags.clone(),
+                    start_time: piece_start,
+                    end_time: Some(piece_end),
+                    idle: inside,
+                });
+                ids.push(new_id);
+            }
+        }
+        ids
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(values: &[&str]) -> Vec<String> {
+        values.iter().map(|t| t.to_string()).collect()
+    }
+
+    fn entry(id: u64, project: Option<&str>, entry_tags: &[&str]) -> TimeEntry {
+        TimeEntry {
+            id,
+            description: format!("entry {}", id),
+            project: project.map(|p| p.to_string()),
+            tags: tags(entry_tags),
+            start_time: Local::now(),
+            end_time: None,
+            idle: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn infers_project_from_sibling_tag_not_first_tag() {
+        assert_eq!(
+            infer_project(&tags(&[
+                "62",
+                "77",
+                "90/#91/#94/#95",
+                "loremind",
+                "loremind/62",
+                "ops"
+            ])),
+            Some("loremind".to_string())
+        );
+    }
+
+    #[test]
+    fn infers_project_from_sibling_tag_when_summary_token_is_first() {
+        assert_eq!(
+            infer_project(&tags(&["63:", "loremind", "loremind/63", "plan"])),
+            Some("loremind".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_first_tag_when_no_sibling_pair() {
+        assert_eq!(
+            infer_project(&tags(&["tt", "impl"])),
+            Some("tt".to_string())
+        );
+    }
+
+    #[test]
+    fn infers_no_project_without_tags() {
+        assert_eq!(infer_project(&[]), None);
+    }
+
+    #[test]
+    fn migrate_fills_missing_projects_and_sets_schema_version() {
+        let mut data = TimeData {
+            entries: vec![
+                entry(1, None, &["tt", "impl"]),
+                entry(2, None, &["63:", "loremind", "loremind/63", "plan"]),
+                entry(3, Some("explicit"), &["tt", "impl"]),
+                entry(4, None, &[]),
+            ],
+            next_id: 5,
+            schema_version: 0,
+        };
+
+        migrate(&mut data);
+
+        assert_eq!(data.schema_version, 1);
+        assert_eq!(data.entries[0].project.as_deref(), Some("tt"));
+        assert_eq!(data.entries[1].project.as_deref(), Some("loremind"));
+        assert_eq!(data.entries[2].project.as_deref(), Some("explicit"));
+        assert_eq!(data.entries[3].project, None);
+    }
+
+    /// A fixed wall clock, so assertions read as offsets rather than literals.
+    fn base() -> DateTime<Local> {
+        NaiveDate::from_ymd_opt(2026, 8, 18)
+            .unwrap()
+            .and_hms_opt(9, 0, 0)
+            .unwrap()
+            .and_local_timezone(Local)
+            .unwrap()
+    }
+
+    /// One logged entry of `span_minutes`, with idle as minute offsets from start.
+    fn logged_with_idle(span_minutes: i64, gaps: &[(i64, i64)]) -> TimeData {
+        let start = base();
+        TimeData {
+            entries: vec![TimeEntry {
+                id: 7,
+                description: "logged span".to_string(),
+                project: Some("tt".to_string()),
+                tags: tags(&["tt", "tt/36"]),
+                start_time: start,
+                end_time: Some(start + Duration::minutes(span_minutes)),
+                idle: gaps
+                    .iter()
+                    .map(|(from, to)| {
+                        IdleInterval::new(
+                            start + Duration::minutes(*from),
+                            start + Duration::minutes(*to),
+                        )
+                    })
+                    .collect(),
+            }],
+            next_id: 8,
+            schema_version: 1,
+        }
+    }
+
+    /// The entry spans, as (minutes from `base`, minutes from `base`) pairs.
+    fn spans(data: &TimeData) -> Vec<(i64, i64)> {
+        data.entries
+            .iter()
+            .map(|e| {
+                (
+                    e.start_time.signed_duration_since(base()).num_minutes(),
+                    e.end_time
+                        .unwrap()
+                        .signed_duration_since(base())
+                        .num_minutes(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn splitting_on_one_idle_interval_gives_two_pieces_excluding_it() {
+        let mut data = logged_with_idle(120, &[(50, 80)]);
+
+        let ids = data.split_at_idle(7);
+
+        assert_eq!(ids.len(), 2, "one hole in the middle cuts the span in two");
+        assert_eq!(ids[0], 7, "the earliest piece keeps the original id");
+        assert_eq!(ids[1], 8, "the later piece takes the next id");
+        assert_eq!(data.next_id, 9);
+        assert_eq!(spans(&data), vec![(0, 50), (50 + 30, 120)]);
+        for entry in &data.entries {
+            assert_eq!(entry.description, "logged span");
+            assert_eq!(entry.project.as_deref(), Some("tt"));
+            assert_eq!(entry.tags, tags(&["tt", "tt/36"]));
+            assert!(entry.idle.is_empty(), "a piece kept a hole it excludes");
+        }
+    }
+
+    #[test]
+    fn splitting_on_two_idle_intervals_gives_three_pieces() {
+        let mut data = logged_with_idle(180, &[(30, 45), (100, 130)]);
+
+        let ids = data.split_at_idle(7);
+
+        assert_eq!(ids, vec![7, 8, 9]);
+        assert_eq!(spans(&data), vec![(0, 30), (45, 100), (130, 180)]);
+    }
+
+    #[test]
+    fn an_idle_interval_touching_an_endpoint_gives_one_piece_not_an_empty_one() {
+        let mut leading = logged_with_idle(90, &[(0, 20)]);
+        assert_eq!(leading.split_at_idle(7), vec![7]);
+        assert_eq!(spans(&leading), vec![(20, 90)]);
+        assert_eq!(
+            leading.next_id, 8,
+            "no fresh id was spent on an empty piece"
+        );
+
+        let mut trailing = logged_with_idle(90, &[(70, 90)]);
+        assert_eq!(trailing.split_at_idle(7), vec![7]);
+        assert_eq!(spans(&trailing), vec![(0, 70)]);
+        assert_eq!(trailing.next_id, 8);
+    }
+
+    #[test]
+    fn idle_covering_the_whole_span_leaves_the_entry_untouched() {
+        let mut data = logged_with_idle(90, &[(0, 90)]);
+        let before = serde_json::to_string(&data).unwrap();
+
+        assert!(data.split_at_idle(7).is_empty());
+
+        assert_eq!(serde_json::to_string(&data).unwrap(), before);
+        assert_eq!(spans(&data), vec![(0, 90)], "the logged entry survived");
+    }
+
+    #[test]
+    fn an_entry_with_no_idle_is_not_split() {
+        let mut data = logged_with_idle(90, &[]);
+        let before = serde_json::to_string(&data).unwrap();
+
+        assert!(data.split_at_idle(7).is_empty());
+        assert!(data.split_at_idle(999).is_empty(), "an unknown id");
+
+        assert_eq!(serde_json::to_string(&data).unwrap(), before);
+    }
+
+    #[test]
+    fn the_pieces_sum_to_the_span_minus_the_idle_intervals() {
+        let gaps = [(20, 35), (60, 61), (100, 140)];
+        let mut data = logged_with_idle(180, &gaps);
+        let original = data.entries[0].duration();
+        let idle_total = data.entries[0]
+            .idle
+            .iter()
+            .fold(Duration::zero(), |acc, gap| acc + gap.duration());
+
+        data.split_at_idle(7);
+
+        let after = data
+            .entries
+            .iter()
+            .fold(Duration::zero(), |acc, e| acc + e.duration());
+        assert_eq!(after, original - idle_total);
+    }
+
+    /// `trim_spans` as minute offsets from `base`.
+    fn trim_offsets(span_minutes: i64, gaps: &[(i64, i64)]) -> Vec<(i64, i64)> {
+        logged_with_idle(span_minutes, gaps).entries[0]
+            .trim_spans()
+            .into_iter()
+            .map(|(from, to)| {
+                (
+                    from.signed_duration_since(base()).num_minutes(),
+                    to.signed_duration_since(base()).num_minutes(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn trim_spans_cuts_the_span_at_every_hole() {
+        assert_eq!(trim_offsets(120, &[(50, 80)]), vec![(0, 50), (80, 120)]);
+        assert_eq!(
+            trim_offsets(180, &[(30, 45), (100, 130)]),
+            vec![(0, 30), (45, 100), (130, 180)]
+        );
+        // Unsorted input is sorted first, so stored order cannot change the answer.
+        assert_eq!(
+            trim_offsets(180, &[(100, 130), (30, 45)]),
+            vec![(0, 30), (45, 100), (130, 180)]
+        );
+    }
+
+    #[test]
+    fn trim_spans_drops_the_empty_piece_at_an_endpoint() {
+        assert_eq!(trim_offsets(90, &[(0, 20)]), vec![(20, 90)]);
+        assert_eq!(trim_offsets(90, &[(70, 90)]), vec![(0, 70)]);
+    }
+
+    /// Overlapping and touching neighbours merge into one hole.
+    #[test]
+    fn trim_spans_merges_overlapping_intervals_into_one_hole() {
+        assert_eq!(
+            trim_offsets(120, &[(30, 60), (50, 80)]),
+            vec![(0, 30), (80, 120)]
+        );
+        // Abutting exactly, and one interval swallowing another, are the same hole.
+        assert_eq!(
+            trim_offsets(120, &[(30, 60), (60, 80)]),
+            vec![(0, 30), (80, 120)]
+        );
+        assert_eq!(
+            trim_offsets(120, &[(30, 90), (40, 50)]),
+            vec![(0, 30), (90, 120)]
+        );
+    }
+
+    /// Empty is the answer to every case where nothing would change.
+    #[test]
+    fn trim_spans_is_empty_when_nothing_would_change() {
+        assert!(trim_offsets(90, &[]).is_empty(), "no idle at all");
+        assert!(
+            trim_offsets(90, &[(0, 90)]).is_empty(),
+            "idle covering the whole span leaves the entry alone"
+        );
+        assert!(
+            trim_offsets(90, &[(-30, 0)]).is_empty(),
+            "an interval clamped to nothing outside the span"
+        );
+
+        // A running entry has no end to split against.
+        let mut running = logged_with_idle(90, &[(30, 45)]);
+        running.entries[0].end_time = None;
+        assert!(running.entries[0].trim_spans().is_empty());
+    }
+
+    #[test]
+    fn a_store_written_before_idle_existed_loads_and_stays_at_schema_version_1() {
+        let json = r#"{
+            "entries": [
+                {
+                    "id": 1,
+                    "description": "an older entry",
+                    "project": "tt",
+                    "tags": ["tt", "impl"],
+                    "start_time": "2026-08-18T09:00:00+02:00",
+                    "end_time": "2026-08-18T10:00:00+02:00"
+                }
+            ],
+            "next_id": 2,
+            "schema_version": 1
+        }"#;
+
+        let mut data: TimeData = serde_json::from_str(json).unwrap();
+
+        assert!(data.entries[0].idle.is_empty(), "absent means empty");
+        assert_eq!(data.entries[0].duration(), Duration::hours(1));
+        migrate(&mut data);
+        assert_eq!(data.schema_version, 1, "no version bump, no migration");
+
+        // …and round-trips unchanged.
+        let round_tripped: TimeData =
+            serde_json::from_str(&serde_json::to_string(&data).unwrap()).unwrap();
+        assert!(round_tripped.entries[0].idle.is_empty());
+        assert_eq!(round_tripped.schema_version, 1);
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let mut data = TimeData {
+            entries: vec![entry(1, None, &["tt", "impl"])],
+            next_id: 2,
+            schema_version: 0,
+        };
+
+        migrate(&mut data);
+        let after_first = serde_json::to_string(&data).unwrap();
+
+        // A tag vector that would now infer differently must not be re-applied
+        data.entries[0].tags = tags(&["other", "other/1"]);
+        migrate(&mut data);
+
+        data.entries[0].tags = tags(&["tt", "impl"]);
+        assert_eq!(serde_json::to_string(&data).unwrap(), after_first);
+        assert_eq!(data.entries[0].project.as_deref(), Some("tt"));
+        assert_eq!(data.schema_version, 1);
     }
 }

--- a/src/tui/entry_form.rs
+++ b/src/tui/entry_form.rs
@@ -80,7 +80,7 @@ impl App {
         let Some((description, tags, start_time, end_time)) = self.build_entry_fields() else {
             return Ok(());
         };
-        self.data.add_entry(description, tags, start_time, end_time);
+        self.data.add_entry(description, None, tags, start_time, end_time);
         save_data(&self.data)?;
         self.cancel_adding();
         Ok(())
@@ -93,7 +93,9 @@ impl App {
         let Some((description, tags, start_time, end_time)) = self.build_entry_fields() else {
             return Ok(());
         };
-        self.data.update_entry(entry_id, description, tags, start_time, end_time);
+        // The form has no project field yet, so an edit keeps whatever the entry has.
+        let project = self.data.get_entry(entry_id).and_then(|e| e.project.clone());
+        self.data.update_entry(entry_id, description, project, tags, start_time, end_time);
         save_data(&self.data)?;
         self.cancel_adding();
         Ok(())

--- a/src/tui/entry_form.rs
+++ b/src/tui/entry_form.rs
@@ -1,14 +1,11 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate};
-use crate::storage::save_data;
 use super::App;
 use super::types::{InputField, InputMode, ViewMode};
 
 impl App {
     pub(crate) fn start_adding(&mut self) {
-        // In week view, snap selected_date to the day the cursor is under so
-        // that new entries land on the right day without the user having to
-        // type a date explicitly.
+        // In week view, snap selected_date to the day under the cursor.
         if self.view_mode == ViewMode::Week {
             if let Some(date) = self.date_under_cursor() {
                 self.selected_date = date;
@@ -17,6 +14,7 @@ impl App {
         self.input_mode = InputMode::AddingEntry;
         self.input_field = InputField::Description;
         self.input_description.clear();
+        self.input_project.clear();
         self.input_tags.clear();
         self.input_start_time.clear();
         self.input_end_time.clear();
@@ -27,6 +25,7 @@ impl App {
     pub(crate) fn cancel_adding(&mut self) {
         self.input_mode = InputMode::Normal;
         self.input_description.clear();
+        self.input_project.clear();
         self.input_tags.clear();
         self.input_start_time.clear();
         self.input_end_time.clear();
@@ -43,6 +42,7 @@ impl App {
                     (
                         entry.id,
                         entry.description.clone(),
+                        entry.project.clone().unwrap_or_default(),
                         entry.tags.join(" "),
                         entry.start_time.format("%Y-%m-%d %H:%M").to_string(),
                         entry.end_time.map(|t| t.format("%Y-%m-%d %H:%M").to_string()),
@@ -52,9 +52,10 @@ impl App {
             })
         };
 
-        if let Some((id, description, tags, start_time, end_time, duration)) = entry_data {
+        if let Some((id, description, project, tags, start_time, end_time, duration)) = entry_data {
             self.editing_entry_id = Some(id);
             self.input_description = description;
+            self.input_project = project;
             self.input_tags = tags;
             self.input_start_time = start_time;
             self.input_end_time = end_time.unwrap_or_default();
@@ -80,8 +81,11 @@ impl App {
         let Some((description, tags, start_time, end_time)) = self.build_entry_fields() else {
             return Ok(());
         };
-        self.data.add_entry(description, None, tags, start_time, end_time);
-        save_data(&self.data)?;
+        let project = self.parse_project();
+        // Added against the freshly loaded store, so the id is the current `next_id`.
+        self.mutate_store(|data| {
+            data.add_entry(description, project, tags, start_time, end_time);
+        })?;
         self.cancel_adding();
         Ok(())
     }
@@ -93,10 +97,11 @@ impl App {
         let Some((description, tags, start_time, end_time)) = self.build_entry_fields() else {
             return Ok(());
         };
-        // The form has no project field yet, so an edit keeps whatever the entry has.
-        let project = self.data.get_entry(entry_id).and_then(|e| e.project.clone());
-        self.data.update_entry(entry_id, description, project, tags, start_time, end_time);
-        save_data(&self.data)?;
+        let project = self.parse_project();
+        // Updating an id that is no longer in the store returns false, not an error.
+        self.mutate_store(|data| {
+            data.update_entry(entry_id, description, project, tags, start_time, end_time)
+        })?;
         self.cancel_adding();
         Ok(())
     }
@@ -105,7 +110,8 @@ impl App {
         let leaving = self.input_field;
         self.apply_time_calculations(leaving);
         self.input_field = match self.input_field {
-            InputField::Description => InputField::Tags,
+            InputField::Description => InputField::Project,
+            InputField::Project => InputField::Tags,
             InputField::Tags => InputField::Duration,
             InputField::Duration => InputField::StartTime,
             InputField::StartTime => InputField::EndTime,
@@ -119,7 +125,8 @@ impl App {
         self.apply_time_calculations(leaving);
         self.input_field = match self.input_field {
             InputField::Description => InputField::EndTime,
-            InputField::Tags => InputField::Description,
+            InputField::Project => InputField::Description,
+            InputField::Tags => InputField::Project,
             InputField::Duration => InputField::Tags,
             InputField::StartTime => InputField::Duration,
             InputField::EndTime => InputField::StartTime,
@@ -131,6 +138,7 @@ impl App {
         let pos = self.cursor_pos;
         let s = match self.input_field {
             InputField::Description => &mut self.input_description,
+            InputField::Project => &mut self.input_project,
             InputField::Tags => &mut self.input_tags,
             InputField::StartTime => &mut self.input_start_time,
             InputField::EndTime => &mut self.input_end_time,
@@ -145,6 +153,7 @@ impl App {
         let pos = self.cursor_pos;
         let s = match self.input_field {
             InputField::Description => &mut self.input_description,
+            InputField::Project => &mut self.input_project,
             InputField::Tags => &mut self.input_tags,
             InputField::StartTime => &mut self.input_start_time,
             InputField::EndTime => &mut self.input_end_time,
@@ -164,6 +173,7 @@ impl App {
     pub(crate) fn active_field_input(&self) -> &str {
         match self.input_field {
             InputField::Description => &self.input_description,
+            InputField::Project => &self.input_project,
             InputField::Tags => &self.input_tags,
             InputField::StartTime => &self.input_start_time,
             InputField::EndTime => &self.input_end_time,
@@ -171,7 +181,7 @@ impl App {
         }
     }
 
-    /// Returns the text of the active input regardless of mode (form field or search bar).
+    /// The active input's text in any mode — form field or search bar.
     fn active_input(&self) -> &str {
         match self.input_mode {
             super::types::InputMode::Searching => &self.search_term,
@@ -195,11 +205,9 @@ impl App {
         let input = self.active_input().to_string();
         let chars: Vec<char> = input.chars().collect();
         let mut pos = self.cursor_pos.min(chars.len());
-        // Step back past non-alphanumeric chars
         while pos > 0 && !chars[pos - 1].is_alphanumeric() {
             pos -= 1;
         }
-        // Step back past the word
         while pos > 0 && chars[pos - 1].is_alphanumeric() {
             pos -= 1;
         }
@@ -212,11 +220,9 @@ impl App {
         let chars: Vec<char> = input.chars().collect();
         let len = chars.len();
         let mut pos = self.cursor_pos.min(len);
-        // Step forward past the word
         while pos < len && chars[pos].is_alphanumeric() {
             pos += 1;
         }
-        // Step forward past non-alphanumeric chars
         while pos < len && !chars[pos].is_alphanumeric() {
             pos += 1;
         }
@@ -225,12 +231,8 @@ impl App {
 
     // ── Time resolution ──────────────────────────────────────────────────────
 
-    /// Resolve start/end times from the three input fields. Priority:
-    /// - Start + Duration → end = start + duration
-    /// - Start + End      → save both as-is
-    /// - End + Duration   → start = end - duration
-    /// - Duration only    → end = selected_date@now, start = end - duration
-    /// - Start only       → active entry (no end time)
+    /// Resolve start/end from the three fields, in priority order: Start+Duration,
+    /// Start+End, End+Duration, Duration only (ends now), Start only (still active).
     pub(crate) fn resolve_times(&self) -> Option<(DateTime<Local>, Option<DateTime<Local>>)> {
         let start = if !self.input_start_time.is_empty() {
             self.parse_time_str(&self.input_start_time)
@@ -254,9 +256,7 @@ impl App {
             (Some(s), Some(e), None) => Some((s, Some(e))),
             (None, Some(e), Some(d)) => Some((e - d, Some(e))),
             (None, None, Some(d)) => {
-                // Anchor to selected_date at current wall-clock time so that
-                // duration-only entries added while browsing a past day land
-                // on that day rather than today.
+                // Anchored to selected_date, so a past day's entry lands on that day.
                 let now_time = Local::now().time();
                 let end = self.selected_date
                     .and_time(now_time)
@@ -270,12 +270,8 @@ impl App {
         }
     }
 
-    /// Auto-fill missing time fields when the user tabs away from a field.
-    ///
-    /// - Leave StartTime:  if Dur set → End = Start + Dur; else if End set → Dur = End − Start
-    /// - Leave EndTime:    if Start + Dur → adjust Start; else if Start → Dur = End − Start;
-    ///                     else if Dur only → Start = End − Dur
-    /// - Leave Duration:   if Start → End = Start + Dur; else if End → Start = End − Dur
+    /// Tabbing off Start / End / Duration derives whichever of the other two is still
+    /// blank, preferring to adjust the field the user did not just leave.
     pub(crate) fn apply_time_calculations(&mut self, leaving_field: InputField) {
         let start_str = self.input_start_time.clone();
         let end_str = self.input_end_time.clone();
@@ -370,8 +366,7 @@ impl App {
         None
     }
 
-    /// Parse a time string. Supports 24-hour and 12-hour (am/pm) formats with
-    /// `:` or `.` as separator; minutes default to `00` when omitted.
+    /// Parse a time: 24- or 12-hour, `:` or `.` separated, minutes default to `00`.
     fn parse_time_part(s: &str) -> Option<chrono::NaiveTime> {
         use chrono::NaiveTime;
 
@@ -412,13 +407,22 @@ impl App {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    /// Returns the date of the entry currently under the cursor, if any.
     fn date_under_cursor(&self) -> Option<chrono::NaiveDate> {
         let filtered = self.filtered_entries();
         self.table_state
             .selected()
             .and_then(|idx| filtered.get(idx))
             .map(|entry| entry.start_time.date_naive())
+    }
+
+    /// The project as typed, trimmed; an empty field means "no project".
+    fn parse_project(&self) -> Option<String> {
+        let project = self.input_project.trim();
+        if project.is_empty() {
+            None
+        } else {
+            Some(project.to_string())
+        }
     }
 
     fn parse_tags(&self) -> Vec<String> {

--- a/src/tui/marks_surface.rs
+++ b/src/tui/marks_surface.rs
@@ -1,0 +1,36 @@
+//! The collapsible `Marks` surface: the phase marks left open by `tt agent
+//! begin`, read from `App.marks` on the event loop's tick — a frame never reads
+//! the directory. Display-only: no focus ring, no cursor, no `Enter`, no scroll.
+
+use super::App;
+use super::panes::surface_count;
+use crate::marks::Mark;
+
+/// Most marks the surface lists; the border count reports the rest.
+const MAX_VISIBLE_MARKS: usize = 3;
+
+impl App {
+    /// The newest [`MAX_VISIBLE_MARKS`], in `App.marks`' own newest-first order.
+    pub(crate) fn visible_marks(&self) -> &[Mark] {
+        let shown = self.marks.len().min(MAX_VISIBLE_MARKS);
+        &self.marks[..shown]
+    }
+
+    /// Height including borders, or 0 while hidden so the layout drops the row.
+    pub(crate) fn marks_surface_height(&self) -> u16 {
+        if !self.show_marks {
+            return 0;
+        }
+        2 + self.marks.len().clamp(1, MAX_VISIBLE_MARKS) as u16
+    }
+
+    /// The top border's count: `N` while all fit, `3/N` once more are open.
+    pub(crate) fn marks_count(&self, visible_rows: usize) -> Option<String> {
+        surface_count(None, self.marks.len(), visible_rows)
+    }
+
+    /// `Shift-A`: show or hide the surface.
+    pub(crate) fn toggle_marks(&mut self) {
+        self.show_marks = !self.show_marks;
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -325,29 +325,9 @@ mod tests {
     /// Serialises the tests that repoint `HOME` and `TT_MARK_DIR`; env is
     /// process-wide, and `marks`' own env test shares this lock.
     use crate::storage::env_guard;
+    use crate::storage::env_sandbox as sandbox;
     use crate::tracker::TimeEntry;
     use std::path::PathBuf;
-
-    /// Point `HOME` and `TT_MARK_DIR` at a fresh scratch dir. **Tests must never
-    /// touch the real store or marks** — live agent sessions write both.
-    fn sandbox(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("tt-store-test-{name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        unsafe { std::env::set_var("HOME", &dir) };
-        unsafe { std::env::set_var("TT_MARK_DIR", dir.join("marks")) };
-        let path = storage::get_data_path().unwrap();
-        assert!(
-            path.starts_with(&dir),
-            "sandbox HOME not in effect: {path:?}"
-        );
-        let marks = crate::marks::mark_dir().expect("a mark dir");
-        assert!(
-            marks.starts_with(&dir),
-            "sandbox TT_MARK_DIR not in effect: {marks:?}"
-        );
-        dir
-    }
 
     /// The sandbox's mark directory, created on demand.
     fn mark_sandbox() -> PathBuf {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,7 +7,8 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend, widgets::TableState};
-use crate::storage::load_data;
+use crate::marks::Mark;
+use crate::storage::{PathStamp, load_data};
 use crate::tracker::TimeData;
 
 pub mod theme;
@@ -15,9 +16,14 @@ pub mod types;
 mod search;
 mod navigation;
 mod entry_form;
+mod marks_surface;
+mod panes;
+mod summary;
 mod render;
 
-pub use types::{InputField, InputMode, SortOrder, ViewMode};
+pub use types::{
+    ConfirmAction, Focus, InputField, InputMode, Pane, PendingConfirm, SortOrder, ViewMode,
+};
 
 pub(crate) struct App {
     pub(crate) data: TimeData,
@@ -28,22 +34,48 @@ pub(crate) struct App {
     pub(crate) input_mode: InputMode,
     pub(crate) input_field: InputField,
     pub(crate) input_description: String,
+    pub(crate) input_project: String,
     pub(crate) input_tags: String,
     pub(crate) input_start_time: String,
     pub(crate) input_end_time: String,
     pub(crate) input_duration: String,
     pub(crate) search_term: String,
-    pub(crate) tag_filter: Vec<String>,
+    /// The values picked in each pane. OR within a set, AND across the two.
+    pub(crate) selected_projects: Vec<String>,
+    pub(crate) selected_tags: Vec<String>,
     pub(crate) editing_entry_id: Option<u64>,
+    /// What `InputMode::Confirm` is asking about: the action, entry and origin mode.
+    pub(crate) pending_confirm: Option<PendingConfirm>,
     pub(crate) sort_order: SortOrder,
-    /// Cursor position within the currently active input field (char index, not byte index).
+    /// Cursor position in the active input field — a char index, not a byte index.
     pub(crate) cursor_pos: usize,
+    /// Fingerprint of the store as of the last load, so a tick can skip the read.
+    pub(crate) store_stamp: Option<PathStamp>,
+    /// The open agent phase marks, newest first, so a frame never reads the directory.
+    pub(crate) marks: Vec<Mark>,
+    /// Fingerprint of the *mark directory*, so a tick need not list it.
+    pub(crate) marks_stamp: Option<PathStamp>,
+    /// Whether each collapsible surface is open. All default to off, so their rows
+    /// are absent from the layout plan.
+    pub(crate) show_projects: bool,
+    pub(crate) show_tags: bool,
+    pub(crate) show_marks: bool,
+    pub(crate) show_summary: bool,
+    /// What `Tab` has given focus to, and where each pane's cursor rests.
+    pub(crate) focus: Focus,
+    pub(crate) project_cursor: usize,
+    pub(crate) tag_cursor: usize,
 }
 
 impl App {
     fn new() -> Result<Self> {
-        Ok(Self {
+        // Stamp before loading — see `App::reload`.
+        let store_stamp = crate::storage::store_stamp();
+        let mut app = Self {
             data: load_data()?,
+            store_stamp,
+            marks: Vec::new(),
+            marks_stamp: None,
             table_state: TableState::default().with_selected(Some(0)),
             should_quit: false,
             view_mode: ViewMode::Day,
@@ -51,16 +83,43 @@ impl App {
             input_mode: InputMode::Normal,
             input_field: InputField::Description,
             input_description: String::new(),
+            input_project: String::new(),
             input_tags: String::new(),
             input_start_time: String::new(),
             input_end_time: String::new(),
             input_duration: String::new(),
             search_term: String::new(),
-            tag_filter: Vec::new(),
+            selected_projects: Vec::new(),
+            selected_tags: Vec::new(),
             editing_entry_id: None,
+            pending_confirm: None,
             sort_order: SortOrder::NewestFirst,
             cursor_pos: 0,
-        })
+            show_projects: false,
+            show_tags: false,
+            show_marks: false,
+            show_summary: false,
+            focus: Focus::Table,
+            project_cursor: 0,
+            tag_cursor: 0,
+        };
+        // The first tick is 250 ms away, so read now for a current first frame.
+        app.sync_from_marks();
+        Ok(app)
+    }
+
+    /// Apply `edit` under the store's exclusive lock, then refresh from what landed.
+    /// **Every** TUI mutation goes through here: `App.data` is a startup snapshot, so
+    /// saving it back would drop outside writes and reuse a stale `next_id`.
+    pub(crate) fn mutate_store<T>(&mut self, edit: impl FnOnce(&mut TimeData) -> T) -> Result<T> {
+        let (result, fresh) = crate::storage::with_data(|data| {
+            let result = edit(data);
+            Ok((result, data.clone()))
+        })?;
+        self.data = fresh;
+        // Our own write moved the file on; stamp it so the next tick skips it.
+        self.store_stamp = crate::storage::store_stamp();
+        Ok(result)
     }
 }
 
@@ -99,20 +158,43 @@ pub fn run_tui() -> Result<()> {
                             KeyCode::Char('q') | KeyCode::Esc => {
                                 if app.is_searching() {
                                     app.clear_search();
-                                } else if app.is_tag_filtering() {
-                                    app.clear_tag_filter();
+                                } else if app.is_filtering() {
+                                    app.clear_filters();
                                 } else {
                                     app.should_quit = true;
                                 }
                             }
-                            KeyCode::Char('j') | KeyCode::Down => app.next(),
-                            KeyCode::Char('k') | KeyCode::Up => app.previous(),
-                            KeyCode::Char('d') => app.delete_selected()?,
+                            // j/k move in the focused pane, else the table.
+                            KeyCode::Char('j') | KeyCode::Down => {
+                                if !app.pane_next() {
+                                    app.next();
+                                }
+                            }
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                if !app.pane_previous() {
+                                    app.previous();
+                                }
+                            }
+                            // One key, disambiguated by focus: `toggle_pane_value`
+                            // reporting false *is* the focus check.
+                            KeyCode::Enter => {
+                                if !app.toggle_pane_value() {
+                                    app.open_detail();
+                                }
+                            }
+                            KeyCode::Char('P') => app.toggle_pane(Pane::Projects),
+                            KeyCode::Char('T') => app.toggle_pane(Pane::Tags),
+                            KeyCode::Char('A') => app.toggle_marks(),
+                            // Capital `S` only; lowercase `s` stops the entry.
+                            KeyCode::Char('S') => app.toggle_summary(),
+                            KeyCode::Tab => app.cycle_focus(),
+                            // crossterm reports Shift-Tab as its own code.
+                            KeyCode::BackTab => app.cycle_focus_back(),
+                            KeyCode::Char('d') => app.request_confirm(ConfirmAction::Delete),
                             KeyCode::Char('s') => app.stop_active()?,
                             KeyCode::Char('r') => app.reload()?,
                             KeyCode::Char('a') => app.start_adding(),
                             KeyCode::Char('e') => app.start_editing(),
-                            KeyCode::Char('f') => app.filter_by_selected_tags(),
                             KeyCode::Char('/') => app.start_search(),
                             KeyCode::Char('1') => app.set_view_mode(ViewMode::Day),
                             KeyCode::Char('2') => app.set_view_mode(ViewMode::Week),
@@ -197,10 +279,35 @@ pub fn run_tui() -> Result<()> {
                             }
                             _ => {}
                         },
+                        // Modal, but not inert: the popover renders whatever
+                        // `selected_entry()` returns, so j/k alone make it follow.
+                        InputMode::Detail => match key.code {
+                            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => {
+                                app.input_mode = InputMode::Normal;
+                            }
+                            // The table's own, so a focused pane cannot capture j/k.
+                            KeyCode::Char('j') | KeyCode::Down => app.next(),
+                            KeyCode::Char('k') | KeyCode::Up => app.previous(),
+                            // The form is modal too, so it replaces the popover.
+                            KeyCode::Char('e') => app.start_editing(),
+                            // Confirmed here as on the table: one key, one meaning.
+                            KeyCode::Char('d') => app.request_confirm(ConfirmAction::Delete),
+                            // `t` rather than `s`, so a slip outside this modal hits
+                            // `go_to_today()`. Bound here only.
+                            KeyCode::Char('t') => app.request_confirm(ConfirmAction::Trim),
+                            _ => {}
+                        },
+                        // Which key is a yes depends on the pending action, so the
+                        // whole answer lives in `answer_confirm`.
+                        InputMode::Confirm => app.answer_confirm(key.code)?,
                     }
                 }
             }
         }
+
+        // The poll above is the loop's clock, key or timeout alike.
+        app.sync_from_store()?;
+        app.sync_from_marks();
 
         if app.should_quit {
             break;
@@ -209,4 +316,2063 @@ pub fn run_tui() -> Result<()> {
 
     restore_terminal(&mut terminal)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage;
+    /// Serialises the tests that repoint `HOME` and `TT_MARK_DIR`; env is
+    /// process-wide, and `marks`' own env test shares this lock.
+    use crate::storage::env_guard;
+    use crate::tracker::TimeEntry;
+    use std::path::PathBuf;
+
+    /// Point `HOME` and `TT_MARK_DIR` at a fresh scratch dir. **Tests must never
+    /// touch the real store or marks** — live agent sessions write both.
+    fn sandbox(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-store-test-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        unsafe { std::env::set_var("HOME", &dir) };
+        unsafe { std::env::set_var("TT_MARK_DIR", dir.join("marks")) };
+        let path = storage::get_data_path().unwrap();
+        assert!(
+            path.starts_with(&dir),
+            "sandbox HOME not in effect: {path:?}"
+        );
+        let marks = crate::marks::mark_dir().expect("a mark dir");
+        assert!(
+            marks.starts_with(&dir),
+            "sandbox TT_MARK_DIR not in effect: {marks:?}"
+        );
+        dir
+    }
+
+    /// The sandbox's mark directory, created on demand.
+    fn mark_sandbox() -> PathBuf {
+        let dir = crate::marks::mark_dir().expect("a mark dir");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Write a mark file the way `tt agent begin` does: name is the phase key,
+    /// content a unix-seconds start. Never shells out.
+    fn begin_mark(dir: &std::path::Path, key: &str, minutes_ago: i64) {
+        let start = Local::now() - chrono::Duration::minutes(minutes_ago);
+        std::fs::write(dir.join(key), format!("{}\n", start.timestamp())).unwrap();
+    }
+
+    fn entry(id: u64, description: &str) -> TimeEntry {
+        TimeEntry {
+            id,
+            description: description.to_string(),
+            project: None,
+            tags: Vec::new(),
+            start_time: Local::now(),
+            end_time: None,
+            idle: Vec::new(),
+        }
+    }
+
+    fn seed(entries: Vec<TimeEntry>, next_id: u64) {
+        storage::save_data(&TimeData {
+            entries,
+            next_id,
+            schema_version: 1,
+        })
+        .unwrap();
+    }
+
+    /// A write from outside the TUI, through the same `with_data` path `tt log` uses.
+    fn agent_write(description: &str) -> u64 {
+        storage::with_data(|data| {
+            Ok(data
+                .add_entry(
+                    description.to_string(),
+                    Some("probe".to_string()),
+                    vec!["probe".to_string()],
+                    Local::now(),
+                    Some(Local::now()),
+                )
+                .id)
+        })
+        .unwrap()
+    }
+
+    fn on_disk() -> TimeData {
+        storage::load_data().unwrap()
+    }
+
+    fn descriptions(data: &TimeData) -> Vec<&str> {
+        data.entries
+            .iter()
+            .map(|e| e.description.as_str())
+            .collect()
+    }
+
+    /// `d` pressed and answered, via the two real calls the event loop makes. The
+    /// current mode is the mode the prompt is raised from.
+    fn press_d_then(app: &mut App, answer: KeyCode) {
+        app.request_confirm(ConfirmAction::Delete);
+        app.answer_confirm(answer).unwrap();
+    }
+
+    /// `t` pressed and answered, the same way.
+    fn press_t_then(app: &mut App, answer: KeyCode) {
+        app.request_confirm(ConfirmAction::Trim);
+        app.answer_confirm(answer).unwrap();
+    }
+
+    fn select(app: &mut App, description: &str) {
+        let idx = app
+            .filtered_entries()
+            .iter()
+            .position(|e| e.description == description)
+            .expect("entry not in view");
+        app.table_state.select(Some(idx));
+    }
+
+    #[test]
+    fn delete_keeps_a_concurrent_agent_write() {
+        let _guard = env_guard();
+        sandbox("delete");
+        seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+
+        let mut app = App::new().unwrap();
+        agent_write("probe");
+        select(&mut app, "doomed");
+        press_d_then(&mut app, KeyCode::Char('d'));
+
+        let data = on_disk();
+        assert_eq!(descriptions(&data), vec!["keep", "probe"]);
+        assert_eq!(descriptions(&app.data), vec!["keep", "probe"]);
+    }
+
+    #[test]
+    fn deleting_an_already_removed_id_is_a_no_op() {
+        let _guard = env_guard();
+        sandbox("delete-gone");
+        seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "doomed");
+        // Someone else removed it first, then wrote an entry of their own
+        storage::with_data(|data| {
+            data.entries.retain(|e| e.id != 1);
+            Ok(())
+        })
+        .unwrap();
+        agent_write("probe");
+
+        press_d_then(&mut app, KeyCode::Char('d'));
+
+        let data = on_disk();
+        assert_eq!(descriptions(&data), vec!["keep", "probe"]);
+    }
+
+    #[test]
+    fn stop_active_keeps_a_concurrent_agent_write() {
+        let _guard = env_guard();
+        sandbox("stop");
+        seed(vec![entry(0, "running")], 1);
+
+        let mut app = App::new().unwrap();
+        agent_write("probe");
+        app.stop_active().unwrap();
+
+        let data = on_disk();
+        assert_eq!(descriptions(&data), vec!["running", "probe"]);
+        assert!(
+            data.entries[0].end_time.is_some(),
+            "the active entry should have been stopped"
+        );
+    }
+
+    #[test]
+    fn add_keeps_a_concurrent_agent_write_and_takes_a_fresh_id() {
+        let _guard = env_guard();
+        sandbox("add");
+        seed(vec![entry(0, "existing")], 1);
+
+        let mut app = App::new().unwrap();
+        // The agent claims id 1, which the TUI's snapshot still thinks is free
+        let agent_id = agent_write("probe");
+        assert_eq!(agent_id, 1);
+
+        app.start_adding();
+        app.input_description = "from the tui".to_string();
+        app.input_duration = "15m".to_string();
+        app.submit_entry().unwrap();
+
+        let data = on_disk();
+        assert_eq!(
+            descriptions(&data),
+            vec!["existing", "probe", "from the tui"]
+        );
+        let tui_id = data
+            .entries
+            .iter()
+            .find(|e| e.description == "from the tui")
+            .unwrap()
+            .id;
+        assert_ne!(tui_id, agent_id, "the TUI entry reused the agent's id");
+        assert_eq!(tui_id, 2);
+        let mut ids: Vec<u64> = data.entries.iter().map(|e| e.id).collect();
+        let count = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "duplicate ids in the store");
+    }
+
+    fn selected_description(app: &App) -> String {
+        let idx = app.table_state.selected().expect("nothing selected");
+        app.filtered_entries()[idx].description.clone()
+    }
+
+    #[test]
+    fn sync_picks_up_an_outside_write_and_keeps_the_selection() {
+        let _guard = env_guard();
+        sandbox("sync");
+        seed(vec![entry(0, "first"), entry(1, "second")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "second");
+        agent_write("probe");
+
+        app.sync_from_store().unwrap();
+
+        assert!(descriptions(&app.data).contains(&"probe"));
+        assert_eq!(selected_description(&app), "second");
+    }
+
+    #[test]
+    fn sync_is_skipped_while_a_form_is_open() {
+        let _guard = env_guard();
+        sandbox("sync-form");
+        seed(vec![entry(0, "first")], 1);
+
+        let mut app = App::new().unwrap();
+        agent_write("probe");
+        for mode in [
+            InputMode::AddingEntry,
+            InputMode::EditingEntry,
+            InputMode::Searching,
+        ] {
+            app.input_mode = mode;
+            app.input_description = "half typed".to_string();
+            app.sync_from_store().unwrap();
+            assert_eq!(descriptions(&app.data), vec!["first"]);
+            assert_eq!(app.input_description, "half typed");
+        }
+
+        // …and the change is picked up once the mode is Normal again.
+        app.input_mode = InputMode::Normal;
+        app.sync_from_store().unwrap();
+        assert!(descriptions(&app.data).contains(&"probe"));
+    }
+
+    /// The phase keys of the marks the app currently holds, newest first.
+    fn mark_keys(app: &App) -> Vec<String> {
+        app.marks
+            .iter()
+            .map(|m| match &m.issue {
+                Some(issue) => format!("{}.{}.{}", m.project, issue, m.phase),
+                None => format!("{}.-.{}", m.project, m.phase),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_mark_begun_outside_the_tui_appears_on_the_next_tick_and_cancelling_removes_it() {
+        let _guard = env_guard();
+        sandbox("marks-tick");
+        seed(vec![entry(0, "first")], 1);
+        let marks = mark_sandbox();
+
+        // Nothing open: an empty mark directory is an empty list, not an error.
+        let mut app = App::new().unwrap();
+        assert!(app.marks.is_empty());
+
+        begin_mark(&marks, "tt.14.impl", 2);
+        app.sync_from_marks();
+        assert_eq!(mark_keys(&app), vec!["tt.14.impl"]);
+
+        begin_mark(&marks, "vinge.-.plan", 126);
+        app.sync_from_marks();
+        assert_eq!(mark_keys(&app), vec!["tt.14.impl", "vinge.-.plan"]);
+
+        // `tt agent cancel` / `tt agent end` both remove the file.
+        std::fs::remove_file(marks.join("tt.14.impl")).unwrap();
+        app.sync_from_marks();
+        assert_eq!(mark_keys(&app), vec!["vinge.-.plan"]);
+    }
+
+    /// An in-place rewrite inside the mark directory leaves its mtime alone, so a
+    /// settled stamp means no re-read.
+    #[test]
+    fn an_unchanged_mark_directory_is_not_read_again() {
+        let _guard = env_guard();
+        sandbox("marks-noread");
+        seed(vec![entry(0, "first")], 1);
+        let marks = mark_sandbox();
+        begin_mark(&marks, "tt.14.impl", 2);
+
+        let mut app = App::new().unwrap();
+        let first = app.marks.clone();
+        assert_eq!(mark_keys(&app), vec!["tt.14.impl"]);
+
+        // Let the mtime settle out of the current second, so the stamp is trusted.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        // Same length, no file added or removed: only a re-read could show this.
+        begin_mark(&marks, "tt.14.impl", 999);
+        app.sync_from_marks();
+        assert_eq!(app.marks, first, "the directory did not change: no re-read");
+
+        // Creating a file *does* move the directory on, so the whole list re-reads.
+        begin_mark(&marks, "loremind.64.plan", 38);
+        app.sync_from_marks();
+        assert_eq!(mark_keys(&app), vec!["loremind.64.plan", "tt.14.impl"]);
+    }
+
+    #[test]
+    fn sync_falls_back_to_a_nearby_row_when_the_selection_is_gone() {
+        let _guard = env_guard();
+        sandbox("sync-gone");
+        seed(vec![entry(0, "a"), entry(1, "b"), entry(2, "c")], 3);
+
+        let mut app = App::new().unwrap();
+        let last = app.filtered_entries().len() - 1;
+        app.table_state.select(Some(last));
+        let doomed = app.filtered_entries()[last].id;
+        storage::with_data(|data| {
+            data.entries.retain(|e| e.id != doomed);
+            Ok(())
+        })
+        .unwrap();
+
+        app.sync_from_store().unwrap();
+
+        let len = app.filtered_entries().len();
+        assert_eq!(len, 2);
+        assert_eq!(app.table_state.selected(), Some(len - 1));
+    }
+
+    #[test]
+    fn an_untouched_store_reports_no_change_but_an_unsettled_mtime_does() {
+        let _guard = env_guard();
+        sandbox("sync-quiet");
+        seed(vec![entry(0, "first")], 1);
+
+        let mut app = App::new().unwrap();
+        // Let the mtime fall out of the current second, past the granularity guard.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        assert!(
+            app.store_is_unchanged(),
+            "a quiet store should not trigger a reload"
+        );
+
+        agent_write("probe");
+        assert!(!app.store_is_unchanged(), "an outside write was missed");
+
+        // Inside the current second even an identical stamp counts as changed.
+        app.store_stamp = storage::store_stamp();
+        assert!(
+            !app.store_is_unchanged(),
+            "an unsettled stamp should not be trusted"
+        );
+    }
+
+    #[test]
+    fn edit_keeps_a_concurrent_agent_write() {
+        let _guard = env_guard();
+        sandbox("edit");
+        seed(vec![entry(0, "before")], 1);
+
+        let mut app = App::new().unwrap();
+        agent_write("probe");
+        select(&mut app, "before");
+        app.start_editing();
+        app.input_description = "after".to_string();
+        app.submit_edit().unwrap();
+
+        let data = on_disk();
+        assert_eq!(descriptions(&data), vec!["after", "probe"]);
+        assert_eq!(descriptions(&app.data), vec!["after", "probe"]);
+    }
+
+    /// A whitespace-only Project means "no project", and must land as JSON `null`.
+    #[test]
+    fn the_form_writes_the_project_and_leaves_a_blank_one_null() {
+        let _guard = env_guard();
+        sandbox("project-form");
+        seed(Vec::new(), 0);
+
+        let mut app = App::new().unwrap();
+        app.start_adding();
+        app.input_description = "with a project".to_string();
+        app.input_project = "  acme  ".to_string();
+        app.input_duration = "15m".to_string();
+        app.submit_entry().unwrap();
+
+        app.start_adding();
+        app.input_description = "without one".to_string();
+        app.input_project = "   ".to_string();
+        app.input_duration = "15m".to_string();
+        app.submit_entry().unwrap();
+
+        let data = on_disk();
+        let project = |desc: &str| {
+            data.entries
+                .iter()
+                .find(|e| e.description == desc)
+                .unwrap()
+                .project
+                .clone()
+        };
+        assert_eq!(project("with a project"), Some("acme".to_string()));
+        assert_eq!(project("without one"), None);
+
+        let raw = std::fs::read_to_string(storage::get_data_path().unwrap()).unwrap();
+        assert!(
+            raw.contains("\"project\": null"),
+            "blank project not null: {raw}"
+        );
+        assert!(
+            !raw.contains("\"project\": \"\""),
+            "blank project stored as \"\": {raw}"
+        );
+    }
+
+    fn dated(
+        id: u64,
+        description: &str,
+        project: &str,
+        tags: &[&str],
+        date: NaiveDate,
+    ) -> TimeEntry {
+        logged(id, description, project, tags, date, 60)
+    }
+
+    /// [`dated`] with a duration, for the summary's per-project totals.
+    fn logged(
+        id: u64,
+        description: &str,
+        project: &str,
+        tags: &[&str],
+        date: NaiveDate,
+        minutes: i64,
+    ) -> TimeEntry {
+        let start = date
+            .and_hms_opt(9, 0, 0)
+            .unwrap()
+            .and_local_timezone(Local)
+            .unwrap();
+        TimeEntry {
+            id,
+            description: description.to_string(),
+            project: (!project.is_empty()).then(|| project.to_string()),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            start_time: start,
+            end_time: Some(start + chrono::Duration::minutes(minutes)),
+            idle: Vec::new(),
+        }
+    }
+
+    /// A logged entry with idle stretches, as minute offsets from its own start.
+    fn with_idle(id: u64, minutes: i64, gaps: &[(i64, i64)]) -> TimeEntry {
+        let mut entry = logged(
+            id,
+            "long session",
+            "tt",
+            &["tt"],
+            Local::now().date_naive(),
+            minutes,
+        );
+        let start = entry.start_time;
+        entry.idle = gaps
+            .iter()
+            .map(|(from, to)| {
+                crate::tracker::IdleInterval::new(
+                    start + chrono::Duration::minutes(*from),
+                    start + chrono::Duration::minutes(*to),
+                )
+            })
+            .collect();
+        entry
+    }
+
+    /// Two days in the current week plus one a week back, so each scope differs.
+    fn seed_panes() -> App {
+        let today = Local::now().date_naive();
+        let week_start = TimeData::week_start(today);
+        let day_one = week_start;
+        let day_two = week_start + chrono::Duration::days(1);
+        let last_week = week_start - chrono::Duration::days(7);
+        seed(
+            vec![
+                dated(0, "a", "tt", &["impl", "tt/8"], day_one),
+                dated(1, "b", "tt", &["plan"], day_one),
+                dated(2, "c", "loremind", &["impl", "ops"], day_one),
+                dated(3, "d", "vinge", &["ops"], day_two),
+                dated(4, "e", "vinge", &["impl"], last_week),
+                dated(5, "f", "", &[], day_one),
+            ],
+            6,
+        );
+        let mut app = App::new().unwrap();
+        app.selected_date = day_one;
+        app
+    }
+
+    /// A pane's rows as `value=count`, in the order they are listed.
+    fn values(app: &App, pane: Pane) -> String {
+        app.pane_values(pane)
+            .iter()
+            .map(|(value, count)| format!("{value}={count}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Each pane offers its scope's distinct values; no project means no row.
+    #[test]
+    fn pane_values_follow_the_view_scope() {
+        let _guard = env_guard();
+        sandbox("pane-scope");
+        let mut app = seed_panes();
+
+        app.view_mode = ViewMode::Day;
+        assert_eq!(values(&app, Pane::Projects), "tt=2 loremind=1");
+        assert_eq!(values(&app, Pane::Tags), "impl=2 ops=1 plan=1 tt/8=1");
+
+        app.view_mode = ViewMode::Week;
+        assert_eq!(values(&app, Pane::Projects), "tt=2 loremind=1 vinge=1");
+        assert_eq!(values(&app, Pane::Tags), "impl=2 ops=2 plan=1 tt/8=1");
+
+        app.view_mode = ViewMode::All;
+        assert_eq!(values(&app, Pane::Projects), "tt=2 vinge=2 loremind=1");
+        assert_eq!(values(&app, Pane::Tags), "impl=3 ops=2 plan=1 tt/8=1");
+    }
+
+    #[test]
+    fn pane_values_ignore_the_active_filter_and_search() {
+        let _guard = env_guard();
+        sandbox("pane-prefilter");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        let before = app.pane_values(Pane::Tags);
+
+        app.selected_tags = vec!["plan".to_string()];
+        app.search_term = "nothing matches this".to_string();
+        assert!(app.filtered_entries().is_empty(), "filter did not bite");
+        assert_eq!(app.pane_values(Pane::Tags), before);
+        assert_eq!(app.pane_values(Pane::Projects).len(), 2);
+    }
+
+    #[test]
+    fn the_scroll_indicator_appears_only_when_values_do_not_fit() {
+        let _guard = env_guard();
+        sandbox("pane-scroll-indicator");
+        let today = Local::now().date_naive();
+        let tags: Vec<String> = (0..8).map(|n| format!("tag{n}")).collect();
+        let entries: Vec<TimeEntry> = tags
+            .iter()
+            .enumerate()
+            .map(|(n, tag)| dated(n as u64, "x", "tt", &[tag.as_str()], today))
+            .collect();
+        seed(entries, 8);
+        let mut app = App::new().unwrap();
+        app.selected_date = today;
+        app.view_mode = ViewMode::Day;
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.pane_values(Pane::Tags).len(), 8);
+
+        // Six rows, eight values: the position tracks every one, wrap included.
+        for expected in 1..=8 {
+            assert_eq!(
+                app.pane_scroll_indicator(Pane::Tags, 6).as_deref(),
+                Some(format!("{expected}/8").as_str())
+            );
+            app.pane_next();
+        }
+        assert_eq!(
+            app.pane_scroll_indicator(Pane::Tags, 6).as_deref(),
+            Some("1/8"),
+            "the cursor did not wrap back to the first value"
+        );
+
+        assert_eq!(app.pane_scroll_indicator(Pane::Tags, 8), None);
+        assert_eq!(app.pane_scroll_indicator(Pane::Tags, 12), None);
+        assert_eq!(app.pane_scroll_indicator(Pane::Projects, 6), None);
+    }
+
+    #[test]
+    fn the_surface_has_no_height_until_a_pane_is_opened() {
+        let _guard = env_guard();
+        sandbox("pane-height");
+        let mut app = seed_panes();
+        assert!(!app.show_projects && !app.show_tags);
+        assert_eq!(app.pane_surface_height(), 0);
+
+        app.toggle_pane(Pane::Projects);
+        assert!(app.pane_surface_height() > 0);
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.pane_surface_height(), 0);
+    }
+
+    /// An app with `n` open marks, newest first, in a sandboxed mark directory.
+    fn seed_marks(names: &[(&str, i64)]) -> App {
+        let dir = mark_sandbox();
+        for (key, minutes_ago) in names {
+            begin_mark(&dir, key, *minutes_ago);
+        }
+        App::new().unwrap()
+    }
+
+    #[test]
+    fn the_marks_surface_has_no_height_until_it_is_toggled_on() {
+        let _guard = env_guard();
+        sandbox("marks-height");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[]);
+
+        assert!(!app.show_marks);
+        assert_eq!(app.marks_surface_height(), 0, "hidden: no row at all");
+
+        // Empty, but open: one row, so the box can say there is nothing.
+        app.toggle_marks();
+        assert_eq!(app.marks_surface_height(), 3);
+
+        // Then two borders plus one row per mark, capped at three.
+        let dir = mark_sandbox();
+        for (n, expected) in [(1, 3), (2, 4), (3, 5), (4, 5), (5, 5)] {
+            begin_mark(&dir, &format!("proj.{n}.impl"), n);
+            app.marks_stamp = None; // force a re-read; the tick would do this
+            app.sync_from_marks();
+            assert_eq!(app.marks.len(), n as usize);
+            assert_eq!(app.marks_surface_height(), expected, "{n} marks");
+        }
+
+        app.toggle_marks();
+        assert_eq!(app.marks_surface_height(), 0, "hidden again: no row again");
+    }
+
+    #[test]
+    fn the_surface_lists_the_three_newest_marks_and_counts_the_rest() {
+        let _guard = env_guard();
+        sandbox("marks-cap");
+        seed(vec![entry(0, "first")], 1);
+        let app = seed_marks(&[
+            ("tt.14.impl", 2),
+            ("loremind.64.plan", 38),
+            ("vinge.-.plan", 126),
+            ("ops.-.rota", 300),
+        ]);
+
+        let shown: Vec<String> = app.visible_marks().iter().map(Mark::label).collect();
+        assert_eq!(
+            shown,
+            vec!["tt/14 impl", "loremind/64 plan", "vinge plan"],
+            "the three newest, newest first"
+        );
+        // Three rows on screen, four open: existence, not position.
+        assert_eq!(app.marks_count(3).as_deref(), Some("3/4"));
+    }
+
+    #[test]
+    fn the_border_count_reports_how_many_marks_exist() {
+        let _guard = env_guard();
+        sandbox("marks-count");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[]);
+        assert_eq!(app.marks_count(3), None, "nothing open: nothing to count");
+
+        let dir = mark_sandbox();
+        for (n, expected) in [(1, "1"), (2, "2"), (3, "3")] {
+            begin_mark(&dir, &format!("proj.{n}.impl"), n);
+            app.marks_stamp = None;
+            app.sync_from_marks();
+            assert_eq!(
+                app.marks_count(3).as_deref(),
+                Some(expected),
+                "all {n} fit: a bare total"
+            );
+        }
+    }
+
+    #[test]
+    fn toggling_the_marks_surface_leaves_focus_and_the_table_alone() {
+        let _guard = env_guard();
+        sandbox("marks-focus");
+        seed(vec![entry(0, "first"), entry(1, "second")], 2);
+        let mut app = seed_marks(&[("tt.14.impl", 2)]);
+
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        app.toggle_marks();
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects), "opening it");
+        app.toggle_marks();
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects), "closing it");
+
+        app.toggle_marks();
+        app.focus = Focus::Table;
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Table, "the ring skips the marks surface");
+
+        app.focus = Focus::Table;
+        app.open_detail();
+        assert!(matches!(app.input_mode, InputMode::Detail));
+    }
+
+    #[test]
+    fn tab_cycles_focus_through_the_visible_panes_only() {
+        let _guard = env_guard();
+        sandbox("pane-focus");
+        let mut app = seed_panes();
+
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Table);
+
+        app.toggle_pane(Pane::Tags);
+        app.focus = Focus::Table;
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Table);
+
+        app.toggle_pane(Pane::Projects);
+        app.focus = Focus::Table;
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Table);
+    }
+
+    /// Opening a pane focuses it, so `j`/`k`/`Enter` drive it with no `Tab` first.
+    #[test]
+    fn opening_a_pane_focuses_it() {
+        let _guard = env_guard();
+        sandbox("pane-open-focus");
+        let mut app = seed_panes();
+        assert_eq!(app.focus, Focus::Table);
+
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        assert_eq!(app.focused_pane(), Some(Pane::Projects));
+
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+
+        // …in either order.
+        let mut app = seed_panes();
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+    }
+
+    /// A reopened pane resumes its cursor: it lives on `App`, not on visibility.
+    #[test]
+    fn a_reopened_pane_resumes_its_cursor() {
+        let _guard = env_guard();
+        sandbox("pane-reopen-cursor");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        app.toggle_pane(Pane::Tags);
+        app.pane_next();
+        app.pane_next();
+        assert_eq!(app.pane_cursor(Pane::Tags), 2);
+
+        app.toggle_pane(Pane::Tags);
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+        assert_eq!(app.pane_cursor(Pane::Tags), 2);
+    }
+
+    /// `Shift-Tab` undoes `Tab` for every pane-visibility combination.
+    #[test]
+    fn shift_tab_cycles_focus_in_the_exact_reverse_order() {
+        let _guard = env_guard();
+        sandbox("pane-focus-back");
+
+        for (projects, tags) in [(false, false), (true, false), (false, true), (true, true)] {
+            let mut app = seed_panes();
+            if projects {
+                app.toggle_pane(Pane::Projects);
+            }
+            if tags {
+                app.toggle_pane(Pane::Tags);
+            }
+            app.focus = Focus::Table;
+
+            let ring_len = 1 + app.visible_panes().len();
+            let mut forward = Vec::new();
+            for _ in 0..ring_len {
+                app.cycle_focus();
+                forward.push(app.focus);
+            }
+            assert_eq!(
+                app.focus,
+                Focus::Table,
+                "forward did not return to the table"
+            );
+
+            let mut backward = Vec::new();
+            for _ in 0..ring_len {
+                app.cycle_focus_back();
+                backward.push(app.focus);
+            }
+            backward.reverse();
+            let mut expected = forward.clone();
+            expected.rotate_right(1);
+            assert_eq!(
+                backward, expected,
+                "reverse cycling is not the inverse of forward for \
+                 projects={projects} tags={tags}"
+            );
+
+            for _ in 0..ring_len {
+                let before = app.focus;
+                app.cycle_focus();
+                app.cycle_focus_back();
+                assert_eq!(app.focus, before, "Shift-Tab did not undo Tab");
+                app.cycle_focus();
+            }
+        }
+    }
+
+    #[test]
+    fn shift_tab_recovers_when_the_focused_pane_was_hidden() {
+        let _guard = env_guard();
+        sandbox("pane-focus-back-hidden");
+        let mut app = seed_panes();
+        app.toggle_pane(Pane::Projects);
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+
+        // Bypass `toggle_pane`'s hand-off: the only way to observe this state.
+        app.show_tags = false;
+        assert!(app.focused_pane().is_none());
+        app.cycle_focus_back();
+        assert_eq!(
+            app.focus,
+            Focus::Pane(Pane::Projects),
+            "reverse left focus off screen"
+        );
+
+        app.show_tags = true;
+        app.focus = Focus::Pane(Pane::Tags);
+        app.show_tags = false;
+        app.cycle_focus();
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+    }
+
+    #[test]
+    fn hiding_the_focused_pane_falls_back_to_the_other_pane_then_the_table() {
+        let _guard = env_guard();
+        sandbox("pane-focus-drop");
+        let mut app = seed_panes();
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.focus, Focus::Table);
+        assert!(app.focused_pane().is_none());
+
+        app.toggle_pane(Pane::Projects);
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Tags));
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+
+        // Closing an *unfocused* pane leaves focus alone.
+        app.toggle_pane(Pane::Tags);
+        app.focus = Focus::Pane(Pane::Projects);
+        app.toggle_pane(Pane::Tags);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+    }
+
+    /// `j`/`k` wrap in the focused pane, or report "not handled" so the table moves.
+    #[test]
+    fn pane_cursor_moves_only_while_a_pane_has_focus() {
+        let _guard = env_guard();
+        sandbox("pane-cursor");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        app.table_state.select(Some(0));
+
+        assert!(!app.pane_next(), "no pane focused, yet j was swallowed");
+        assert_eq!(app.pane_cursor(Pane::Tags), 0);
+
+        app.toggle_pane(Pane::Tags);
+        let len = app.pane_values(Pane::Tags).len();
+        assert_eq!(len, 4);
+        assert!(app.pane_next());
+        assert_eq!(app.pane_cursor(Pane::Tags), 1);
+        assert!(app.pane_previous());
+        assert_eq!(app.pane_cursor(Pane::Tags), 0);
+        assert!(app.pane_previous());
+        assert_eq!(app.pane_cursor(Pane::Tags), len - 1);
+        assert!(app.pane_next());
+        assert_eq!(app.pane_cursor(Pane::Tags), 0);
+        assert_eq!(app.table_state.selected(), Some(0), "the table moved too");
+    }
+
+    #[test]
+    fn a_stale_pane_cursor_is_clamped_to_the_new_value_list() {
+        let _guard = env_guard();
+        sandbox("pane-cursor-stale");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::All;
+        app.project_cursor = 2;
+        assert_eq!(app.pane_cursor(Pane::Projects), 2);
+
+        // Day scope has fewer projects than All
+        app.view_mode = ViewMode::Day;
+        assert_eq!(app.pane_values(Pane::Projects).len(), 2);
+        assert_eq!(app.pane_cursor(Pane::Projects), 1);
+    }
+
+    /// The descriptions of the entries currently in view, in table order.
+    fn in_view(app: &App) -> Vec<String> {
+        app.filtered_entries()
+            .iter()
+            .map(|e| e.description.clone())
+            .collect()
+    }
+
+    /// Move focus onto `pane` and put its cursor on `value`.
+    fn point_at(app: &mut App, pane: Pane, value: &str) {
+        if !app.pane_is_visible(pane) {
+            app.toggle_pane(pane);
+        }
+        while app.focused_pane() != Some(pane) {
+            app.cycle_focus();
+        }
+        let idx = app
+            .pane_values(pane)
+            .iter()
+            .position(|(v, _)| v == value)
+            .unwrap_or_else(|| panic!("{value} not offered by the pane"));
+        match pane {
+            Pane::Projects => app.project_cursor = idx,
+            Pane::Tags => app.tag_cursor = idx,
+        }
+    }
+
+    /// `Enter` in a pane filters on the value under its cursor; on the table it does not.
+    #[test]
+    fn enter_toggles_the_value_under_the_pane_cursor() {
+        let _guard = env_guard();
+        sandbox("pane-toggle");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+
+        point_at(&mut app, Pane::Projects, "tt");
+        assert!(app.toggle_pane_value(), "Enter was not handled by the pane");
+        assert_eq!(app.selected_projects, vec!["tt".to_string()]);
+        assert_eq!(in_view(&app), vec!["a", "b"]);
+        assert!(app.is_filtering());
+        assert!(app.pane_value_is_selected(Pane::Projects, "tt"));
+
+        assert!(app.toggle_pane_value());
+        assert!(app.selected_projects.is_empty());
+        assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+        assert!(!app.is_filtering());
+
+        app.focus = Focus::Table;
+        assert!(!app.toggle_pane_value());
+        assert!(app.selected_projects.is_empty() && app.selected_tags.is_empty());
+        assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+    }
+
+    #[test]
+    fn enter_opens_the_detail_popover_only_from_the_table() {
+        let _guard = env_guard();
+        sandbox("detail-focus");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        app.table_state.select(Some(0));
+
+        // This is exactly what the Normal-mode Enter arm does.
+        let enter = |app: &mut App| {
+            if !app.toggle_pane_value() {
+                app.open_detail();
+            }
+        };
+
+        point_at(&mut app, Pane::Projects, "tt");
+        enter(&mut app);
+        assert!(
+            app.input_mode == InputMode::Normal,
+            "Enter in a pane opened the popover instead of filtering"
+        );
+        assert_eq!(app.selected_projects, vec!["tt".to_string()]);
+
+        app.focus = Focus::Table;
+        enter(&mut app);
+        assert!(
+            app.input_mode == InputMode::Detail,
+            "Enter on the table did not open the popover"
+        );
+        assert_eq!(app.table_state.selected(), Some(0));
+        assert_eq!(app.selected_projects, vec!["tt".to_string()]);
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(0));
+    }
+
+    /// What the `Detail` arm does with j/k, `e` and `d`, via the calls it makes.
+    #[test]
+    fn the_detail_popover_traverses_the_list_and_acts_on_what_it_shows() {
+        let _guard = env_guard();
+        sandbox("detail-traverse");
+        seed(vec![entry(0, "a"), entry(1, "b"), entry(2, "c")], 3);
+
+        let mut app = App::new().unwrap();
+        app.table_state.select(Some(0));
+        app.open_detail();
+        let ids: Vec<u64> = app.filtered_entries().iter().map(|e| e.id).collect();
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(ids[0]));
+
+        app.next();
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(ids[1]));
+        app.previous();
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(ids[0]));
+        app.previous();
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(ids[2]));
+        app.next();
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(ids[0]));
+        assert!(app.input_mode == InputMode::Detail, "traversal closed it");
+
+        app.start_editing();
+        assert!(app.input_mode == InputMode::EditingEntry);
+        assert_eq!(app.editing_entry_id, Some(ids[0]));
+
+        // `d` asks, the repeated `d` answers, and the popover stays open.
+        app.input_mode = InputMode::Detail;
+        press_d_then(&mut app, KeyCode::Char('d'));
+        assert!(app.input_mode == InputMode::Detail);
+        assert_eq!(app.filtered_entries().len(), 2);
+        assert!(app.selected_entry().is_some());
+
+        // …and the delete that empties the view closes it.
+        press_d_then(&mut app, KeyCode::Char('y'));
+        press_d_then(&mut app, KeyCode::Char('d'));
+        assert_eq!(app.filtered_entries().len(), 0);
+        assert!(app.input_mode == InputMode::Normal);
+    }
+
+    #[test]
+    fn t_in_the_popover_trims_the_entry_and_stays_on_the_piece_that_kept_the_id() {
+        let _guard = env_guard();
+        sandbox("detail-trim");
+        let today = Local::now().date_naive();
+        seed(
+            vec![
+                with_idle(4, 180, &[(30, 45), (100, 130)]),
+                dated(9, "untouched", "vinge", &["ops"], today),
+            ],
+            10,
+        );
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "long session");
+        app.open_detail();
+        assert!(
+            app.detail_hints().contains(&("t", "trim…")),
+            "the footer hid the hint on an entry that has idle"
+        );
+        let before = app
+            .selected_entry()
+            .map(|e| (e.duration(), e.idle.len()))
+            .unwrap();
+        let idle_total = with_idle(4, 180, &[(30, 45), (100, 130)])
+            .idle
+            .iter()
+            .fold(chrono::Duration::zero(), |acc, gap| acc + gap.duration());
+
+        press_t_then(&mut app, KeyCode::Char('t'));
+
+        assert!(app.input_mode == InputMode::Detail, "the trim closed it");
+        assert_eq!(
+            app.selected_entry().map(|e| e.id),
+            Some(4),
+            "the popover slid off the piece that kept the id"
+        );
+        // Two holes, so three pieces, plus the entry that was never touched.
+        assert_eq!(app.filtered_entries().len(), before.1 + 1 + 1);
+        let pieces: Vec<&TimeEntry> = app
+            .filtered_entries()
+            .into_iter()
+            .filter(|e| e.description == "long session")
+            .collect();
+        assert_eq!(pieces.len(), 3);
+        let after = pieces
+            .iter()
+            .fold(chrono::Duration::zero(), |acc, e| acc + e.duration());
+        assert_eq!(after, before.0 - idle_total);
+        assert!(pieces.iter().all(|e| e.idle.is_empty()));
+        assert!(
+            !app.detail_hints().contains(&("t", "trim…")),
+            "the footer advertises a trim that would now do nothing"
+        );
+        assert!(
+            descriptions(&on_disk()).contains(&"untouched"),
+            "the trim disturbed another entry"
+        );
+    }
+
+    #[test]
+    fn t_on_an_entry_with_no_idle_does_nothing_and_the_footer_omits_the_hint() {
+        let _guard = env_guard();
+        sandbox("detail-trim-noop");
+        seed(vec![entry(0, "no idle here"), entry(1, "nor here")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "no idle here");
+        app.open_detail();
+        assert!(
+            !app.detail_hints().contains(&("t", "trim…")),
+            "the footer advertised a no-op"
+        );
+        let before = serde_json::to_string(&on_disk()).unwrap();
+
+        press_t_then(&mut app, KeyCode::Char('t'));
+
+        assert!(app.input_mode == InputMode::Detail);
+        assert_eq!(selected_description(&app), "no idle here");
+        assert_eq!(
+            serde_json::to_string(&on_disk()).unwrap(),
+            before,
+            "a no-op trim rewrote the store"
+        );
+    }
+
+    #[test]
+    fn t_outside_the_popover_still_jumps_to_today() {
+        let _guard = env_guard();
+        sandbox("detail-trim-normal-t");
+        seed(vec![with_idle(4, 180, &[(30, 45)])], 5);
+
+        let mut app = App::new().unwrap();
+        app.previous_period();
+        assert_ne!(app.selected_date, Local::now().date_naive());
+
+        // What the `Normal` arm's `t` calls.
+        app.go_to_today();
+
+        assert_eq!(app.selected_date, Local::now().date_naive());
+        assert_eq!(on_disk().entries.len(), 1, "the table's `t` split an entry");
+    }
+
+    #[test]
+    fn requesting_a_confirmation_records_the_selected_id_and_writes_nothing() {
+        let _guard = env_guard();
+        sandbox("confirm-request");
+        seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "doomed");
+        let before = serde_json::to_string(&on_disk()).unwrap();
+
+        app.request_confirm(ConfirmAction::Delete);
+
+        assert!(app.input_mode == InputMode::Confirm);
+        let pending = app.pending_confirm.expect("a pending confirmation");
+        assert_eq!(pending.action, ConfirmAction::Delete);
+        assert_eq!(pending.entry_id, 1, "the prompt pinned the selected entry");
+        assert!(pending.from == InputMode::Normal, "raised from the table");
+        assert_eq!(
+            serde_json::to_string(&on_disk()).unwrap(),
+            before,
+            "asking the question wrote to the store"
+        );
+    }
+
+    #[test]
+    fn a_confirmed_delete_acts_on_the_captured_id_not_the_current_selection() {
+        let _guard = env_guard();
+        sandbox("confirm-captured");
+        seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "doomed");
+        app.request_confirm(ConfirmAction::Delete);
+        // The cursor moves out from under the prompt.
+        app.next();
+        assert_ne!(app.selected_entry().map(|e| e.id), Some(1));
+
+        app.confirm_pending().unwrap();
+
+        assert_eq!(descriptions(&on_disk()), vec!["keep"]);
+        assert!(app.pending_confirm.is_none());
+        assert!(app.input_mode == InputMode::Normal);
+    }
+
+    /// The live poll can drop the cursor onto a different entry; the id keeps it on target.
+    #[test]
+    fn the_poll_moving_the_cursor_under_the_prompt_does_not_move_the_target() {
+        let _guard = env_guard();
+        sandbox("confirm-poll-moves");
+        let today = Local::now().date_naive();
+        seed(
+            vec![
+                dated(1, "doomed", "tt", &["tt"], today),
+                dated(2, "bystander", "tt", &["tt"], today),
+            ],
+            3,
+        );
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "doomed");
+        app.request_confirm(ConfirmAction::Delete);
+
+        // The pending entry leaves the day view, so the cursor falls back by position.
+        storage::with_data(|data| {
+            let e = data.entries.iter_mut().find(|e| e.id == 1).unwrap();
+            e.start_time -= chrono::Duration::days(1);
+            e.end_time = Some(e.start_time + chrono::Duration::hours(1));
+            Ok(())
+        })
+        .unwrap();
+        app.sync_from_store().unwrap();
+        assert_eq!(
+            app.selected_entry().map(|e| e.id),
+            Some(2),
+            "the fixture no longer reproduces the cursor moving under the prompt"
+        );
+        assert!(app.input_mode == InputMode::Confirm, "the poll closed it");
+
+        app.confirm_pending().unwrap();
+
+        assert_eq!(
+            descriptions(&on_disk()),
+            vec!["bystander"],
+            "the confirm destroyed an entry the prompt never named"
+        );
+    }
+
+    #[test]
+    fn a_confirm_whose_target_vanished_performs_nothing() {
+        let _guard = env_guard();
+        sandbox("confirm-vanished");
+        seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "doomed");
+        app.open_detail();
+        app.request_confirm(ConfirmAction::Delete);
+
+        // Someone else removes it while the prompt is on screen.
+        storage::with_data(|data| {
+            data.entries.retain(|e| e.id != 1);
+            Ok(())
+        })
+        .unwrap();
+        app.sync_from_store().unwrap();
+        assert!(app.pending_confirm.is_none());
+        assert!(
+            app.input_mode == InputMode::Detail,
+            "the popover still has a row"
+        );
+
+        // …and a confirm arriving on a prompt that is already gone is inert too.
+        app.confirm_pending().unwrap();
+        assert_eq!(descriptions(&on_disk()), vec!["keep"]);
+    }
+
+    #[test]
+    fn cancelling_restores_the_originating_mode_and_leaves_the_store_alone() {
+        let _guard = env_guard();
+        sandbox("confirm-cancel");
+        seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "doomed");
+        let before = serde_json::to_string(&on_disk()).unwrap();
+
+        app.request_confirm(ConfirmAction::Delete);
+        app.cancel_confirm();
+        assert!(app.input_mode == InputMode::Normal);
+        assert!(app.pending_confirm.is_none());
+        assert_eq!(selected_description(&app), "doomed", "the cursor moved");
+
+        // From the popover, which reopens on the same entry.
+        app.open_detail();
+        app.request_confirm(ConfirmAction::Delete);
+        app.cancel_confirm();
+        assert!(app.input_mode == InputMode::Detail);
+        assert_eq!(selected_description(&app), "doomed");
+
+        assert_eq!(
+            serde_json::to_string(&on_disk()).unwrap(),
+            before,
+            "a cancelled confirmation wrote to the store"
+        );
+    }
+
+    #[test]
+    fn a_confirmed_trim_splits_the_captured_entry_and_stays_on_the_first_piece() {
+        let _guard = env_guard();
+        sandbox("confirm-trim");
+        seed(vec![with_idle(4, 180, &[(30, 45), (100, 130)])], 5);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "long session");
+        app.open_detail();
+        app.request_confirm(ConfirmAction::Trim);
+        assert_eq!(
+            app.pending_confirm.map(|p| (p.action, p.entry_id)),
+            Some((ConfirmAction::Trim, 4))
+        );
+        assert_eq!(on_disk().entries.len(), 1, "the prompt trimmed on its own");
+
+        app.confirm_pending().unwrap();
+
+        assert_eq!(
+            on_disk().entries.len(),
+            3,
+            "two holes should give three pieces"
+        );
+        assert!(
+            app.input_mode == InputMode::Detail,
+            "the trim closed the popover"
+        );
+        assert_eq!(app.selected_entry().map(|e| e.id), Some(4));
+    }
+
+    #[test]
+    fn only_y_or_the_originating_key_is_a_yes() {
+        let _guard = env_guard();
+        sandbox("confirm-keys");
+        seed(vec![with_idle(4, 180, &[(30, 45)])], 5);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "long session");
+        assert!(!app.confirms_pending('y'), "no prompt, no yes");
+
+        app.request_confirm(ConfirmAction::Delete);
+        assert!(app.confirms_pending('d'));
+        assert!(app.confirms_pending('y'));
+        assert!(!app.confirms_pending('t'), "`t` confirmed a delete");
+        assert!(!app.confirms_pending('n'));
+        app.cancel_confirm();
+
+        app.open_detail();
+        app.request_confirm(ConfirmAction::Trim);
+        assert!(app.confirms_pending('t'));
+        assert!(app.confirms_pending('y'));
+        assert!(!app.confirms_pending('d'), "`d` confirmed a trim");
+    }
+
+    /// One rendered frame as lines of text, so assertions read the real screen.
+    fn frame_lines(app: &mut App, width: u16, height: u16) -> Vec<String> {
+        let mut terminal =
+            Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| render::ui(f, app)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_delete_prompt_names_the_entry_it_would_destroy() {
+        let _guard = env_guard();
+        sandbox("confirm-render-delete");
+        let today = Local::now().date_naive();
+        seed(
+            vec![dated(12, "pane cursor markers", "tt", &["tt"], today)],
+            13,
+        );
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "pane cursor markers");
+        app.request_confirm(ConfirmAction::Delete);
+        let screen = frame_lines(&mut app, 100, 30).join("\n");
+
+        assert!(
+            screen.contains("Delete entry #12?"),
+            "the title did not ask about the captured entry:\n{screen}"
+        );
+        assert!(
+            screen.contains("pane cursor markers (tt)"),
+            "the prompt did not name the entry:\n{screen}"
+        );
+        let duration = app.data.get_entry(12).unwrap().format_duration();
+        assert!(
+            screen.contains(&duration),
+            "the prompt did not state the duration {duration}:\n{screen}"
+        );
+        assert!(screen.contains("d / y yes"), "hint row:\n{screen}");
+        assert!(
+            screen.contains("n / esc / enter cancel"),
+            "hint row:\n{screen}"
+        );
+        assert!(!screen.contains("t / y"), "a delete prompt offered `t`");
+    }
+
+    /// The trim prompt states its outcome, from the same helper the write uses.
+    #[test]
+    fn the_trim_prompt_states_the_pieces_and_what_is_removed() {
+        let _guard = env_guard();
+        sandbox("confirm-render-trim");
+        seed(vec![with_idle(14, 110, &[(25, 45), (85, 100)])], 15);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "long session");
+        app.open_detail();
+        app.request_confirm(ConfirmAction::Trim);
+        let screen = frame_lines(&mut app, 100, 30).join("\n");
+
+        assert!(
+            screen.contains("Trim entry #14?"),
+            "the title did not ask about a trim:\n{screen}"
+        );
+        // Two holes, so three pieces: 0-25, 45-85, 100-110.
+        assert!(
+            screen.contains("3 pieces: 0h 25m, 0h 40m, 0h 10m"),
+            "the prompt did not state the pieces:\n{screen}"
+        );
+        assert!(
+            screen.contains("0h 35m removed"),
+            "the prompt did not state what it removes:\n{screen}"
+        );
+        assert!(screen.contains("t / y yes"), "hint row:\n{screen}");
+        assert!(
+            !screen.contains("split"),
+            "the user-facing verb is trim, never split:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn the_key_hints_say_the_destructive_keys_ask_first() {
+        let _guard = env_guard();
+        sandbox("confirm-render-hints");
+        seed(vec![with_idle(4, 180, &[(30, 45)])], 5);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "long session");
+
+        // The footer legend, which clips at 80 columns, so it gets a bare `…`.
+        let footer = frame_lines(&mut app, 200, 30).join("\n");
+        assert!(footer.contains("d: del…"), "footer legend:\n{footer}");
+
+        app.input_mode = InputMode::Help;
+        let help = frame_lines(&mut app, 100, 40).join("\n");
+        assert!(
+            help.contains("delete selected entry (asks first)"),
+            "help popup:\n{help}"
+        );
+
+        app.input_mode = InputMode::Detail;
+        let popover = frame_lines(&mut app, 100, 40).join("\n");
+        assert!(popover.contains("d delete…"), "popover hints:\n{popover}");
+        assert!(popover.contains("t trim…"), "popover hints:\n{popover}");
+    }
+
+    #[test]
+    fn each_answer_key_does_exactly_what_the_hint_row_says() {
+        let _guard = env_guard();
+        sandbox("confirm-answer-keys");
+
+        // Yes, by the originating key and by `y`.
+        for yes in [KeyCode::Char('d'), KeyCode::Char('y')] {
+            seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+            let mut app = App::new().unwrap();
+            select(&mut app, "doomed");
+            press_d_then(&mut app, yes);
+            assert_eq!(
+                descriptions(&on_disk()),
+                vec!["keep"],
+                "{yes:?} was not taken as a yes"
+            );
+            assert!(app.input_mode == InputMode::Normal);
+        }
+
+        // No, by every route out, `Enter` among them.
+        for no in [KeyCode::Char('n'), KeyCode::Esc, KeyCode::Enter] {
+            seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+            let mut app = App::new().unwrap();
+            select(&mut app, "doomed");
+            app.open_detail();
+            press_d_then(&mut app, no);
+            assert_eq!(
+                descriptions(&on_disk()),
+                vec!["keep", "doomed"],
+                "{no:?} destroyed something"
+            );
+            assert!(
+                app.input_mode == InputMode::Detail,
+                "{no:?} left the popover"
+            );
+            assert!(app.pending_confirm.is_none());
+        }
+
+        // Neither the other destructive key nor a stray press dismisses the prompt.
+        for inert in [KeyCode::Char('t'), KeyCode::Char('j'), KeyCode::Char('q')] {
+            seed(vec![entry(0, "keep"), entry(1, "doomed")], 2);
+            let mut app = App::new().unwrap();
+            select(&mut app, "doomed");
+            press_d_then(&mut app, inert);
+            assert_eq!(
+                descriptions(&on_disk()),
+                vec!["keep", "doomed"],
+                "{inert:?} confirmed a delete"
+            );
+            assert!(
+                app.input_mode == InputMode::Confirm,
+                "{inert:?} closed the prompt"
+            );
+            assert!(app.pending_confirm.is_some());
+        }
+    }
+
+    #[test]
+    fn the_trim_prompt_takes_t_and_y_and_ignores_d() {
+        let _guard = env_guard();
+        sandbox("confirm-trim-keys");
+
+        for yes in [KeyCode::Char('t'), KeyCode::Char('y')] {
+            seed(vec![with_idle(4, 180, &[(30, 45), (100, 130)])], 5);
+            let mut app = App::new().unwrap();
+            select(&mut app, "long session");
+            app.open_detail();
+            press_t_then(&mut app, yes);
+            assert_eq!(on_disk().entries.len(), 3, "{yes:?} was not taken as a yes");
+            assert!(app.input_mode == InputMode::Detail);
+            assert_eq!(app.selected_entry().map(|e| e.id), Some(4));
+        }
+
+        seed(vec![with_idle(4, 180, &[(30, 45), (100, 130)])], 5);
+        let mut app = App::new().unwrap();
+        select(&mut app, "long session");
+        app.open_detail();
+        press_t_then(&mut app, KeyCode::Char('d'));
+        assert_eq!(on_disk().entries.len(), 1, "`d` confirmed a trim");
+        assert!(app.input_mode == InputMode::Confirm);
+    }
+
+    /// `t` outside the popover is navigation, and `s` acts without a prompt.
+    #[test]
+    fn the_keys_that_were_not_wired_still_mean_what_they_did() {
+        let _guard = env_guard();
+        sandbox("confirm-unwired-keys");
+        seed(
+            vec![with_idle(4, 180, &[(30, 45)]), entry(9, "running")],
+            10,
+        );
+
+        let mut app = App::new().unwrap();
+        app.previous_period();
+
+        // What the `Normal` arm's `t` calls.
+        app.go_to_today();
+        assert_eq!(app.selected_date, Local::now().date_naive());
+        assert!(
+            app.pending_confirm.is_none(),
+            "the table's `t` raised a prompt"
+        );
+        assert_eq!(on_disk().entries.len(), 2, "the table's `t` split an entry");
+
+        // …and what its `s` calls, which acts at once and asks nothing.
+        app.stop_active().unwrap();
+        assert!(app.pending_confirm.is_none(), "`s` raised a prompt");
+        assert!(app.input_mode == InputMode::Normal);
+    }
+
+    #[test]
+    fn a_trim_with_nothing_to_trim_raises_no_prompt() {
+        let _guard = env_guard();
+        sandbox("confirm-trim-noop");
+        seed(vec![entry(0, "no idle here")], 1);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "no idle here");
+        app.open_detail();
+
+        app.request_confirm(ConfirmAction::Trim);
+
+        assert!(app.pending_confirm.is_none());
+        assert!(app.input_mode == InputMode::Detail);
+    }
+
+    /// `Detail` is *not* in `sync_from_store`'s guarded set; the poll re-anchors on the
+    /// selected id. `selected_entry` is positional, so `trim_entry` re-selects by id.
+    #[test]
+    fn an_outside_write_reaches_the_open_detail_popover_without_moving_it() {
+        let _guard = env_guard();
+        sandbox("detail-sync");
+        seed(vec![entry(0, "first"), entry(1, "second")], 2);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "second");
+        app.open_detail();
+        let shown = app.selected_entry().map(|e| e.id);
+        agent_write("probe");
+
+        app.sync_from_store().unwrap();
+
+        assert!(descriptions(&app.data).contains(&"probe"));
+        assert!(app.input_mode == InputMode::Detail);
+        assert_eq!(
+            app.selected_entry().map(|e| e.id),
+            shown,
+            "the popover changed entry under the reader"
+        );
+        assert_eq!(selected_description(&app), "second");
+    }
+
+    #[test]
+    fn the_detail_popover_stays_shut_with_nothing_selected() {
+        let _guard = env_guard();
+        sandbox("detail-empty");
+        seed(vec![], 0);
+        let mut app = App::new().unwrap();
+        assert!(app.selected_entry().is_none());
+
+        app.open_detail();
+        assert!(app.input_mode == InputMode::Normal);
+    }
+
+    #[test]
+    fn selections_or_within_a_pane_and_and_across_panes() {
+        let _guard = env_guard();
+        sandbox("pane-filter-semantics");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+
+        point_at(&mut app, Pane::Projects, "tt");
+        app.toggle_pane_value();
+        assert_eq!(in_view(&app), vec!["a", "b"]);
+
+        // A second project widens the set — the two are OR'd.
+        point_at(&mut app, Pane::Projects, "loremind");
+        app.toggle_pane_value();
+        assert_eq!(in_view(&app), vec!["a", "b", "c"]);
+
+        // A tag narrows within them — the panes are AND'd.
+        point_at(&mut app, Pane::Tags, "impl");
+        app.toggle_pane_value();
+        assert_eq!(in_view(&app), vec!["a", "c"]);
+
+        point_at(&mut app, Pane::Tags, "plan");
+        app.toggle_pane_value();
+        assert_eq!(in_view(&app), vec!["a", "b", "c"]);
+
+        app.clear_filters();
+        assert!(!app.is_filtering());
+        assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+    }
+
+    /// The footer's total is the filtered one, so it describes the rows on screen.
+    #[test]
+    fn the_filtered_total_tracks_the_selection() {
+        let _guard = env_guard();
+        sandbox("pane-filter-total");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        // Four one-hour entries in scope.
+        assert_eq!(app.filtered_total().num_hours(), 4);
+
+        point_at(&mut app, Pane::Projects, "tt");
+        app.toggle_pane_value();
+        assert_eq!(app.filtered_total().num_hours(), 2);
+        assert!(app.is_filtering());
+    }
+
+    /// Unequal per-project times across three scopes, two unprojected entries and a
+    /// tie the name breaks. Day: tt 90m/2, loremind 90m, none 30m — 210m. Week adds
+    /// vinge 120m and none 45m — 375m. All adds loremind 60m — 435m.
+    fn seed_summary() -> App {
+        let today = Local::now().date_naive();
+        let week_start = TimeData::week_start(today);
+        let day_one = week_start;
+        let day_two = week_start + chrono::Duration::days(1);
+        let last_week = week_start - chrono::Duration::days(7);
+        seed(
+            vec![
+                logged(0, "a", "tt", &["impl"], day_one, 60),
+                logged(1, "b", "tt", &["plan"], day_one, 30),
+                logged(2, "c", "loremind", &["impl"], day_one, 90),
+                logged(3, "d", "", &[], day_one, 30),
+                logged(4, "e", "vinge", &["ops"], day_two, 120),
+                logged(5, "f", "  ", &["ops"], day_two, 45),
+                logged(6, "g", "loremind", &["impl"], last_week, 60),
+            ],
+            7,
+        );
+        let mut app = App::new().unwrap();
+        app.selected_date = day_one;
+        app
+    }
+
+    /// The three view scopes with a name to report against; `ViewMode` is not `Debug`.
+    fn scopes() -> [(ViewMode, &'static str); 3] {
+        [
+            (ViewMode::Day, "day"),
+            (ViewMode::Week, "week"),
+            (ViewMode::All, "all"),
+        ]
+    }
+
+    /// The summary's rows as `project=minutes/entries/share%`, in order.
+    fn summary(app: &App) -> String {
+        app.project_summary()
+            .iter()
+            .map(|row| {
+                format!(
+                    "{}={}m/{}/{}%",
+                    row.project,
+                    row.total.num_minutes(),
+                    row.entries,
+                    row.share
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Totals per scope, largest first, ties by name, absence collapsed into one row.
+    #[test]
+    fn project_summary_totals_and_counts_follow_the_view_scope() {
+        let _guard = env_guard();
+        sandbox("summary-scope");
+        let mut app = seed_summary();
+
+        app.view_mode = ViewMode::Day;
+        assert_eq!(
+            summary(&app),
+            "loremind=90m/1/43% tt=90m/2/43% (no project)=30m/1/14%"
+        );
+
+        app.view_mode = ViewMode::Week;
+        assert_eq!(
+            summary(&app),
+            "vinge=120m/1/32% loremind=90m/1/24% tt=90m/2/24% (no project)=75m/2/20%"
+        );
+
+        app.view_mode = ViewMode::All;
+        assert_eq!(
+            summary(&app),
+            "loremind=150m/2/34% vinge=120m/1/28% tt=90m/2/21% (no project)=75m/2/17%"
+        );
+
+        for (mode, name) in scopes() {
+            app.view_mode = mode;
+            assert_eq!(
+                app.project_summary()
+                    .iter()
+                    .filter(|row| row.project == super::summary::NO_PROJECT)
+                    .count(),
+                1,
+                "{name} did not collapse absence into one row"
+            );
+        }
+    }
+
+    /// The rows sum to the scope total, and their shares to within a point of 100.
+    #[test]
+    fn project_summary_rows_account_for_the_whole_scope() {
+        let _guard = env_guard();
+        sandbox("summary-sums");
+        let mut app = seed_summary();
+
+        for (mode, name) in scopes() {
+            app.view_mode = mode;
+            let rows = app.project_summary();
+            let scope_total: i64 = app
+                .scope_entries()
+                .iter()
+                .map(|e| e.duration().num_seconds())
+                .sum();
+            let summed: i64 = rows.iter().map(|r| r.total.num_seconds()).sum();
+            assert_eq!(summed, scope_total, "{name} rows do not sum to the scope");
+            let entries: usize = rows.iter().map(|r| r.entries).sum();
+            assert_eq!(entries, app.scope_entries().len(), "{name} entry counts");
+
+            let shares: u32 = rows.iter().map(|r| u32::from(r.share)).sum();
+            assert!(
+                (99..=101).contains(&shares),
+                "{name} shares sum to {shares}, not ~100"
+            );
+        }
+    }
+
+    #[test]
+    fn project_summary_ignores_the_active_filter_and_search() {
+        let _guard = env_guard();
+        sandbox("summary-prefilter");
+        let mut app = seed_summary();
+        app.view_mode = ViewMode::Week;
+        let before = app.project_summary();
+        let in_scope = app.scope_entries().len();
+
+        app.selected_projects = vec!["tt".to_string()];
+        assert!(
+            app.filtered_entries().len() < in_scope,
+            "filter did not bite"
+        );
+        assert_eq!(app.project_summary(), before);
+
+        app.selected_projects.clear();
+        app.selected_tags = vec!["ops".to_string()];
+        assert!(
+            app.filtered_entries().len() < in_scope,
+            "filter did not bite"
+        );
+        assert_eq!(app.project_summary(), before);
+
+        app.search_term = "nothing matches this".to_string();
+        assert!(app.filtered_entries().is_empty());
+        assert_eq!(app.project_summary(), before);
+    }
+
+    #[test]
+    fn an_empty_or_zero_length_scope_summarises_without_dividing_by_zero() {
+        let _guard = env_guard();
+        sandbox("summary-empty");
+        seed(Vec::new(), 0);
+        let mut app = App::new().unwrap();
+        app.view_mode = ViewMode::Day;
+        assert!(app.project_summary().is_empty());
+        app.view_mode = ViewMode::All;
+        assert!(app.project_summary().is_empty());
+
+        // A populated store still has empty scopes: a day nobody worked.
+        let today = Local::now().date_naive();
+        seed(vec![logged(0, "a", "tt", &["impl"], today, 60)], 1);
+        let mut app = App::new().unwrap();
+        app.view_mode = ViewMode::Day;
+        app.selected_date = today - chrono::Duration::days(400);
+        assert!(app.project_summary().is_empty());
+
+        // Zero-length entries: rows exist, and the shares are 0%.
+        seed(
+            vec![
+                logged(0, "a", "tt", &[], today, 0),
+                logged(1, "b", "", &[], today, 0),
+            ],
+            2,
+        );
+        let mut app = App::new().unwrap();
+        app.selected_date = today;
+        app.view_mode = ViewMode::Day;
+        // Nothing separates them by total, so the name tie-break decides.
+        assert_eq!(summary(&app), "(no project)=0m/1/0% tt=0m/1/0%");
+    }
+
+    /// Hidden, the surface has no height, so `ui` leaves its row out of the plan.
+    #[test]
+    fn the_summary_surface_has_no_height_until_it_is_toggled_on() {
+        let _guard = env_guard();
+        sandbox("summary-height");
+        let mut app = seed_summary();
+        app.view_mode = ViewMode::Day;
+
+        assert!(!app.show_summary);
+        assert_eq!(app.summary_surface_height(), 0, "hidden: no row at all");
+
+        // Two borders plus one row per project: the day has three.
+        app.toggle_summary();
+        assert_eq!(app.summary_surface_height(), 5);
+        // Re-scoping re-sizes it: the week has four projects, all entries too.
+        app.view_mode = ViewMode::Week;
+        assert_eq!(app.summary_surface_height(), 6);
+
+        // An empty scope still gets one row, so the box can say it is empty.
+        app.view_mode = ViewMode::Day;
+        app.selected_date = Local::now().date_naive() - chrono::Duration::days(400);
+        assert!(app.project_summary().is_empty());
+        assert_eq!(app.summary_surface_height(), 3);
+
+        app.toggle_summary();
+        assert_eq!(app.summary_surface_height(), 0, "hidden again: no row");
+    }
+
+    #[test]
+    fn toggling_the_summary_surface_leaves_focus_and_the_table_alone() {
+        let _guard = env_guard();
+        sandbox("summary-focus");
+        let mut app = seed_summary();
+        app.toggle_pane(Pane::Projects);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        app.table_state.select(Some(1));
+
+        app.toggle_summary();
+        assert!(app.show_summary);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        assert_eq!(app.table_state.selected(), Some(1));
+
+        app.toggle_summary();
+        assert!(!app.show_summary);
+        assert_eq!(app.focus, Focus::Pane(Pane::Projects));
+        assert_eq!(app.table_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn the_title_marker_names_the_scope_and_always_says_all_projects() {
+        let _guard = env_guard();
+        sandbox("summary-marker");
+        let mut app = seed_summary();
+        app.toggle_summary();
+
+        for (mode, word) in scopes() {
+            app.set_view_mode(mode);
+            assert_eq!(app.summary_marker(6), format!("{word} · all projects"));
+        }
+
+        // A filter changes the emphasis, never the words.
+        app.set_view_mode(ViewMode::Day);
+        assert!(!app.total_is_filtered());
+        let unfiltered = app.summary_marker(6);
+        app.selected_projects = vec!["tt".to_string()];
+        assert!(app.total_is_filtered(), "the footer total is now narrowed");
+        assert_eq!(app.summary_marker(6), unfiltered);
+    }
+
+    /// Overflow says `shown/total` off the frame's real height, and nothing while all fit.
+    #[test]
+    fn more_projects_than_fit_are_counted_on_the_title() {
+        let _guard = env_guard();
+        sandbox("summary-overflow");
+        let today = Local::now().date_naive();
+        let entries: Vec<TimeEntry> = (0..9)
+            .map(|n| logged(n, "x", &format!("p{n}"), &[], today, 30 + n as i64))
+            .collect();
+        seed(entries, 9);
+        let mut app = App::new().unwrap();
+        app.selected_date = today;
+        app.view_mode = ViewMode::Day;
+        app.toggle_summary();
+
+        // Capped at six rows, so nine projects overflow: `6/9`, on the one title.
+        assert_eq!(app.summary_surface_height(), 8);
+        assert_eq!(app.summary_count(6).as_deref(), Some("6/9"));
+        assert_eq!(app.summary_marker(6), "day · all projects · 6/9");
+        assert_eq!(app.visible_project_summary(6).len(), 6);
+
+        // A shorter box counts what *it* left out, not what the cap would have.
+        assert_eq!(app.summary_marker(2), "day · all projects · 2/9");
+        assert_eq!(app.visible_project_summary(2).len(), 2);
+
+        assert_eq!(app.summary_count(9), None);
+        assert_eq!(app.summary_marker(9), "day · all projects");
+    }
+
+    #[test]
+    fn the_rows_sum_to_the_footer_total_until_a_filter_narrows_it() {
+        let _guard = env_guard();
+        sandbox("summary-vs-footer");
+        let mut app = seed_summary();
+        app.view_mode = ViewMode::Week;
+
+        let rows = app.project_summary();
+        let summed: chrono::Duration = rows
+            .iter()
+            .fold(chrono::Duration::zero(), |acc, row| acc + row.total);
+        // Unfiltered, the footer prints the scope total for the week.
+        let week_start = TimeData::week_start(app.selected_date);
+        assert!(!app.total_is_filtered());
+        assert_eq!(summed, app.data.total_for_week(week_start));
+
+        app.selected_projects = vec!["tt".to_string()];
+        assert!(app.total_is_filtered(), "the marker is now emphasised");
+        assert!(
+            app.filtered_total() < summed,
+            "the footer total should have dropped below the summary's"
+        );
+        assert_eq!(app.project_summary(), rows, "the summary must not move");
+    }
+
+    #[test]
+    fn search_matches_every_field_a_row_shows() {
+        let _guard = env_guard();
+        sandbox("search-any-field");
+        let today = Local::now().date_naive();
+        let start = today
+            .and_hms_opt(14, 30, 0)
+            .unwrap()
+            .and_local_timezone(Local)
+            .unwrap();
+        seed(
+            vec![
+                TimeEntry {
+                    id: 42,
+                    description: "wrote the migration".to_string(),
+                    project: Some("loremind".to_string()),
+                    tags: vec!["impl".to_string()],
+                    start_time: start,
+                    end_time: Some(start + chrono::Duration::hours(2)),
+                    idle: Vec::new(),
+                },
+                dated(7, "unrelated", "vinge", &["ops"], today),
+            ],
+            43,
+        );
+        let mut app = App::new().unwrap();
+        app.selected_date = today;
+        app.view_mode = ViewMode::Day;
+        assert_eq!(in_view(&app).len(), 2);
+
+        for needle in [
+            "migration", // description
+            "LOREMIND",  // project, case-insensitively
+            "impl",      // a tag
+            "42",        // the id
+            "14:",       // a fragment of the start time
+            "16:30",     // the end time
+            "2h 0m",     // the formatted duration
+            &today.format("%Y-%m-%d").to_string(),
+        ] {
+            app.search_term = needle.to_string();
+            let view = in_view(&app);
+            assert!(
+                view.contains(&"wrote the migration".to_string()),
+                "search {needle:?} missed the entry: {view:?}"
+            );
+        }
+
+        // The date matches both entries; every other needle above is unique to one.
+        app.search_term = "loremind".to_string();
+        assert_eq!(in_view(&app), vec!["wrote the migration"]);
+        app.search_term = "no such thing".to_string();
+        assert!(in_view(&app).is_empty());
+    }
+
+    /// `e` pre-fills the Project field, and clearing it drops the project.
+    #[test]
+    fn editing_round_trips_the_project_field() {
+        let _guard = env_guard();
+        sandbox("project-edit");
+        let mut seeded = entry(0, "has a project");
+        seeded.project = Some("acme".to_string());
+        seed(vec![seeded], 1);
+
+        let mut app = App::new().unwrap();
+        select(&mut app, "has a project");
+        app.start_editing();
+        assert_eq!(app.input_project, "acme");
+
+        app.input_project = "beta".to_string();
+        app.submit_edit().unwrap();
+        assert_eq!(on_disk().entries[0].project, Some("beta".to_string()));
+
+        select(&mut app, "has a project");
+        app.start_editing();
+        app.input_project.clear();
+        app.submit_edit().unwrap();
+        assert_eq!(on_disk().entries[0].project, None);
+    }
 }

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -1,12 +1,82 @@
+use crossterm::event::KeyCode;
 use anyhow::Result;
 use chrono::{Duration, Local};
-use crate::storage::save_data;
+use crate::storage::PathStamp;
 use super::App;
-use super::types::ViewMode;
+use super::types::{ConfirmAction, InputMode, PendingConfirm, ViewMode};
 
 impl App {
+    /// Record the store's fingerprint, then load it. Stamp *before* the read —
+    /// stamping after records a fingerprint newer than the data and loses the update.
     pub(crate) fn reload(&mut self) -> Result<()> {
+        self.store_stamp = crate::storage::store_stamp();
         self.data = crate::storage::load_data()?;
+        Ok(())
+    }
+
+    /// Whether the store on disk still matches the snapshot in memory.
+    pub(crate) fn store_is_unchanged(&self) -> bool {
+        PathStamp::unchanged(self.store_stamp, crate::storage::store_stamp())
+    }
+
+    /// Pick up marks begun, ended or cancelled outside the TUI, on the same tick as
+    /// [`sync_from_store`](Self::sync_from_store). Unguarded by `input_mode` and by
+    /// `show_marks`, since the mark list is display-only; costs one `stat` per tick.
+    pub(crate) fn sync_from_marks(&mut self) {
+        let Some(dir) = crate::marks::mark_dir() else {
+            self.marks.clear();
+            return;
+        };
+        // Stamp before reading, as `reload` does.
+        let current = PathStamp::read(&dir);
+        if PathStamp::unchanged(self.marks_stamp, current) {
+            return;
+        }
+        self.marks_stamp = current;
+        self.marks = crate::marks::open_marks_in(&dir);
+    }
+
+    /// Pick up writes made outside the TUI, once per event-loop tick.
+    pub(crate) fn sync_from_store(&mut self) -> Result<()> {
+        // Replacing `data` mid-form would clobber the text being typed; a later tick
+        // picks the change up once the mode is Normal again.
+        if matches!(
+            self.input_mode,
+            InputMode::AddingEntry | InputMode::EditingEntry | InputMode::Searching
+        ) {
+            return Ok(());
+        }
+        if self.store_is_unchanged() {
+            return Ok(());
+        }
+
+        // The index means nothing once the data changes, so anchor on the id.
+        let previous_idx = self.table_state.selected();
+        let anchor_id =
+            previous_idx.and_then(|idx| self.filtered_entries().get(idx).map(|entry| entry.id));
+
+        self.reload()?;
+
+        let (anchored_idx, len) = {
+            let entries = self.filtered_entries();
+            let anchored = anchor_id.and_then(|id| entries.iter().position(|e| e.id == id));
+            (anchored, entries.len())
+        };
+        self.table_state.select(match (anchored_idx, previous_idx) {
+            (Some(idx), _) => Some(idx),
+            // The anchor is gone: stay as near the old position as the list allows.
+            (None, Some(idx)) => Some(idx.min(len.saturating_sub(1))),
+            (None, None) => None,
+        });
+
+        // `Confirm` is absent from the guard above, so the reload can carry away the
+        // entry a prompt is describing; drop the prompt rather than leave it asking.
+        let target_vanished = self
+            .pending_confirm
+            .is_some_and(|pending| self.data.get_entry(pending.entry_id).is_none());
+        if target_vanished {
+            self.cancel_confirm();
+        }
         Ok(())
     }
 
@@ -36,25 +106,140 @@ impl App {
         self.table_state.select(Some(i));
     }
 
-    pub(crate) fn delete_selected(&mut self) -> Result<()> {
-        let filtered = self.filtered_entries();
-        if let Some(idx) = self.table_state.selected() {
-            if idx < filtered.len() {
-                let entry_id = filtered[idx].id;
-                self.data.entries.retain(|e| e.id != entry_id);
-                save_data(&self.data)?;
-                let new_len = self.filtered_entries().len();
-                if idx >= new_len && new_len > 0 {
-                    self.table_state.select(Some(new_len - 1));
-                }
-            }
+    pub(crate) fn selected_entry(&self) -> Option<&crate::tracker::TimeEntry> {
+        let idx = self.table_state.selected()?;
+        self.filtered_entries().into_iter().nth(idx)
+    }
+
+    /// `Enter` on the table: show the entry in full, or nothing when none is selected.
+    pub(crate) fn open_detail(&mut self) {
+        if self.selected_entry().is_some() {
+            self.input_mode = InputMode::Detail;
+        }
+    }
+
+    /// Remove one entry by id, then keep the table cursor inside the shorter list.
+    /// By id and never by selection — see [`PendingConfirm`].
+    pub(crate) fn delete_entry(&mut self, entry_id: u64) -> Result<()> {
+        // An id that is already gone matches nothing — not an error.
+        self.mutate_store(|data| data.entries.retain(|e| e.id != entry_id))?;
+
+        let new_len = self.filtered_entries().len();
+        let past_the_end = self
+            .table_state
+            .selected()
+            .is_some_and(|idx| idx >= new_len);
+        if past_the_end && new_len > 0 {
+            self.table_state.select(Some(new_len - 1));
         }
         Ok(())
     }
 
+    /// `[t]` in the detail popover, once confirmed: split the entry at its idle.
+    /// Re-selects **by id**, since `selected_entry` is positional and the inserted
+    /// pieces shift the list.
+    pub(crate) fn trim_entry(&mut self, entry_id: u64) -> Result<()> {
+        let pieces = self.mutate_store(|data| data.split_at_idle(entry_id))?;
+        if pieces.is_empty() {
+            return Ok(());
+        }
+        self.select_by_id(entry_id);
+        Ok(())
+    }
+
+    /// Raise the prompt for a destructive action on the selected entry. **The target
+    /// id is captured here, now**, because the 250 ms poll can re-anchor the table
+    /// cursor while the prompt is up. A trim with no idle to trim raises nothing.
+    pub(crate) fn request_confirm(&mut self, action: ConfirmAction) {
+        let Some(entry) = self.selected_entry() else {
+            return;
+        };
+        let entry_id = entry.id;
+        if action == ConfirmAction::Trim && entry.trim_spans().is_empty() {
+            return;
+        }
+        self.pending_confirm = Some(PendingConfirm {
+            action,
+            entry_id,
+            from: self.input_mode,
+        });
+        self.input_mode = InputMode::Confirm;
+    }
+
+    /// Answer the prompt with a keypress — the whole body of the `Confirm` arm. `n`,
+    /// `Esc` and `Enter` are all a no; anything else is ignored and the prompt stays.
+    pub(crate) fn answer_confirm(&mut self, code: KeyCode) -> Result<()> {
+        match code {
+            KeyCode::Char(c) if self.confirms_pending(c) => self.confirm_pending()?,
+            KeyCode::Char('n') | KeyCode::Esc | KeyCode::Enter => self.cancel_confirm(),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Whether `c` is a yes: `y`, or the key that raised this prompt — so a `d` on a
+    /// trim prompt and a `t` on a delete prompt are both inert.
+    pub(crate) fn confirms_pending(&self, c: char) -> bool {
+        self.pending_confirm
+            .is_some_and(|pending| c == 'y' || c == pending.action.key())
+    }
+
+    /// The yes: act on **the captured id and nothing else**, or self-cancel when that
+    /// id is no longer in the store.
+    pub(crate) fn confirm_pending(&mut self) -> Result<()> {
+        let Some(pending) = self.pending_confirm.take() else {
+            return Ok(());
+        };
+        if self.data.get_entry(pending.entry_id).is_some() {
+            match pending.action {
+                ConfirmAction::Delete => self.delete_entry(pending.entry_id)?,
+                ConfirmAction::Trim => self.trim_entry(pending.entry_id)?,
+            }
+        }
+        self.close_confirm(pending.from);
+        Ok(())
+    }
+
+    /// The no: `n`, `Esc` and `Enter` all land here, and the store is untouched.
+    pub(crate) fn cancel_confirm(&mut self) {
+        let from = self
+            .pending_confirm
+            .take()
+            .map_or(InputMode::Normal, |pending| pending.from);
+        self.close_confirm(from);
+    }
+
+    /// Back to the mode that raised the prompt, or `Normal` if its view has emptied.
+    fn close_confirm(&mut self, from: InputMode) {
+        self.pending_confirm = None;
+        self.input_mode = if from == InputMode::Detail && self.selected_entry().is_none() {
+            InputMode::Normal
+        } else {
+            from
+        };
+    }
+
+    /// Put the table cursor on this id, or leave it alone if the view lacks that row.
+    pub(crate) fn select_by_id(&mut self, id: u64) {
+        if let Some(idx) = self.filtered_entries().iter().position(|e| e.id == id) {
+            self.table_state.select(Some(idx));
+        }
+    }
+
+    /// The detail popover's footer hints, in render order. `[t]` appears only on an
+    /// entry that has idle; `d` and `t` trail a `…` because they raise a confirmation.
+    pub(crate) fn detail_hints(&self) -> Vec<(&'static str, &'static str)> {
+        let mut hints = vec![("j/k", "move"), ("e", "edit"), ("d", "delete…")];
+        if self.selected_entry().is_some_and(|e| !e.idle.is_empty()) {
+            // "trim" is the user-facing verb, though the store call is `split_at_idle`.
+            hints.push(("t", "trim…"));
+        }
+        hints.push(("esc", "close"));
+        hints
+    }
+
     pub(crate) fn stop_active(&mut self) -> Result<()> {
-        self.data.stop_active();
-        save_data(&self.data)?;
+        self.mutate_store(|data| data.stop_active())?;
         Ok(())
     }
 

--- a/src/tui/panes.rs
+++ b/src/tui/panes.rs
@@ -1,0 +1,235 @@
+//! The collapsible Projects / Tags pane surface. Each pane offers the distinct
+//! values of the current view scope *before* any filter, with their match counts.
+
+use std::collections::HashMap;
+
+use super::App;
+use super::types::{Focus, Pane};
+use crate::tracker::TimeEntry;
+
+/// Most value rows a pane shows before it starts scrolling.
+const MAX_VISIBLE_VALUES: usize = 6;
+
+/// The number a collapsible surface puts on its top border, or `None` when it has
+/// nothing to say. With a cursor (`position` is `Some`) it is about *place*: hidden
+/// while every row fits, `position/total` once the list scrolls. Without one it is
+/// about *existence*: a bare `total` while all fit, `shown/total` once they do not.
+pub(crate) fn surface_count(
+    position: Option<usize>,
+    total: usize,
+    visible_rows: usize,
+) -> Option<String> {
+    match (position, total <= visible_rows) {
+        (_, true) if total == 0 => None,
+        (Some(_), true) => None,
+        (Some(position), false) => Some(format!("{}/{}", position + 1, total)),
+        (None, true) => Some(total.to_string()),
+        (None, false) => Some(format!("{}/{}", visible_rows, total)),
+    }
+}
+
+impl App {
+    /// The current view scope, before any filter. `filtered_entries` starts here.
+    pub(crate) fn scope_entries(&self) -> Vec<&TimeEntry> {
+        use super::types::ViewMode;
+        use crate::tracker::TimeData;
+        match self.view_mode {
+            ViewMode::All => self.data.entries.iter().collect(),
+            ViewMode::Day => self.data.entries_for_date(self.selected_date),
+            ViewMode::Week => {
+                let week_start = TimeData::week_start(self.selected_date);
+                self.data.entries_for_week(week_start)
+            }
+        }
+    }
+
+    pub(crate) fn pane_is_visible(&self, pane: Pane) -> bool {
+        match pane {
+            Pane::Projects => self.show_projects,
+            Pane::Tags => self.show_tags,
+        }
+    }
+
+    pub(crate) fn visible_panes(&self) -> Vec<Pane> {
+        [Pane::Projects, Pane::Tags]
+            .into_iter()
+            .filter(|pane| self.pane_is_visible(*pane))
+            .collect()
+    }
+
+    /// Distinct values with match counts, most used first, ties broken by name. No
+    /// project contributes no row; a tag repeated within one entry counts once.
+    pub(crate) fn pane_values(&self, pane: Pane) -> Vec<(String, usize)> {
+        let entries = self.scope_entries();
+        let mut counts: HashMap<&str, usize> = HashMap::new();
+        for entry in &entries {
+            match pane {
+                Pane::Projects => {
+                    let project = entry.project.as_deref().map(str::trim).unwrap_or("");
+                    if !project.is_empty() {
+                        *counts.entry(project).or_default() += 1;
+                    }
+                }
+                Pane::Tags => {
+                    let mut seen: Vec<&str> = Vec::new();
+                    for tag in &entry.tags {
+                        let tag = tag.trim();
+                        if tag.is_empty() || seen.contains(&tag) {
+                            continue;
+                        }
+                        seen.push(tag);
+                        *counts.entry(tag).or_default() += 1;
+                    }
+                }
+            }
+        }
+
+        let mut values: Vec<(String, usize)> = counts
+            .into_iter()
+            .map(|(value, count)| (value.to_string(), count))
+            .collect();
+        values.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        values
+    }
+
+    /// Height including borders, or 0 when both are hidden so the layout drops it.
+    pub(crate) fn pane_surface_height(&self) -> u16 {
+        let panes = self.visible_panes();
+        if panes.is_empty() {
+            return 0;
+        }
+        let longest = panes
+            .iter()
+            .map(|pane| self.pane_values(*pane).len())
+            .max()
+            .unwrap_or(0);
+        2 + longest.clamp(1, MAX_VISIBLE_VALUES) as u16
+    }
+
+    pub(crate) fn pane_cursor(&self, pane: Pane) -> usize {
+        let cursor = match pane {
+            Pane::Projects => self.project_cursor,
+            Pane::Tags => self.tag_cursor,
+        };
+        let len = self.pane_values(pane).len();
+        cursor.min(len.saturating_sub(1))
+    }
+
+    /// `position/total` once the values do not all fit in `visible_rows`.
+    pub(crate) fn pane_scroll_indicator(&self, pane: Pane, visible_rows: usize) -> Option<String> {
+        surface_count(
+            Some(self.pane_cursor(pane)),
+            self.pane_values(pane).len(),
+            visible_rows,
+        )
+    }
+
+    pub(crate) fn focused_pane(&self) -> Option<Pane> {
+        match self.focus {
+            Focus::Pane(pane) if self.pane_is_visible(pane) => Some(pane),
+            _ => None,
+        }
+    }
+
+    /// Show or hide a pane. Opening one focuses it; hiding the focused one falls
+    /// back to the other pane, or to the table.
+    pub(crate) fn toggle_pane(&mut self, pane: Pane) {
+        match pane {
+            Pane::Projects => self.show_projects = !self.show_projects,
+            Pane::Tags => self.show_tags = !self.show_tags,
+        }
+        if self.pane_is_visible(pane) {
+            self.focus = Focus::Pane(pane);
+        } else if self.focus == Focus::Pane(pane) {
+            self.focus = self
+                .visible_panes()
+                .first()
+                .copied()
+                .map_or(Focus::Table, Focus::Pane);
+        }
+    }
+
+    /// `Tab`: entries table → each visible pane, left to right → back.
+    pub(crate) fn cycle_focus(&mut self) {
+        self.shift_focus(1);
+    }
+
+    /// `Shift-Tab`: the exact inverse of [`cycle_focus`](Self::cycle_focus).
+    pub(crate) fn cycle_focus_back(&mut self) {
+        self.shift_focus(-1);
+    }
+
+    /// Walk the ring — table then visible panes, left to right — by `delta`, wrapping.
+    /// A focus off the ring reads as the table, so both directions recover.
+    fn shift_focus(&mut self, delta: isize) {
+        let mut order = vec![Focus::Table];
+        order.extend(self.visible_panes().into_iter().map(Focus::Pane));
+        let current = order.iter().position(|f| *f == self.focus).unwrap_or(0) as isize;
+        let len = order.len() as isize;
+        self.focus = order[(current + delta).rem_euclid(len) as usize];
+    }
+
+    pub(crate) fn pane_selection(&self, pane: Pane) -> &[String] {
+        match pane {
+            Pane::Projects => &self.selected_projects,
+            Pane::Tags => &self.selected_tags,
+        }
+    }
+
+    /// Exact match: both sides come from [`pane_values`](Self::pane_values), though
+    /// the filter predicates themselves stay case-insensitive.
+    pub(crate) fn pane_value_is_selected(&self, pane: Pane, value: &str) -> bool {
+        self.pane_selection(pane).iter().any(|v| v == value)
+    }
+
+    /// `Enter` in the focused pane: toggle the value under its cursor. Returns false
+    /// when no pane has focus, so `Enter` falls through to the detail popover.
+    pub(crate) fn toggle_pane_value(&mut self) -> bool {
+        let Some(pane) = self.focused_pane() else {
+            return false;
+        };
+        let cursor = self.pane_cursor(pane);
+        let Some((value, _)) = self.pane_values(pane).into_iter().nth(cursor) else {
+            return true;
+        };
+        let selection = match pane {
+            Pane::Projects => &mut self.selected_projects,
+            Pane::Tags => &mut self.selected_tags,
+        };
+        match selection.iter().position(|v| v == &value) {
+            Some(pos) => {
+                selection.remove(pos);
+            }
+            None => selection.push(value),
+        }
+        // The row that was selected is very unlikely to still be the same row.
+        self.table_state.select(Some(0));
+        true
+    }
+
+    /// `j` in the focused pane, or false so the caller moves the table instead.
+    pub(crate) fn pane_next(&mut self) -> bool {
+        self.move_pane_cursor(1)
+    }
+
+    pub(crate) fn pane_previous(&mut self) -> bool {
+        self.move_pane_cursor(-1)
+    }
+
+    fn move_pane_cursor(&mut self, delta: isize) -> bool {
+        let Some(pane) = self.focused_pane() else {
+            return false;
+        };
+        let len = self.pane_values(pane).len();
+        if len == 0 {
+            return true;
+        }
+        let current = self.pane_cursor(pane) as isize;
+        let next = (current + delta).rem_euclid(len as isize) as usize;
+        match pane {
+            Pane::Projects => self.project_cursor = next,
+            Pane::Tags => self.tag_cursor = next,
+        }
+        true
+    }
+}

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,36 +1,89 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 use chrono::{Duration, Local, NaiveDate};
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Tabs},
+    widgets::{
+        Block, Borders, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
+        Tabs,
+    },
 };
 use crate::tracker::TimeData;
 use super::{theme, App};
-use super::types::{InputField, InputMode, ViewMode};
+use super::types::{ConfirmAction, InputField, InputMode, Pane, ViewMode};
+
+/// The cursor row marker for every list that has one. One constant, so a list's
+/// reserved width can never be out of step with what gets drawn.
+const CURSOR_MARKER: &str = ">> ";
+
+/// A named vertical row of the main layout. Some rows are conditional, so
+/// `LayoutRows` resolves a row to its `Rect` by name rather than by index.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LayoutRow {
+    Status,
+    Marks,
+    Panes,
+    Tabs,
+    Search,
+    Content,
+    Summary,
+    Footer,
+}
+
+/// The rows actually laid out this frame, paired with their areas.
+struct LayoutRows {
+    names: Vec<LayoutRow>,
+    areas: Rc<[Rect]>,
+}
+
+impl LayoutRows {
+    /// `plan` is the rows top to bottom; a conditional row is left out entirely.
+    fn split(area: Rect, plan: Vec<(LayoutRow, Constraint)>) -> Self {
+        let (names, constraints): (Vec<LayoutRow>, Vec<Constraint>) = plan.into_iter().unzip();
+        let areas = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(area);
+        Self { names, areas }
+    }
+
+    /// The row's area, or `None` when this frame omits it.
+    fn get(&self, row: LayoutRow) -> Option<Rect> {
+        self.names
+            .iter()
+            .position(|name| *name == row)
+            .map(|idx| self.areas[idx])
+    }
+
+    /// For the rows that are always part of the layout.
+    fn area(&self, row: LayoutRow) -> Rect {
+        self.get(row)
+            .unwrap_or_else(|| panic!("layout row {row:?} is always present"))
+    }
+}
 
 pub fn ui(f: &mut Frame, app: &mut App) {
-    let show_search = app.is_searching();
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(if show_search {
-            vec![
-                Constraint::Length(3), // Status
-                Constraint::Length(3), // Tabs + date info
-                Constraint::Length(3), // Search bar
-                Constraint::Min(10),   // Main content
-                Constraint::Length(3), // Footer
-            ]
-        } else {
-            vec![
-                Constraint::Length(3), // Status
-                Constraint::Length(3), // Tabs + date info
-                Constraint::Min(10),   // Main content
-                Constraint::Length(3), // Footer
-            ]
-        })
-        .split(f.area());
+    let mut plan = vec![(LayoutRow::Status, Constraint::Length(3))];
+    let marks_height = app.marks_surface_height();
+    if marks_height > 0 {
+        plan.push((LayoutRow::Marks, Constraint::Length(marks_height)));
+    }
+    let pane_height = app.pane_surface_height();
+    if pane_height > 0 {
+        plan.push((LayoutRow::Panes, Constraint::Length(pane_height)));
+    }
+    plan.push((LayoutRow::Tabs, Constraint::Length(3))); // Tabs + date info
+    if app.is_searching() {
+        plan.push((LayoutRow::Search, Constraint::Length(3)));
+    }
+    plan.push((LayoutRow::Content, Constraint::Min(10)));
+    let summary_height = app.summary_surface_height();
+    if summary_height > 0 {
+        plan.push((LayoutRow::Summary, Constraint::Length(summary_height)));
+    }
+    plan.push((LayoutRow::Footer, Constraint::Length(3)));
+    let rows = LayoutRows::split(f.area(), plan);
 
-    // Status header
     let (status_text, status_style) = match app.data.active_entry() {
         Some(entry) => (
             format!(
@@ -54,9 +107,16 @@ pub fn ui(f: &mut Frame, app: &mut App) {
                 .border_style(Style::default().fg(theme::border()))
                 .title(Span::styled(" Status ", Style::default().fg(theme::title()))),
         );
-    f.render_widget(header, chunks[0]);
+    f.render_widget(header, rows.area(LayoutRow::Status));
 
-    // View tabs
+    if let Some(area) = rows.get(LayoutRow::Marks) {
+        render_marks_surface(f, app, area);
+    }
+
+    if let Some(area) = rows.get(LayoutRow::Panes) {
+        render_pane_surface(f, app, area);
+    }
+
     let tab_titles = vec!["[1] Day", "[2] Week", "[3] All"];
     let selected_tab = match app.view_mode {
         ViewMode::Day => 0,
@@ -89,32 +149,33 @@ pub fn ui(f: &mut Frame, app: &mut App) {
                     Style::default().fg(theme::highlight()),
                 )),
         );
-    f.render_widget(tabs, chunks[1]);
+    f.render_widget(tabs, rows.area(LayoutRow::Tabs));
 
-    let (content_idx, footer_idx) = if show_search { (3, 4) } else { (2, 3) };
-
-    if show_search {
-        render_search_bar(f, app, chunks[2]);
+    if let Some(area) = rows.get(LayoutRow::Search) {
+        render_search_bar(f, app, area);
     }
 
+    let content = rows.area(LayoutRow::Content);
     if app.input_mode == InputMode::AddingEntry || app.input_mode == InputMode::EditingEntry {
-        render_entry_form(f, app, chunks[content_idx]);
+        render_entry_form(f, app, content);
     } else if app.view_mode == ViewMode::Week {
         let content_chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Length(25), Constraint::Min(40)])
-            .split(chunks[content_idx]);
+            .split(content);
         render_weekly_breakdown(f, app, content_chunks[0]);
         render_entries_table(f, app, content_chunks[1]);
     } else {
-        render_entries_table(f, app, chunks[content_idx]);
+        render_entries_table(f, app, content);
     }
 
-    // Footer: left = hints (clips), right = "? : help" (always visible)
-    let (total, total_label) = if app.is_searching() && !app.search_term.is_empty() {
+    if let Some(area) = rows.get(LayoutRow::Summary) {
+        render_summary_surface(f, app, area);
+    }
+
+    // Footer: left = hints (clips), right = the key legend (never clips).
+    let (total, total_label) = if app.total_is_filtered() {
         (app.filtered_total(), "Filtered: ")
-    } else if app.is_tag_filtering() {
-        (app.filtered_total(), "Tagged: ")
     } else {
         let t = match app.view_mode {
             ViewMode::All => app.data.today_total(),
@@ -128,23 +189,28 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     };
 
     let total_str = crate::duration::format(total);
+    let footer = rows.area(LayoutRow::Footer);
     let footer_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme::border()));
-    let footer_inner = footer_block.inner(chunks[footer_idx]);
-    f.render_widget(footer_block, chunks[footer_idx]);
+    let footer_inner = footer_block.inner(footer);
+    f.render_widget(footer_block, footer);
 
-    const HELP_WIDTH: u16 = 11;
-    let hints_width = footer_inner.width.saturating_sub(HELP_WIDTH);
+    // Hand-counted against the spans below — update it when they change.
+    const KEYS_WIDTH: u16 = 24; // " | P/T/A | Tab | ?: help"
+    let hints_width = footer_inner.width.saturating_sub(KEYS_WIDTH);
     let footer_chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(hints_width), Constraint::Length(HELP_WIDTH)])
+        .constraints([Constraint::Length(hints_width), Constraint::Length(KEYS_WIDTH)])
         .split(footer_inner);
 
-    let hints = Paragraph::new(Line::from(vec![
+    let hint_spans = vec![
         Span::styled(format!(" {}", total_label), Style::default().fg(theme::title())),
         Span::styled(total_str, Style::default().fg(theme::highlight()).bold()),
         Span::styled(" | ", Style::default().fg(theme::border())),
+        // Detail goes first; this zone clips from the right at 80 columns.
+        Span::styled("Enter", Style::default().fg(theme::accent())),
+        Span::styled(": detail | ", Style::default().fg(theme::inactive())),
         Span::styled("t", Style::default().fg(theme::accent())),
         Span::styled(": today | ", Style::default().fg(theme::inactive())),
         Span::styled("/", Style::default().fg(theme::accent())),
@@ -154,37 +220,106 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         Span::styled("e", Style::default().fg(theme::accent())),
         Span::styled(": edit | ", Style::default().fg(theme::inactive())),
         Span::styled("d", Style::default().fg(theme::accent())),
-        Span::styled(": del | ", Style::default().fg(theme::inactive())),
+        Span::styled(": del… | ", Style::default().fg(theme::inactive())),
         Span::styled("s", Style::default().fg(theme::accent())),
         Span::styled(": stop", Style::default().fg(theme::inactive())),
-    ]));
+    ];
+    let hints = Paragraph::new(Line::from(hint_spans));
     f.render_widget(hints, footer_chunks[0]);
 
-    let help_hint = Paragraph::new(Line::from(vec![
+    // A surface's key is accented while it is open, dim while hidden.
+    let key_style = |on: bool| {
+        Style::default().fg(if on {
+            theme::accent()
+        } else {
+            theme::inactive()
+        })
+    };
+    let panes_open = !app.visible_panes().is_empty();
+    let keys_hint = Paragraph::new(Line::from(vec![
+        Span::styled(" | ", Style::default().fg(theme::border())),
+        Span::styled("P", key_style(app.show_projects)),
+        Span::styled("/", Style::default().fg(theme::border())),
+        Span::styled("T", key_style(app.show_tags)),
+        Span::styled("/", Style::default().fg(theme::border())),
+        Span::styled("A", key_style(app.show_marks)),
+        Span::styled(" | ", Style::default().fg(theme::border())),
+        Span::styled("Tab", key_style(panes_open)),
         Span::styled(" | ", Style::default().fg(theme::border())),
         Span::styled("?", Style::default().fg(theme::accent())),
         Span::styled(": help", Style::default().fg(theme::inactive())),
     ]));
-    f.render_widget(help_hint, footer_chunks[1]);
+    f.render_widget(keys_hint, footer_chunks[1]);
 
-    if app.input_mode == InputMode::Help {
-        render_help_popup(f);
+    match app.input_mode {
+        InputMode::Help => render_help_popup(f),
+        InputMode::Detail => render_detail_popup(f, app),
+        InputMode::Confirm => render_confirm_popup(f, app),
+        _ => {}
     }
 }
 
-pub fn render_help_popup(f: &mut Frame) {
+/// The only place any modal overlay is positioned or framed: a centred, cleared
+/// `Rect` with `title` and `marker` on its top border and `hints` on its last row.
+/// Returns the content area between the two.
+fn render_overlay(
+    f: &mut Frame,
+    width: u16,
+    height: u16,
+    title: Span<'_>,
+    marker: Span<'_>,
+    hints: Line<'_>,
+) -> Rect {
     let area = f.area();
-    let popup_width = 52u16.min(area.width.saturating_sub(4));
-    let popup_height = 26u16.min(area.height.saturating_sub(4));
+    let width = width.min(area.width.saturating_sub(4));
+    let height = height.min(area.height.saturating_sub(2));
     let popup_area = Rect {
-        x: (area.width.saturating_sub(popup_width)) / 2,
-        y: (area.height.saturating_sub(popup_height)) / 2,
-        width: popup_width,
-        height: popup_height,
+        x: (area.width.saturating_sub(width)) / 2,
+        y: (area.height.saturating_sub(height)) / 2,
+        width,
+        height,
     };
 
+    // `Clear` first, or the widgets underneath show through the popup's gaps.
     f.render_widget(Clear, popup_area);
+    let overlay_style = Style::default().bg(theme::OVERLAY_BG);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::accent()))
+        .title(title)
+        .title_top(Line::from(marker).right_aligned())
+        .style(overlay_style);
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
 
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner);
+    f.render_widget(Paragraph::new(hints).style(overlay_style), rows[1]);
+    rows[0]
+}
+
+/// ` esc close `-style hints, spelled out rather than glyphed.
+fn overlay_hints(pairs: &[(&'static str, &'static str)]) -> Line<'static> {
+    let mut spans = vec![Span::raw(" ")];
+    for (i, (k, what)) in pairs.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled("  ", Style::default().fg(theme::border())));
+        }
+        spans.push(Span::styled(
+            *k,
+            Style::default().fg(theme::accent()).bold(),
+        ));
+        spans.push(Span::styled(
+            format!(" {}", what),
+            Style::default().fg(theme::inactive()),
+        ));
+    }
+    Line::from(spans)
+}
+
+pub fn render_help_popup(f: &mut Frame) {
     fn key(k: &'static str) -> Span<'static> {
         Span::styled(k, Style::default().fg(theme::accent()).bold())
     }
@@ -207,32 +342,490 @@ pub fn render_help_popup(f: &mut Frame) {
         heading("  Entries"),
         Line::from(vec![key("  a"), sep("        add entry (uses browsed date)")]),
         Line::from(vec![key("  e"), sep("        edit selected entry")]),
-        Line::from(vec![key("  d"), sep("        delete selected entry")]),
+        Line::from(vec![key("  d"), sep("        delete selected entry (asks first)")]),
         Line::from(vec![key("  s"), sep("        stop active entry")]),
+        Line::from(vec![key("  Enter"), sep("    entry detail")]),
+        // A path, not a key: the trim is live only while the popover is open.
+        Line::from(vec![
+            key("  Enter, t"),
+            sep(" trim idle from the entry (asks first)"),
+        ]),
         Line::from(Span::raw("")),
         heading("  Search & Filter"),
-        Line::from(vec![key("  /"), sep("        search entries")]),
-        Line::from(vec![key("  f"), sep("        filter by selected tags")]),
+        // This section's key column is two wider, for `Shift-Tab`.
+        Line::from(vec![key("  /"), sep("          search any field")]),
+        Line::from(vec![key("  Shift-P"), sep("    Projects pane on / off")]),
+        Line::from(vec![key("  Shift-T"), sep("    Tags pane on / off")]),
+        Line::from(vec![key("  Tab"), sep("        focus table / panes")]),
+        Line::from(vec![key("  Shift-Tab"), sep("  focus panes in reverse")]),
+        Line::from(vec![key("  Enter"), sep("      filter on the pane value")]),
         Line::from(Span::raw("")),
         heading("  Other"),
+        Line::from(vec![key("  Shift-A"), sep("  agent phases on / off")]),
+        Line::from(vec![key("  Shift-S"), sep("  project summary on / off")]),
         Line::from(vec![key("  o"), sep("        toggle sort order")]),
         Line::from(vec![key("  r"), sep("        reload data from disk")]),
         Line::from(vec![key("  ?"), sep("        toggle this help")]),
         Line::from(vec![key("  q / Esc"), sep("  quit")]),
     ];
 
-    let popup = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(theme::accent()))
-                .title(Span::styled(
-                    " Keybindings ",
-                    Style::default().fg(theme::highlight()).bold(),
-                )),
+    // Sized from the content, so adding a binding cannot push the last one out.
+    let content = render_overlay(
+        f,
+        52,
+        lines.len() as u16 + 3,
+        Span::styled(
+            " Keybindings ",
+            Style::default().fg(theme::highlight()).bold(),
+        ),
+        Span::styled(" ? ", Style::default().fg(theme::inactive())),
+        overlay_hints(&[("esc", "close")]),
+    );
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(theme::OVERLAY_BG)),
+        content,
+    );
+}
+
+/// A destructive action waiting for a yes. **It names the entry**, from the
+/// *captured* id and never `selected_entry()`, which the poll can move. The trim
+/// outcome comes from `TimeEntry::trim_spans` — never a second copy of that here.
+fn render_confirm_popup(f: &mut Frame, app: &App) {
+    let Some(pending) = app.pending_confirm else {
+        return;
+    };
+    // Gone from under the prompt: draw nothing rather than the wrong entry.
+    let Some(entry) = app.data.get_entry(pending.entry_id) else {
+        return;
+    };
+
+    let value = Style::default().fg(Color::White);
+    let dim = Style::default().fg(theme::inactive());
+
+    // The subject line, so a cursor on the wrong row shows up here.
+    let mut subject = vec![Span::styled(format!("  {}", entry.description), value)];
+    if let Some(project) = entry.project.as_deref().filter(|p| !p.trim().is_empty()) {
+        subject.push(Span::styled(format!(" ({})", project), dim));
+    }
+    subject.push(Span::styled(
+        format!("  {}", entry.format_duration()),
+        Style::default().fg(theme::accent()).bold(),
+    ));
+    let mut lines = vec![Line::from(subject)];
+
+    if pending.action == ConfirmAction::Trim {
+        let pieces = entry.trim_spans();
+        let kept = pieces.iter().fold(Duration::zero(), |acc, (from, to)| {
+            acc + to.signed_duration_since(*from)
+        });
+        let durations: Vec<String> = pieces
+            .iter()
+            .map(|(from, to)| crate::duration::format(to.signed_duration_since(*from)))
+            .collect();
+        lines.push(Line::from(vec![
+            Span::styled("  -> ", dim),
+            Span::styled(format!("{} pieces: ", durations.len()), value),
+            Span::styled(durations.join(", "), Style::default().fg(theme::accent())),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("     ", dim),
+            Span::styled(
+                crate::duration::format(entry.duration() - kept),
+                Style::default().fg(theme::accent()).bold(),
+            ),
+            Span::styled(" removed", dim),
+        ]));
+    }
+
+    // Sized from the content but bounded, so it never becomes a full-width banner.
+    let title = format!(" {} entry #{}? ", pending.action.verb(), entry.id);
+    let widest = lines
+        .iter()
+        .map(Line::width)
+        .chain(std::iter::once(title.chars().count()))
+        .max()
+        .unwrap_or(0);
+    let width = (widest as u16 + 4).clamp(32, 72);
+
+    let content = render_overlay(
+        f,
+        width,
+        lines.len() as u16 + 3,
+        Span::styled(title, Style::default().fg(theme::highlight()).bold()),
+        Span::styled(" confirm ", Style::default().fg(theme::inactive())),
+        // Exactly what the `Confirm` arm binds, `enter` among the cancels.
+        overlay_hints(&[
+            (pending.action.confirm_keys(), "yes"),
+            ("n / esc / enter", "cancel"),
+        ]),
+    );
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(theme::OVERLAY_BG)),
+        content,
+    );
+}
+
+/// The selected entry, every field wrapped rather than truncated.
+fn render_detail_popup(f: &mut Frame, app: &App) {
+    let Some(entry) = app.selected_entry() else {
+        return;
+    };
+
+    // Wide enough for the longest label, so values line up.
+    const LABEL: usize = 12;
+    let width = 80u16.min(f.area().width.saturating_sub(4)).max(24) as usize;
+    // Hand-counted: 2 borders + 2 indent + label + 2 right margin.
+    let value_width = width.saturating_sub(2 + 2 + LABEL + 2).max(8);
+
+    fn label(text: &str) -> Span<'_> {
+        Span::styled(
+            format!("  {:<width$}", text, width = LABEL),
+            Style::default().fg(theme::title()),
         )
-        .style(Style::default().bg(Color::Rgb(28, 28, 28)));
-    f.render_widget(popup, popup_area);
+    }
+
+    /// Greedy word wrap on spaces; a word longer than the line is left long.
+    fn wrap(text: &str, width: usize) -> Vec<String> {
+        let mut lines: Vec<String> = Vec::new();
+        for word in text.split_whitespace() {
+            match lines.last_mut() {
+                Some(line) if line.chars().count() + 1 + word.chars().count() <= width => {
+                    line.push(' ');
+                    line.push_str(word);
+                }
+                _ => lines.push(word.to_string()),
+            }
+        }
+        if lines.is_empty() {
+            lines.push(String::new());
+        }
+        lines
+    }
+
+    /// One labelled field, continuation lines indented to the value column.
+    fn field(name: &str, value: &str, style: Style, value_width: usize) -> Vec<Line<'static>> {
+        wrap(value, value_width)
+            .into_iter()
+            .enumerate()
+            .map(|(i, text)| {
+                let head = if i == 0 {
+                    format!("  {:<width$}", name, width = LABEL)
+                } else {
+                    " ".repeat(2 + LABEL)
+                };
+                Line::from(vec![
+                    Span::styled(head, Style::default().fg(theme::title())),
+                    Span::styled(text, style),
+                ])
+            })
+            .collect()
+    }
+
+    let value = Style::default().fg(Color::White);
+    let tags = if entry.tags.is_empty() {
+        "—".to_string()
+    } else {
+        entry.format_tags()
+    };
+    let mut lines: Vec<Line> = vec![Line::from(Span::raw(""))];
+    lines.extend(field(
+        "Project",
+        entry.project.as_deref().unwrap_or("—"),
+        Style::default().fg(theme::accent()),
+        value_width,
+    ));
+    lines.extend(field(
+        "Tags",
+        &tags,
+        Style::default().fg(theme::highlight()),
+        value_width,
+    ));
+    lines.extend(field("Date", &entry.format_date(), value, value_width));
+    lines.extend(field(
+        "Start",
+        &entry.format_start_time(),
+        value,
+        value_width,
+    ));
+    // `format_end_time` is already the em dash while an entry runs.
+    lines.extend(field("End", &entry.format_end_time(), value, value_width));
+    lines.extend(field(
+        "Duration",
+        &entry.format_duration(),
+        Style::default().fg(theme::accent()).bold(),
+        value_width,
+    ));
+    // Idle rows only when the entry has any.
+    for (i, gap) in entry.idle.iter().enumerate() {
+        lines.push(Line::from(vec![
+            label(if i == 0 { "Idle" } else { "" }),
+            Span::styled(gap.format_span(), Style::default().fg(theme::inactive())),
+        ]));
+    }
+    lines.push(Line::from(Span::raw("")));
+    lines.push(Line::from(label("Description")));
+    // The description gets the full inner width, not the value column.
+    for text in wrap(&entry.description, width.saturating_sub(2 + 2 + 2).max(8)) {
+        lines.push(Line::from(vec![Span::raw("  "), Span::styled(text, value)]));
+    }
+    lines.push(Line::from(Span::raw("")));
+
+    let (marker, marker_style) = if entry.is_active() {
+        (" active ", Style::default().fg(theme::active()).bold())
+    } else {
+        (" logged ", Style::default().fg(theme::inactive()))
+    };
+    let content = render_overlay(
+        f,
+        width as u16,
+        lines.len() as u16 + 3,
+        Span::styled(
+            format!(" Entry #{} ", entry.id),
+            Style::default().fg(theme::highlight()).bold(),
+        ),
+        Span::styled(marker, marker_style),
+        // Every hint here is bound in the `InputMode::Detail` arm.
+        overlay_hints(&app.detail_hints()),
+    );
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(theme::OVERLAY_BG)),
+        content,
+    );
+}
+
+/// The `Marks` surface: `project/issue phase`, start time and elapsed, newest
+/// first. Rows come from `crate::marks` so the CLI and the TUI cannot disagree;
+/// elapsed is asked for per frame, so it counts up between directory reads.
+fn render_marks_surface(f: &mut Frame, app: &App, area: Rect) {
+    /// Narrowest the label column gets, so short labels still line their times up.
+    const LABEL_WIDTH: usize = 18;
+
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::border()))
+        .title(Span::styled(
+            " Agents (A) ",
+            Style::default().fg(theme::title()),
+        ));
+    let inner = block.inner(area);
+
+    // Driven off the rows this frame really has, not a constant.
+    if let Some(count) = app.marks_count(inner.height as usize) {
+        block = block.title_top(
+            Line::from(Span::styled(
+                format!(" {} ", count),
+                Style::default().fg(theme::inactive()),
+            ))
+            .right_aligned(),
+        );
+    }
+
+    let marks = app.visible_marks();
+    // One label column for the whole box, so the times read as columns.
+    let label_width = marks
+        .iter()
+        .map(|mark| mark.label().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(LABEL_WIDTH);
+
+    let lines: Vec<Line> = if marks.is_empty() {
+        vec![Line::from(Span::styled(
+            " no phases in progress",
+            Style::default().fg(theme::inactive()).italic(),
+        ))]
+    } else {
+        marks
+            .iter()
+            .map(|mark| {
+                let label = mark.label();
+                let pad = " ".repeat(label_width.saturating_sub(label.chars().count()));
+                Line::from(vec![
+                    Span::styled(
+                        format!(" {}{}", label, pad),
+                        Style::default().fg(Color::White),
+                    ),
+                    Span::styled(
+                        format!(" {}", mark.started_at()),
+                        Style::default().fg(theme::inactive()),
+                    ),
+                    Span::styled(
+                        format!("   ({})", mark.elapsed()),
+                        Style::default().fg(theme::highlight()),
+                    ),
+                ])
+            })
+            .collect()
+    };
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// The `Summary` surface: how the current scope split across projects. The title
+/// bar's `all projects` marker keeps its words in both filter states and changes
+/// only colour, off the same predicate the footer's total uses.
+fn render_summary_surface(f: &mut Frame, app: &App, area: Rect) {
+    /// Narrowest the project column gets, so short names still line their totals up.
+    const LABEL_WIDTH: usize = 14;
+    /// The three right-flushed number columns. Fixed, not content-derived, so a
+    /// re-scope that widens one figure cannot shift them.
+    const TOTAL_WIDTH: usize = 8;
+    const COUNT_WIDTH: usize = 5;
+    const SHARE_WIDTH: usize = 6;
+
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::border()))
+        .title(Span::styled(
+            " Summary (S) ",
+            Style::default().fg(theme::title()),
+        ));
+    let inner = block.inner(area);
+
+    let marker_style = Style::default().fg(if app.total_is_filtered() {
+        theme::highlight()
+    } else {
+        theme::title()
+    });
+    block = block.title_top(
+        Line::from(Span::styled(
+            format!(" {} ", app.summary_marker(inner.height as usize)),
+            marker_style,
+        ))
+        .right_aligned(),
+    );
+
+    let rows = app.visible_project_summary(inner.height as usize);
+    // One project column for the whole box, so the numbers read as columns.
+    let label_width = rows
+        .iter()
+        .map(|row| row.project.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(LABEL_WIDTH);
+
+    let lines: Vec<Line> = if rows.is_empty() {
+        vec![Line::from(Span::styled(
+            " nothing in scope",
+            Style::default().fg(theme::inactive()).italic(),
+        ))]
+    } else {
+        rows.iter()
+            .map(|row| {
+                let pad = " ".repeat(label_width.saturating_sub(row.project.chars().count()));
+                Line::from(vec![
+                    Span::styled(
+                        format!(" {}{}", row.project, pad),
+                        Style::default().fg(Color::White),
+                    ),
+                    Span::styled(
+                        format!("{:>TOTAL_WIDTH$}", crate::duration::format(row.total)),
+                        Style::default().fg(theme::highlight()),
+                    ),
+                    Span::styled(
+                        format!("{:>COUNT_WIDTH$}", row.entries),
+                        Style::default().fg(theme::inactive()),
+                    ),
+                    Span::styled(
+                        format!("{:>SHARE_WIDTH$}", format!("{}%", row.share)),
+                        Style::default().fg(theme::accent()),
+                    ),
+                ])
+            })
+            .collect()
+    };
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// The pane surface: both panes side by side, or the single open one full width.
+fn render_pane_surface(f: &mut Frame, app: &App, area: Rect) {
+    let panes = app.visible_panes();
+    let share = panes.len() as u32;
+    let constraints: Vec<Constraint> = panes.iter().map(|_| Constraint::Ratio(1, share)).collect();
+    let areas = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(constraints)
+        .split(area);
+    for (pane, pane_area) in panes.iter().zip(areas.iter()) {
+        render_pane(f, app, *pane, *pane_area);
+    }
+}
+
+fn render_pane(f: &mut Frame, app: &App, pane: Pane, area: Rect) {
+    let focused = app.focused_pane() == Some(pane);
+    let values = app.pane_values(pane);
+
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(if focused {
+            theme::accent()
+        } else {
+            theme::border()
+        }))
+        .title(Span::styled(
+            pane.title(),
+            Style::default().fg(if focused {
+                theme::highlight()
+            } else {
+                theme::title()
+            }),
+        ));
+
+    let inner = block.inner(area);
+
+    // On the top border, which is dead space: costs no row and no inner column.
+    if let Some(indicator) = app.pane_scroll_indicator(pane, inner.height as usize) {
+        block = block.title_top(
+            Line::from(Span::styled(
+                format!(" {} ", indicator),
+                Style::default().fg(theme::inactive()),
+            ))
+            .right_aligned(),
+        );
+    }
+
+    // The marker is a gutter on every row, so it comes off the rows' layout width.
+    let width = (inner.width as usize).saturating_sub(CURSOR_MARKER.len());
+    let items: Vec<ListItem> = if values.is_empty() {
+        vec![ListItem::new(Span::styled(
+            " nothing in view",
+            Style::default().fg(theme::inactive()).italic(),
+        ))]
+    } else {
+        values
+            .iter()
+            .map(|(value, count)| {
+                // The lead column carries the selection mark, so it costs no width.
+                let selected = app.pane_value_is_selected(pane, value);
+                let mark = if selected { "•" } else { " " };
+                let count = count.to_string();
+                let used = 1 + value.chars().count() + count.chars().count() + 1;
+                let gap = width.saturating_sub(used).max(1);
+                let value_style = if selected {
+                    Style::default().fg(theme::accent()).bold()
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!("{}{}", mark, value), value_style),
+                    Span::raw(" ".repeat(gap)),
+                    Span::styled(count, Style::default().fg(theme::highlight())),
+                ]))
+            })
+            .collect()
+    };
+
+    // Shown with or without focus: it says where this pane's cursor will resume.
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().bg(theme::selected_bg()))
+        .highlight_symbol(CURSOR_MARKER);
+    let mut state = ListState::default();
+    if !values.is_empty() {
+        state.select(Some(app.pane_cursor(pane)));
+    }
+    f.render_stateful_widget(list, area, &mut state);
 }
 
 fn render_search_bar(f: &mut Frame, app: &App, area: Rect) {
@@ -304,6 +897,7 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
         .margin(2)
         .constraints([
             Constraint::Length(3), // Description
+            Constraint::Length(3), // Project
             Constraint::Length(3), // Tags
             Constraint::Length(3), // Duration
             Constraint::Length(3), // Start Time
@@ -340,28 +934,37 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
         chunks[0],
     );
     f.render_widget(
+        Paragraph::new(app.input_project.as_str())
+            .style(Style::default().fg(Color::White))
+            .block(field_block(
+                " Project (optional: single name, e.g. acme) ",
+                active == InputField::Project,
+            )),
+        chunks[1],
+    );
+    f.render_widget(
         Paragraph::new(app.input_tags.as_str())
             .style(Style::default().fg(Color::White))
             .block(field_block(" Tags (space-separated, e.g., work meeting) ", active == InputField::Tags)),
-        chunks[1],
+        chunks[2],
     );
     f.render_widget(
         Paragraph::new(app.input_duration.as_str())
             .style(Style::default().fg(Color::White))
             .block(field_block(" Duration (optional: 1h30m, 45m, 2h) ", active == InputField::Duration)),
-        chunks[2],
+        chunks[3],
     );
     f.render_widget(
         Paragraph::new(app.input_start_time.as_str())
             .style(Style::default().fg(Color::White))
             .block(field_block(" Start Time (e.g. 9am, 14:30, 25/03 9.30am) ", active == InputField::StartTime)),
-        chunks[3],
+        chunks[4],
     );
     f.render_widget(
         Paragraph::new(app.input_end_time.as_str())
             .style(Style::default().fg(Color::White))
             .block(field_block(" End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ", active == InputField::EndTime)),
-        chunks[4],
+        chunks[5],
     );
 
     let help = Paragraph::new(Line::from(vec![
@@ -379,9 +982,8 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
             .border_style(Style::default().fg(theme::border()))
             .title(Span::styled(form_title, Style::default().fg(theme::highlight()))),
     );
-    f.render_widget(help, chunks[5]);
+    f.render_widget(help, chunks[6]);
 
-    // Cursor: use cursor_pos for correct mid-text cursor placement
     let cursor_text_width = |text: &str, pos: usize| -> u16 {
         let byte_idx = text.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(text.len());
         Line::from(&text[..byte_idx]).width() as u16
@@ -391,21 +993,25 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
             chunks[0].x + cursor_text_width(&app.input_description, app.cursor_pos) + 1,
             chunks[0].y + 1,
         ),
-        InputField::Tags => (
-            chunks[1].x + cursor_text_width(&app.input_tags, app.cursor_pos) + 1,
+        InputField::Project => (
+            chunks[1].x + cursor_text_width(&app.input_project, app.cursor_pos) + 1,
             chunks[1].y + 1,
         ),
-        InputField::Duration => (
-            chunks[2].x + cursor_text_width(&app.input_duration, app.cursor_pos) + 1,
+        InputField::Tags => (
+            chunks[2].x + cursor_text_width(&app.input_tags, app.cursor_pos) + 1,
             chunks[2].y + 1,
         ),
-        InputField::StartTime => (
-            chunks[3].x + cursor_text_width(&app.input_start_time, app.cursor_pos) + 1,
+        InputField::Duration => (
+            chunks[3].x + cursor_text_width(&app.input_duration, app.cursor_pos) + 1,
             chunks[3].y + 1,
         ),
-        InputField::EndTime => (
-            chunks[4].x + cursor_text_width(&app.input_end_time, app.cursor_pos) + 1,
+        InputField::StartTime => (
+            chunks[4].x + cursor_text_width(&app.input_start_time, app.cursor_pos) + 1,
             chunks[4].y + 1,
+        ),
+        InputField::EndTime => (
+            chunks[5].x + cursor_text_width(&app.input_end_time, app.cursor_pos) + 1,
+            chunks[5].y + 1,
         ),
     };
     f.set_cursor_position((cursor_x, cursor_y));
@@ -487,17 +1093,10 @@ fn entry_row(entry: &crate::tracker::TimeEntry, stripe: bool) -> Row<'_> {
         Style::default()
     };
 
-    let end_str = entry
-        .end_time
-        .map(|t| t.format("%H:%M").to_string())
-        .unwrap_or_else(|| "—".to_string());
-
     Row::new(vec![
-        Cell::from(entry.start_time.format("%Y-%m-%d").to_string())
-            .style(Style::default().fg(theme::title())),
-        Cell::from(entry.start_time.format("%H:%M").to_string())
-            .style(Style::default().fg(theme::accent())),
-        Cell::from(end_str).style(Style::default().fg(theme::inactive())),
+        Cell::from(entry.format_date()).style(Style::default().fg(theme::title())),
+        Cell::from(entry.format_start_time()).style(Style::default().fg(theme::accent())),
+        Cell::from(entry.format_end_time()).style(Style::default().fg(theme::inactive())),
         Cell::from(entry.description.clone()),
         Cell::from(entry.format_tags()).style(Style::default().fg(theme::highlight())),
         Cell::from(entry.format_duration()).style(Style::default().fg(dur_color)),
@@ -591,28 +1190,30 @@ fn render_entries_table(f: &mut Frame, app: &mut App, area: Rect) {
             (rows, app.table_state.selected())
         };
 
-    let title = if app.is_tag_filtering() {
-        format!(
-            " Entries [filtered: {}] ",
-            app.tag_filter
-                .iter()
-                .map(|t| format!("#{}", t))
-                .collect::<Vec<_>>()
-                .join(" ")
-        )
+    // `(tt)` and `#impl`, the CLI's own sigils, so the title needs no legend.
+    let title = if app.is_filtering() {
+        let values: Vec<String> = app
+            .selected_projects
+            .iter()
+            .map(|p| format!("({})", p))
+            .chain(app.selected_tags.iter().map(|t| format!("#{}", t)))
+            .collect();
+        format!(" Entries [filtered: {}] ", values.join(" "))
     } else {
         " Entries ".to_string()
     };
 
+    // `Fill(1)` and `Min(12)` share what the fixed columns leave, so both grow with
+    // the terminal. The fixed widths are exactly what they render, with no padding.
     let table = Table::new(
         rows,
         [
-            Constraint::Length(12),
-            Constraint::Length(7),
-            Constraint::Length(7),
+            Constraint::Length(10),
+            Constraint::Length(5),
+            Constraint::Length(5),
             Constraint::Min(12),
-            Constraint::Length(14),
-            Constraint::Length(9),
+            Constraint::Fill(1),
+            Constraint::Length(8),
             Constraint::Length(3),
         ],
     )
@@ -624,7 +1225,7 @@ fn render_entries_table(f: &mut Frame, app: &mut App, area: Rect) {
             .title(Span::styled(title, Style::default().fg(theme::title()))),
     )
     .row_highlight_style(Style::default().bg(theme::selected_bg()))
-    .highlight_symbol(">> ");
+    .highlight_symbol(CURSOR_MARKER);
 
     let mut render_state = TableState::default().with_selected(visual_selected);
     f.render_stateful_widget(table, area, &mut render_state);

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -1,32 +1,24 @@
 use chrono::Duration;
-use crate::tracker::TimeData;
 use super::App;
-use super::types::{InputMode, SortOrder, ViewMode};
+use super::types::{InputMode, SortOrder};
 
 impl App {
     pub(crate) fn filtered_entries(&self) -> Vec<&crate::tracker::TimeEntry> {
-        let mut entries: Vec<_> = match self.view_mode {
-            ViewMode::All => self.data.entries.iter().collect(),
-            ViewMode::Day => self.data.entries_for_date(self.selected_date),
-            ViewMode::Week => {
-                let week_start = TimeData::week_start(self.selected_date);
-                self.data.entries_for_week(week_start)
-            }
-        };
+        let mut entries = self.scope_entries();
 
         match self.sort_order {
             SortOrder::NewestFirst => entries.sort_by(|a, b| b.start_time.cmp(&a.start_time)),
             SortOrder::OldestFirst => entries.sort_by(|a, b| a.start_time.cmp(&b.start_time)),
         }
 
-        let entries = if self.tag_filter.is_empty() {
-            entries
-        } else {
-            entries
-                .into_iter()
-                .filter(|e| e.has_any_tag(&self.tag_filter))
-                .collect()
-        };
+        // OR within a pane, AND across the two; an empty set is not a filter.
+        let entries: Vec<_> = entries
+            .into_iter()
+            .filter(|e| {
+                self.selected_projects.is_empty() || e.has_any_project(&self.selected_projects)
+            })
+            .filter(|e| self.selected_tags.is_empty() || e.has_any_tag(&self.selected_tags))
+            .collect();
 
         if self.search_term.is_empty() {
             entries
@@ -34,10 +26,7 @@ impl App {
             let search_lower = self.search_term.to_lowercase();
             entries
                 .into_iter()
-                .filter(|e| {
-                    e.description.to_lowercase().contains(&search_lower)
-                        || e.tags.iter().any(|t| t.to_lowercase().contains(&search_lower))
-                })
+                .filter(|e| e.matches_search(&search_lower))
                 .collect()
         }
     }
@@ -52,44 +41,21 @@ impl App {
         !self.search_term.is_empty() || self.input_mode == InputMode::Searching
     }
 
-    pub(crate) fn is_tag_filtering(&self) -> bool {
-        !self.tag_filter.is_empty()
+    /// Whether a pane selection is narrowing the view.
+    pub(crate) fn is_filtering(&self) -> bool {
+        !self.selected_projects.is_empty() || !self.selected_tags.is_empty()
     }
 
-    pub(crate) fn toggle_tag_filter(&mut self, tag: &str) {
-        let tag = tag.to_string();
-        if let Some(pos) = self.tag_filter.iter().position(|t| t == &tag) {
-            self.tag_filter.remove(pos);
-        } else {
-            self.tag_filter.push(tag);
-        }
+    /// Whether the footer's figure is narrowed — pane selection or search term.
+    /// The Summary marker reads the same predicate, so the two cannot disagree.
+    pub(crate) fn total_is_filtered(&self) -> bool {
+        !self.search_term.is_empty() || self.is_filtering()
+    }
+
+    pub(crate) fn clear_filters(&mut self) {
+        self.selected_projects.clear();
+        self.selected_tags.clear();
         self.table_state.select(Some(0));
-    }
-
-    pub(crate) fn clear_tag_filter(&mut self) {
-        self.tag_filter.clear();
-        self.table_state.select(Some(0));
-    }
-
-    pub(crate) fn filter_by_selected_tags(&mut self) {
-        let tags = {
-            let filtered = self.filtered_entries();
-            self.table_state.selected().and_then(|idx| {
-                filtered.get(idx).map(|entry| entry.tags.clone())
-            })
-        };
-
-        if let Some(tags) = tags {
-            if tags.is_empty() {
-                return;
-            }
-            if self.tag_filter == tags {
-                self.clear_tag_filter();
-            } else {
-                self.tag_filter = tags;
-                self.table_state.select(Some(0));
-            }
-        }
     }
 
     pub(crate) fn start_search(&mut self) {

--- a/src/tui/summary.rs
+++ b/src/tui/summary.rs
@@ -1,0 +1,122 @@
+//! Per-project totals for the current view scope, and the state behind the
+//! collapsible `Summary` surface. Display-only; `render.rs` draws it.
+//!
+//! **This folds the scope, not the view:** [`App::project_summary`] reads
+//! `scope_entries()`, never `filtered_entries()`, so a filter leaves it alone.
+
+use std::collections::HashMap;
+
+use chrono::Duration;
+
+use super::App;
+use super::panes::surface_count;
+
+/// Most project rows the surface shows before the rest live in the border count.
+const MAX_VISIBLE_PROJECTS: usize = 6;
+
+/// The standing statement on the title bar, after the scope word.
+const ALL_PROJECTS: &str = "all projects";
+
+/// The label for entries with no project; counted so the rows sum to the scope.
+pub(crate) const NO_PROJECT: &str = "(no project)";
+
+/// One row: a project, its time in the scope, its entry count and its share.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProjectTotal {
+    /// The name as stored, or [`NO_PROJECT`].
+    pub(crate) project: String,
+    /// Raw; the caller applies `duration::format`.
+    pub(crate) total: Duration,
+    pub(crate) entries: usize,
+    /// Percent of the scope total, rounded, and **not** fudged to sum to 100.
+    pub(crate) share: u16,
+}
+
+impl App {
+    /// Per-project totals for the current view scope, largest first. Folds
+    /// [`scope_entries`](Self::scope_entries), so it is about the period rather than
+    /// the rows on screen. An empty scope gives an empty list.
+    pub(crate) fn project_summary(&self) -> Vec<ProjectTotal> {
+        let entries = self.scope_entries();
+        let mut totals: HashMap<&str, (Duration, usize)> = HashMap::new();
+        for entry in &entries {
+            // Empty-after-trim counts as absent, as the form and `pane_values` do.
+            let project = entry.project.as_deref().map(str::trim).unwrap_or("");
+            let key = if project.is_empty() {
+                NO_PROJECT
+            } else {
+                project
+            };
+            let row = totals.entry(key).or_insert((Duration::zero(), 0));
+            row.0 += entry.duration();
+            row.1 += 1;
+        }
+
+        let scope_total: i64 = totals.values().map(|(d, _)| d.num_seconds()).sum();
+        let mut rows: Vec<ProjectTotal> = totals
+            .into_iter()
+            .map(|(project, (total, entries))| ProjectTotal {
+                project: project.to_string(),
+                total,
+                entries,
+                share: share_of(total, scope_total),
+            })
+            .collect();
+        // Ties broken by name, so the order is stable rather than the HashMap's.
+        rows.sort_by(|a, b| {
+            b.total
+                .cmp(&a.total)
+                .then_with(|| a.project.cmp(&b.project))
+        });
+        rows
+    }
+
+    /// Height including borders, or 0 while hidden so the layout drops the row.
+    pub(crate) fn summary_surface_height(&self) -> u16 {
+        if !self.show_summary {
+            return 0;
+        }
+        2 + self.project_summary().len().clamp(1, MAX_VISIBLE_PROJECTS) as u16
+    }
+
+    pub(crate) fn visible_project_summary(&self, visible_rows: usize) -> Vec<ProjectTotal> {
+        let mut rows = self.project_summary();
+        rows.truncate(visible_rows);
+        rows
+    }
+
+    /// `shown/total` once more projects exist than fit, else `None`.
+    pub(crate) fn summary_count(&self, visible_rows: usize) -> Option<String> {
+        let total = self.project_summary().len();
+        if total <= visible_rows {
+            return None;
+        }
+        surface_count(None, total, visible_rows)
+    }
+
+    /// The title bar's right half: `day · all projects`, plus `· 6/9` when rows are
+    /// off screen. Present in **both** filter states — only its colour changes.
+    pub(crate) fn summary_marker(&self, visible_rows: usize) -> String {
+        let mut marker = format!("{} · {}", self.view_mode.label(), ALL_PROJECTS);
+        if let Some(count) = self.summary_count(visible_rows) {
+            marker.push_str(" · ");
+            marker.push_str(&count);
+        }
+        marker
+    }
+
+    /// `Shift-S`: show or hide the surface.
+    pub(crate) fn toggle_summary(&mut self) {
+        self.show_summary = !self.show_summary;
+    }
+}
+
+/// `part` as a whole-percent share of `whole`, in seconds; a zero `whole` is 0%.
+fn share_of(part: Duration, whole: i64) -> u16 {
+    if whole <= 0 {
+        return 0;
+    }
+    let part = part.num_seconds().max(0);
+    // Round half up in integers, so the same input always gives the same point.
+    (((part * 200) / whole + 1) / 2) as u16
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -6,6 +6,9 @@ use crate::config;
 /// Not user-configurable: used only for the week-view day-separator rows.
 pub const DAY_HEADER_BG: Color = Color::Rgb(38, 48, 68); // Dark blue for day separators
 
+/// Not user-configurable: used only for the background of modal popups.
+pub const OVERLAY_BG: Color = Color::Rgb(28, 28, 28);
+
 pub struct Theme {
     pub accent: Color,
     pub active: Color,

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -13,6 +13,15 @@ impl ViewMode {
             ViewMode::Week => "Weekly View",
         }
     }
+
+    /// The one-word scope name, for naming the period inline: `day · all projects`.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ViewMode::All => "all",
+            ViewMode::Day => "day",
+            ViewMode::Week => "week",
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -22,15 +31,91 @@ pub enum InputMode {
     EditingEntry,
     Searching,
     Help,
+    /// The selected entry's detail popover. Modal, but the list stays live
+    /// underneath: j/k move the table cursor and the popover re-reads the selection.
+    Detail,
+    /// A destructive action waiting for a yes; `App.pending_confirm` says which.
+    Confirm,
+}
+
+/// Which destructive action a prompt is standing in front of. Each knows the key
+/// that raised it, since that same key is what confirms it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ConfirmAction {
+    Delete,
+    Trim,
+}
+
+impl ConfirmAction {
+    /// The key that opens this prompt, and therefore also confirms it.
+    pub fn key(self) -> char {
+        match self {
+            ConfirmAction::Delete => 'd',
+            ConfirmAction::Trim => 't',
+        }
+    }
+
+    /// The yes keys as the hint row spells them, originating key first.
+    pub fn confirm_keys(self) -> &'static str {
+        match self {
+            ConfirmAction::Delete => "d / y",
+            ConfirmAction::Trim => "t / y",
+        }
+    }
+
+    /// The prompt's verb, capitalised. **`Trim`, never "split"** — the store
+    /// mechanic is `split_at_idle`, the user-facing verb is trim on every surface.
+    pub fn verb(self) -> &'static str {
+        match self {
+            ConfirmAction::Delete => "Delete",
+            ConfirmAction::Trim => "Trim",
+        }
+    }
+}
+
+/// A destructive action asked for and not yet answered. **`entry_id` is captured
+/// when the prompt is raised, not read back when it is answered** — the 250 ms poll
+/// can move the table cursor while the prompt is on screen.
+#[derive(Clone, Copy, PartialEq)]
+pub struct PendingConfirm {
+    pub action: ConfirmAction,
+    pub entry_id: u64,
+    /// The mode to restore on cancel.
+    pub from: InputMode,
 }
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum InputField {
     Description,
+    Project,
     Tags,
     StartTime,
     EndTime,
     Duration,
+}
+
+/// One of the two collapsible value pickers above the tabs row.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Pane {
+    Projects,
+    Tags,
+}
+
+impl Pane {
+    /// Block title, with the toggle key so the surface documents itself.
+    pub fn title(self) -> &'static str {
+        match self {
+            Pane::Projects => " Projects (P) ",
+            Pane::Tags => " Tags (T) ",
+        }
+    }
+}
+
+/// What `j`/`k` move in `InputMode::Normal`; `Tab` cycles through it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Focus {
+    Table,
+    Pane(Pane),
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/tests/agent_end.rs
+++ b/tests/agent_end.rs
@@ -1,0 +1,646 @@
+//! `tt agent item` and `tt agent end`: a one-shot log, and closing an open mark on
+//! the span derived from its timestamps and heartbeats.
+//!
+//! Observables are `cli::log`'s stdout line and the sandbox's `data.json`; every
+//! expectation is derived from the fixture, never written down. Sandbox: [`common`].
+
+mod common;
+
+use common::{Case, clock, logged_duration, now};
+
+// --- item ------------------------------------------------------------------
+
+#[test]
+fn item_logs_the_three_convention_tags() {
+    let case = Case::new("item-tags");
+    let run = case.run(&[
+        "item",
+        "loremind",
+        "77",
+        "impl",
+        "store/links boundary",
+        "43",
+    ]);
+    run.assert_status(0);
+
+    let store = case.store();
+    assert_eq!(store.entries.len(), 1, "one entry");
+    let entry = &store.entries[0];
+    assert_eq!(entry.description, "store/links boundary");
+    assert_eq!(entry.project.as_deref(), Some("loremind"));
+    assert_eq!(entry.tags, ["loremind/77", "impl", "agent"]);
+}
+
+#[test]
+fn item_drops_the_item_tag_for_the_sentinel_issue() {
+    let case = Case::new("item-sentinel");
+    case.run(&["item", "loremind", "-", "plan", "sketched the shape", "20"])
+        .assert_status(0);
+
+    let entry = &case.store().entries[0];
+    assert_eq!(entry.tags, ["plan", "agent"]);
+    // The project is a real field with its own axis — never a tag.
+    assert!(
+        !entry.tags.iter().any(|tag| tag == "loremind"),
+        "a bare project tag was emitted: {:?}",
+        entry.tags
+    );
+}
+
+#[test]
+fn item_rounds_the_minutes_to_a_quarter_hour() {
+    let case = Case::new("item-rounding");
+    let run = case.run(&["item", "proj", "7", "impl", "did the thing", "43"]);
+    run.assert_status(0);
+    run.assert_stdout_has(&logged_duration(43));
+
+    let floored = Case::new("item-rounding-floor");
+    let run = floored.run(&["item", "proj", "7", "impl", "a quick errand", "2"]);
+    run.assert_status(0);
+    run.assert_stdout_has(&logged_duration(2));
+}
+
+/// A summary that merely mentions an issue number does not become a tag.
+#[test]
+fn item_strips_a_stray_hash_from_the_summary() {
+    let case = Case::new("item-stray-hash");
+    case.run(&[
+        "item",
+        "proj",
+        "7",
+        "impl",
+        "closed #12 with the C# bridge",
+        "30",
+    ])
+    .assert_status(0);
+
+    let entry = &case.store().entries[0];
+    assert_eq!(entry.description, "closed 12 with the C# bridge");
+    assert_eq!(entry.tags, ["proj/7", "impl", "agent"]);
+}
+
+#[test]
+fn item_creates_no_mark_file() {
+    let case = Case::new("item-no-mark");
+    case.run(&["item", "proj", "7", "impl", "did the thing", "30"])
+        .assert_status(0);
+    assert_eq!(case.mark_count(), 0, "no mark was written");
+    assert!(!case.beats_file("proj.7.impl").exists());
+}
+
+/// A plain error message and exit 64, not clap's 2 and its usage block.
+#[test]
+fn item_with_non_numeric_minutes_exits_64() {
+    let case = Case::new("item-bad-minutes");
+    let run = case.run(&["item", "proj", "7", "impl", "did the thing", "half an hour"]);
+    run.assert_status(64);
+    run.assert_stderr_has("minutes must be a whole number, got 'half an hour'");
+    // The store already exists by then, so the assertion is on the entries.
+    assert!(
+        case.store().entries.is_empty(),
+        "a rejected item logged something"
+    );
+}
+
+#[test]
+fn item_without_minutes_exits_64() {
+    let case = Case::new("item-no-minutes");
+    let run = case.run(&["item", "proj", "7", "impl", "did the thing"]);
+    run.assert_status(64);
+    run.assert_stderr_has("usage: tt agent item");
+}
+
+#[test]
+fn item_leaves_an_open_mark_alone() {
+    let case = Case::new("item-leaves-marks");
+    case.write_mark("proj.7.impl", now() - 600);
+    case.run(&["item", "proj", "7", "impl", "something else entirely", "30"])
+        .assert_status(0);
+    assert!(case.mark_file("proj.7.impl").is_file(), "the mark survived");
+}
+
+// --- end -------------------------------------------------------------------
+
+#[test]
+fn end_derives_minutes_from_the_mark() {
+    let case = Case::new("end-derives");
+    let elapsed = 1800;
+    case.write_mark("proj.7.impl", now() - elapsed);
+
+    let run = case.run(&["end", "proj", "7", "impl", "did the thing"]);
+    run.assert_status(0);
+    run.assert_stdout_has(&format!(
+        "\"did the thing\" (proj) [#proj/7 #impl #agent] {}",
+        logged_duration(elapsed / 60)
+    ));
+    assert!(!case.mark_file("proj.7.impl").exists());
+}
+
+#[test]
+fn a_successful_end_clears_the_mark_and_its_beats() {
+    let case = Case::new("end-clears");
+    case.write_mark("proj.7.impl", now());
+    case.run(&["touch", "proj", "7", "impl"]).assert_status(0);
+    assert!(case.beats_file("proj.7.impl").is_file());
+
+    case.run(&["end", "proj", "7", "impl", "did the thing"])
+        .assert_status(0);
+    assert!(!case.mark_file("proj.7.impl").exists());
+    assert!(!case.beats_file("proj.7.impl").exists());
+}
+
+#[test]
+fn an_explicit_trailing_minutes_argument_overrides_the_mark() {
+    let case = Case::new("end-explicit");
+    case.write_mark("proj.7.impl", now() - 1800);
+
+    let run = case.run(&["end", "proj", "7", "impl", "did the thing", "90"]);
+    run.assert_status(0);
+    // 90, not the mark's 30: the argument skips the timestamps entirely.
+    run.assert_stdout_has(&logged_duration(90));
+}
+
+#[test]
+fn end_without_a_mark_exits_64() {
+    let case = Case::new("end-unmarked");
+    let run = case.run(&["end", "proj", "7", "impl", "did the thing"]);
+    run.assert_status(64);
+    run.assert_stderr_has("no mark for proj/7 impl");
+    assert!(case.store().entries.is_empty(), "nothing was logged");
+}
+
+/// 64 and not clap's 2, so `summary` must stay an `Option<String>` checked by hand.
+#[test]
+fn end_without_a_summary_exits_64() {
+    let case = Case::new("end-no-summary");
+    case.write_mark("proj.7.impl", now());
+
+    let run = case.run(&["end", "proj", "7", "impl"]);
+    run.assert_status(64);
+    run.assert_stderr_has("need a summary");
+    assert!(case.store().entries.is_empty(), "nothing was logged");
+    assert!(case.mark_file("proj.7.impl").is_file(), "the mark survived");
+}
+
+// --- gaps ------------------------------------------------------------------
+
+#[test]
+fn steady_beats_log_the_full_span_however_long_it_ran() {
+    let case = Case::new("gaps-steady");
+    let step = 600;
+    let start = now() - step * 24;
+    let beats: Vec<i64> = (1..=24).map(|i| start + i * step).collect();
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &beats);
+
+    let run = case.run(&["end", "proj", "7", "impl", "long active session"]);
+    run.assert_status(0);
+    // Measured to the last beat, which the fixture puts exactly at the span's end.
+    let last_beat = *beats.last().unwrap();
+    run.assert_stdout_has(&logged_duration((last_beat - start) / 60));
+}
+
+/// A 110-minute phase with an 80-minute hole, shared so no case restates a number.
+struct GapFixture {
+    hole: (i64, i64),
+    /// The measured span, unrounded.
+    minutes: i64,
+    /// The hole, unrounded.
+    hole_minutes: i64,
+    /// The last heartbeat, where `end` measures to and so where the entry must end.
+    last_beat: i64,
+}
+
+impl GapFixture {
+    /// The measured span as logged, through the same rounding `end` applies.
+    fn minutes_rounded(&self) -> i64 {
+        common::round_quarter(self.minutes)
+    }
+}
+
+fn gap_fixture(case: &Case) -> GapFixture {
+    let start = now() - 110 * 60;
+    let beats = [start + 10 * 60, start + 30 * 60, start + 110 * 60];
+    case.write_mark("proj.12.plan", start);
+    case.beats_at("proj.12.plan", &beats);
+    GapFixture {
+        hole: (beats[1], beats[2]),
+        minutes: (beats[2] - start) / 60,
+        hole_minutes: (beats[2] - beats[1]) / 60,
+        last_beat: beats[2],
+    }
+}
+
+#[test]
+fn a_single_over_threshold_hole_is_refused_and_named() {
+    let case = Case::new("gaps-refused");
+    let fixture = gap_fixture(&case);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing"]);
+    run.assert_status(65);
+    run.assert_stderr_has(&format!(
+        "proj/12 plan has an {}m gap",
+        fixture.hole_minutes
+    ));
+    run.assert_stderr_has(&format!(
+        "({}-{})",
+        clock(fixture.hole.0),
+        clock(fixture.hole.1)
+    ));
+    // Both figures unrounded, and `--trim`'s derived from the fixture, not restated.
+    run.assert_stderr_has(&format!(
+        "--full logs {}m, --trim logs {}m",
+        fixture.minutes,
+        fixture.minutes - fixture.hole_minutes
+    ));
+    run.assert_stderr_has("or pass the real minutes instead.");
+    assert!(case.store().entries.is_empty(), "nothing was logged");
+    // A refusal leaves the mark and its beats intact so the phase can still close.
+    assert!(case.mark_file("proj.12.plan").is_file());
+    assert!(case.beats_file("proj.12.plan").is_file());
+}
+
+/// 70 minutes takes `a`, where the shared fixture's 80 takes `an`.
+#[test]
+fn the_refusal_names_the_gap_with_the_right_article() {
+    let case = Case::new("gaps-article");
+    let start = now() - 100 * 60;
+    let beats = [start + 10 * 60, start + 80 * 60, start + 100 * 60];
+    case.write_mark("proj.12.plan", start);
+    case.beats_at("proj.12.plan", &beats);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing"]);
+    run.assert_status(65);
+    // The whole line, so the shape agents read stays pinned as well as the article.
+    run.assert_stderr_has(&format!(
+        "tt: proj/12 plan has a 70m gap ({}-{})",
+        clock(beats[0]),
+        clock(beats[1])
+    ));
+}
+
+#[test]
+fn full_accepts_a_flagged_span() {
+    let case = Case::new("gaps-full");
+    let fixture = gap_fixture(&case);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing", "--full"]);
+    run.assert_status(0);
+    run.assert_stdout_has(&logged_duration(fixture.minutes));
+    assert!(!case.mark_file("proj.12.plan").exists());
+    assert!(!case.beats_file("proj.12.plan").exists());
+}
+
+#[test]
+fn explicit_minutes_still_win_over_a_flagged_span() {
+    let case = Case::new("gaps-explicit");
+    gap_fixture(&case);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing", "30"]);
+    run.assert_status(0);
+    run.assert_stdout_has(&logged_duration(30));
+}
+
+#[test]
+fn silence_before_the_first_beat_is_a_gap_too() {
+    let case = Case::new("gaps-leading");
+    let start = now() - 120 * 60;
+    let first = start + 110 * 60;
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &[first, first + 300]);
+
+    let run = case.run(&["end", "proj", "7", "impl", "late first beat"]);
+    run.assert_status(65);
+    run.assert_stderr_has(&format!("gap ({}-{})", clock(start), clock(first)));
+}
+
+#[test]
+fn the_threshold_is_configurable() {
+    let case = Case::new("gaps-threshold");
+    let span = 30 * 60;
+    let start = now() - span;
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &[start + span]);
+
+    // Passed explicitly, since the harness clears the environment.
+    let run = case.run_with_env(
+        &[
+            "end",
+            "proj",
+            "7",
+            "impl",
+            "half an hour, no beats inside it",
+        ],
+        &[("TT_MAX_GAP_MINUTES", "10")],
+    );
+    run.assert_status(65);
+    run.assert_stderr_has(&format!("{}m gap", span / 60));
+}
+
+/// An unvouched phase — no heartbeats at all — is judged as one silence across its
+/// whole span, against its own longer threshold, so 90 minutes of it still logs.
+#[test]
+fn an_unvouched_span_under_the_unvouched_threshold_logs() {
+    let case = Case::new("gaps-unvouched-under");
+    let span = 90;
+    case.write_mark("proj.7.impl", now() - span * 60);
+
+    let run = case.run(&["end", "proj", "7", "impl", "no evidence either way"]);
+    run.assert_status(0);
+    run.assert_stdout_has(&logged_duration(span));
+}
+
+/// The other side of that threshold: refused, naming the whole span as the gap.
+#[test]
+fn an_unvouched_span_over_the_unvouched_threshold_is_flagged() {
+    let case = Case::new("gaps-unvouched-over");
+    let start = now() - 150 * 60;
+    case.write_mark("proj.7.impl", start);
+
+    let run = case.run(&["end", "proj", "7", "impl", "no evidence either way"]);
+    run.assert_status(65);
+    run.assert_stderr_has(&format!("gap ({}-", clock(start)));
+    assert!(case.store().entries.is_empty(), "nothing was logged");
+}
+
+/// Beating once does not buy the longer allowance: 46 minutes, one over.
+#[test]
+fn a_beaten_phase_is_still_judged_at_the_interior_threshold() {
+    let case = Case::new("gaps-beaten-boundary");
+    let start = now() - 60 * 60;
+    let beats = [start + 5 * 60, start + 51 * 60, start + 60 * 60];
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &beats);
+
+    let run = case.run(&["end", "proj", "7", "impl", "beat, then went quiet"]);
+    run.assert_status(65);
+    run.assert_stderr_has(&format!(
+        "has a 46m gap ({}-{})",
+        clock(beats[0]),
+        clock(beats[1])
+    ));
+}
+
+#[test]
+fn the_unvouched_threshold_is_configurable() {
+    let case = Case::new("gaps-unvouched-threshold");
+    let span = 30;
+    case.write_mark("proj.7.impl", now() - span * 60);
+
+    // Passed explicitly, since the harness clears the environment.
+    let run = case.run_with_env(
+        &["end", "proj", "7", "impl", "half an hour of nothing"],
+        &[("TT_MAX_UNVOUCHED_MINUTES", "10")],
+    );
+    run.assert_status(65);
+    run.assert_stderr_has(&format!("{span}m gap"));
+}
+
+// --- idle and trim ---------------------------------------------------------
+//
+// `cli::log` takes the intervals as values and splits inside the same store
+// transaction, so these assert on the epoch pairs in the sandbox's `data.json`.
+
+/// Two holes in one phase, so the *order* of the recorded intervals matters.
+struct TwoGapFixture {
+    holes: [(i64, i64); 2],
+}
+
+fn two_gap_fixture(case: &Case) -> TwoGapFixture {
+    let start = now() - 150 * 60;
+    let beats = [
+        start + 10 * 60,
+        start + 70 * 60,
+        start + 80 * 60,
+        start + 140 * 60,
+    ];
+    case.write_mark("proj.12.plan", start);
+    case.beats_at("proj.12.plan", &beats);
+    TwoGapFixture {
+        holes: [(beats[0], beats[1]), (beats[2], beats[3])],
+    }
+}
+
+#[test]
+fn every_flagged_gap_becomes_an_idle_interval_in_chronological_order() {
+    let case = Case::new("idle-order");
+    let fixture = two_gap_fixture(&case);
+
+    case.run(&["end", "proj", "12", "plan", "planned the thing", "--full"])
+        .assert_status(0);
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1, "--full never splits");
+    // One interval per fabricated hole, counted from the fixture.
+    let recorded: Vec<(i64, i64)> = entries[0].idle.iter().map(|gap| gap.epochs()).collect();
+    assert_eq!(recorded, fixture.holes, "the fixture's holes, in order");
+}
+
+#[test]
+fn a_phase_with_no_flagged_gap_records_none_and_no_trim() {
+    let case = Case::new("idle-none");
+    let step = 600;
+    let start = now() - step * 24;
+    let beats: Vec<i64> = (1..=24).map(|i| start + i * step).collect();
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &beats);
+
+    case.run(&["end", "proj", "7", "impl", "long active session"])
+        .assert_status(0);
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1, "nothing was split");
+    assert!(entries[0].idle.is_empty(), "no silence to record");
+}
+
+/// `--full` asks for no split: the entry stands whole with its interval on it.
+#[test]
+fn trim_adds_the_split_and_full_does_not() {
+    let case = Case::new("idle-full-no-trim");
+    let fixture = gap_fixture(&case);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing", "--full"]);
+    run.assert_status(0);
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1, "--full asks for no split");
+    assert_eq!(
+        entries[0]
+            .idle
+            .iter()
+            .map(|gap| gap.epochs())
+            .collect::<Vec<_>>(),
+        vec![fixture.hole],
+        "the silence is recorded, not removed"
+    );
+    assert_eq!(entries[0].seconds(), fixture.minutes_rounded() * 60);
+}
+
+/// A mark-derived entry is pinned to the mark's timeline, not to `now`: `end`
+/// measures to the last heartbeat, so the entry and its `idle` epochs end there.
+#[test]
+fn a_mark_derived_entry_ends_at_the_marks_last_heartbeat() {
+    let case = Case::new("anchor-last-beat");
+    let fixture = gap_fixture(&case);
+
+    case.run(&["end", "proj", "12", "plan", "planned the thing", "--full"])
+        .assert_status(0);
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1);
+    let entry = &entries[0];
+    assert_eq!(
+        entry
+            .end_time
+            .expect("a logged entry is closed")
+            .timestamp(),
+        fixture.last_beat,
+        "the entry ends at the last beat, not at now"
+    );
+
+    // Every recorded interval falls inside the entry that carries it, inclusive.
+    let start = entry.start_time.timestamp();
+    let end = fixture.last_beat;
+    for gap in &entry.idle {
+        let (from, to) = gap.epochs();
+        assert!(
+            from >= start && to <= end,
+            "idle {from}-{to} escaped the entry {start}-{end}"
+        );
+    }
+    assert!(!entry.idle.is_empty(), "the fixture's hole was recorded");
+}
+
+/// The **stored span** is the assertion: stdout's figure and an empty `idle` are
+/// both satisfied by a split that subtracted twice and left a fragment behind.
+#[test]
+fn trim_subtracts_each_gap_exactly_once_and_reports_what_survived() {
+    let case = Case::new("idle-trim");
+    let fixture = gap_fixture(&case);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing", "--trim"]);
+    run.assert_status(0);
+
+    // `split_at_idle` does the subtraction, so what survives is the *rounded* span
+    // minus the hole.
+    let survives = fixture.minutes_rounded() - fixture.hole_minutes;
+    let entries = case.store().entries;
+    let stored: i64 = entries.iter().map(|entry| entry.seconds()).sum();
+    assert_eq!(
+        stored,
+        survives * 60,
+        "the store holds the span minus the hole, once: {entries:?}"
+    );
+    // A piece so short it is not work — a fragment plus a full piece would sum right.
+    assert!(
+        entries.iter().all(|entry| entry.seconds() >= 60),
+        "a sub-second fragment survived the split: {entries:?}"
+    );
+    // And it reports what it stored, not what it was asked for.
+    assert_eq!(run.logged_minutes(), survives);
+
+    // The surviving piece ends where the silence began, not near `now`.
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.end_time.expect("closed").timestamp())
+            .max(),
+        Some(fixture.hole.0),
+        "the last surviving piece ends at the start of the hole"
+    );
+    // A split on every interval consumes them all; `--full` keeps the evidence.
+    assert!(
+        entries.iter().all(|entry| entry.idle.is_empty()),
+        "the split did not consume the interval: {entries:?}"
+    );
+    assert!(!case.mark_file("proj.12.plan").exists());
+    assert!(!case.beats_file("proj.12.plan").exists());
+}
+
+/// The flag and the override are given *together*, and the override still wins.
+#[test]
+fn explicit_minutes_beat_trim_as_well_and_record_nothing() {
+    let case = Case::new("idle-explicit");
+    gap_fixture(&case);
+
+    let run = case.run(&[
+        "end",
+        "proj",
+        "12",
+        "plan",
+        "planned the thing",
+        "30",
+        "--trim",
+    ]);
+    run.assert_status(0);
+    assert_eq!(run.logged_minutes(), common::round_quarter(30));
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1, "nothing was split");
+    // The mark's timestamps were skipped entirely, so there was no silence to find.
+    assert!(entries[0].idle.is_empty(), "an idle interval was recorded");
+}
+
+/// Quarter-aligned, so `--full` and `--trim` differ by the hole, not by rounding.
+struct AlignedGapFixture {
+    hole_minutes: i64,
+}
+
+fn aligned_gap_fixture(case: &Case) -> AlignedGapFixture {
+    let start = now() - 120 * 60;
+    let beats = [start + 30 * 60, start + 120 * 60];
+    case.write_mark("proj.12.plan", start);
+    case.beats_at("proj.12.plan", &beats);
+    AlignedGapFixture {
+        hole_minutes: (beats[1] - beats[0]) / 60,
+    }
+}
+
+#[test]
+fn full_logs_the_whole_measured_span() {
+    let case = Case::new("aligned-full");
+    aligned_gap_fixture(&case);
+
+    let run = case.run(&["end", "proj", "12", "plan", "planned the thing", "--full"]);
+    run.assert_status(0);
+    assert!(run.logged_minutes() > 0, "no duration was logged");
+}
+
+/// Two runs compared as a **delta**, so neither figure is written down.
+#[test]
+fn trim_logs_the_span_minus_every_flagged_gap() {
+    let full_case = Case::new("aligned-full-delta");
+    let fixture = aligned_gap_fixture(&full_case);
+    let full = full_case.run(&["end", "proj", "12", "plan", "planned the thing", "--full"]);
+    full.assert_status(0);
+
+    let trim_case = Case::new("aligned-trim-delta");
+    aligned_gap_fixture(&trim_case);
+    let trim = trim_case.run(&["end", "proj", "12", "plan", "planned the thing", "--trim"]);
+    trim.assert_status(0);
+
+    assert_eq!(
+        full.logged_minutes() - trim.logged_minutes(),
+        fixture.hole_minutes,
+        "minutes removed by --trim"
+    );
+}
+
+/// Not a usage error: nothing flagged simply logs the whole span.
+#[test]
+fn trim_on_a_phase_with_nothing_flagged_is_a_no_op() {
+    let case = Case::new("idle-trim-noop");
+    let span = 30 * 60;
+    let start = now() - span;
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &[start + 10 * 60, start + span]);
+
+    let run = case.run(&["end", "proj", "7", "impl", "nothing to trim", "--trim"]);
+    run.assert_status(0);
+    // `--trim` alone is a clap usage error, so `trim: true` must never be passed alone.
+    run.assert_stdout_has(&logged_duration(span / 60));
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1, "nothing was split");
+    assert!(entries[0].idle.is_empty());
+}

--- a/tests/agent_end.rs
+++ b/tests/agent_end.rs
@@ -6,7 +6,10 @@
 
 mod common;
 
-use common::{Case, clock, logged_duration, now};
+#[cfg(unix)]
+use common::Mode;
+use common::{Case, StoreRow, clock, logged_duration, now};
+use std::fs;
 
 // --- item ------------------------------------------------------------------
 
@@ -678,4 +681,126 @@ fn trim_on_a_phase_with_nothing_flagged_is_a_no_op() {
     let entries = case.store().entries;
     assert_eq!(entries.len(), 1, "nothing was split");
     assert!(entries[0].idle.is_empty());
+}
+
+// --- an unwritable mark directory ------------------------------------------
+
+/// A 30-minute beaten phase with one unrelated entry already in the store, so
+/// every count below is a delta against something.
+struct ClosableFixture {
+    /// Entries in the store before the close.
+    before: usize,
+    start: i64,
+}
+
+fn closable_fixture(case: &Case) -> ClosableFixture {
+    case.write_store(&[StoreRow {
+        description: "an earlier phase",
+        project: Some("proj"),
+        tags: &["proj/7", "review", "agent"],
+        start: now() - 7200,
+        end: Some(now() - 5400),
+    }]);
+    let start = now() - 30 * 60;
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &[start + 10 * 60, start + 30 * 60]);
+    ClosableFixture {
+        before: case.store().entries.len(),
+        start,
+    }
+}
+
+/// The failure needs no crash: an unwritable mark directory alone used to log the
+/// entry and leave the mark, so the retry the non-zero exit invites logged the
+/// same span again.
+/// Needs a mode change to make `unlink` fail, which has no Windows equivalent.
+#[cfg(unix)]
+#[test]
+fn an_unwritable_mark_directory_logs_nothing_and_the_retry_logs_once() {
+    let case = Case::new("end-unwritable");
+    let fixture = closable_fixture(&case);
+
+    let run = {
+        let _mode = Mode::set(&case.marks, 0o555);
+        case.run(&["end", "proj", "7", "impl", "did the thing"])
+    };
+    assert_eq!(run.status, Some(1), "stderr: {:?}", run.stderr);
+    assert_ne!(
+        run.status,
+        Some(74),
+        "74 would mean the entry was recorded after all"
+    );
+    assert_eq!(
+        case.store().entries.len() - fixture.before,
+        0,
+        "the store gained an entry: {:?}",
+        case.store().entries
+    );
+    assert!(case.mark_file("proj.7.impl").is_file(), "the mark survived");
+    assert!(!case.closing_file("proj.7.impl").exists());
+
+    let retry = case.run(&["end", "proj", "7", "impl", "did the thing"]);
+    retry.assert_status(0);
+    assert_eq!(
+        case.store().entries.len() - fixture.before,
+        1,
+        "the retry logged the span more than once: {:?}",
+        case.store().entries
+    );
+    assert_eq!(case.mark_count(), 0);
+    assert!(!case.closing_file("proj.7.impl").exists());
+}
+
+/// The residual state this narrows to: recorded, uncleared, and refused rather
+/// than logged a second time.
+#[test]
+fn a_close_left_unfinished_refuses_instead_of_logging_again() {
+    let case = Case::new("end-unfinished");
+    let fixture = closable_fixture(&case);
+    case.write_closing("proj.7.impl", fixture.start);
+
+    let run = case.run(&["end", "proj", "7", "impl", "did the thing"]);
+    run.assert_status(75);
+    run.assert_stderr_has("proj/7 impl has an unfinished close");
+    run.assert_stderr_has("tt agent cancel proj 7 impl");
+    assert_eq!(
+        case.store().entries.len() - fixture.before,
+        0,
+        "the store gained an entry: {:?}",
+        case.store().entries
+    );
+    // Named, never cleared: only the operator can tell whether the entry landed.
+    assert!(case.closing_file("proj.7.impl").is_file());
+    assert!(case.mark_file("proj.7.impl").is_file());
+}
+
+/// The one case where the entry does land and the cleanup does not: the `closing/`
+/// directory is already there, so only the mark's own removal hits the mode.
+/// Needs a mode change to make `unlink` fail, which has no Windows equivalent.
+#[cfg(unix)]
+#[test]
+fn an_entry_recorded_with_the_mark_left_behind_exits_74() {
+    let case = Case::new("end-uncleared");
+    let fixture = closable_fixture(&case);
+    fs::create_dir_all(case.closing_file("proj.7.impl").parent().unwrap()).unwrap();
+
+    let run = {
+        let _mode = Mode::set(&case.marks, 0o555);
+        case.run(&["end", "proj", "7", "impl", "did the thing"])
+    };
+    run.assert_status(74);
+    run.assert_stderr_has("proj/7 impl is recorded, but its mark could not be cleared");
+    run.assert_stderr_has("do not retry the close");
+    assert_eq!(
+        case.store().entries.len() - fixture.before,
+        1,
+        "the entry is recorded exactly once: {:?}",
+        case.store().entries
+    );
+    assert!(case.mark_file("proj.7.impl").is_file(), "the mark survived");
+
+    // A caller that retries anyway is refused rather than logging the span twice.
+    let retry = case.run(&["end", "proj", "7", "impl", "did the thing"]);
+    retry.assert_status(75);
+    assert_eq!(case.store().entries.len() - fixture.before, 1);
 }

--- a/tests/agent_end.rs
+++ b/tests/agent_end.rs
@@ -381,6 +381,41 @@ fn a_beaten_phase_is_still_judged_at_the_interior_threshold() {
     ));
 }
 
+/// Both thresholds are settable in `config.toml`, and the environment still wins.
+#[test]
+fn the_thresholds_come_from_the_config_file_unless_the_environment_says_otherwise() {
+    let configured = Case::new("threshold-config");
+    configured.write_config("[agent]\nmax_unvouched_minutes = 30\n");
+    configured.write_mark("proj.7.impl", now() - 60 * 60);
+    let run = configured.run(&["end", "proj", "7", "impl", "an hour of nothing"]);
+    run.assert_status(65);
+    run.assert_stderr_has("60m gap");
+
+    let overridden = Case::new("threshold-config-env");
+    overridden.write_config("[agent]\nmax_unvouched_minutes = 30\n");
+    overridden.write_mark("proj.7.impl", now() - 60 * 60);
+    let run = overridden.run_with_env(
+        &["end", "proj", "7", "impl", "an hour of nothing"],
+        &[("TT_MAX_UNVOUCHED_MINUTES", "90")],
+    );
+    run.assert_status(0);
+    run.assert_stdout_has(&logged_duration(60));
+}
+
+/// A beaten phase reads its threshold from the same file.
+#[test]
+fn the_gap_threshold_comes_from_the_config_file_too() {
+    let case = Case::new("gap-threshold-config");
+    case.write_config("[agent]\nmax_gap_minutes = 10\n");
+    let start = now() - 40 * 60;
+    case.write_mark("proj.7.impl", start);
+    case.beats_at("proj.7.impl", &[start + 5 * 60, start + 25 * 60]);
+
+    let run = case.run(&["end", "proj", "7", "impl", "beat, then quiet"]);
+    run.assert_status(65);
+    run.assert_stderr_has("20m gap");
+}
+
 #[test]
 fn the_unvouched_threshold_is_configurable() {
     let case = Case::new("gaps-unvouched-threshold");

--- a/tests/agent_marks.rs
+++ b/tests/agent_marks.rs
@@ -1,0 +1,269 @@
+//! `tt agent`'s mark lifecycle — `begin`, `touch`, `cancel` and `list` — driving the
+//! real binary, plus the assertion only a real process can make: that a mark command
+//! takes no store lock and creates no `data.json`.
+//!
+//! Every case runs in the throwaway `HOME` and `TT_MARK_DIR` [`common`] sets up.
+
+mod common;
+
+use common::{Case, clock, count_lines, now};
+use std::fs;
+
+// --- the store is never touched -------------------------------------------
+
+/// `main` dispatches the mark-only commands ahead of its `storage::with_data`
+/// preamble, so none of them creates the store or takes its lock. Asserted on the
+/// two *files*, not the directory, because `get_data_path` does a `create_dir_all`;
+/// the `item` complement in the same test proves the sandbox was in effect.
+#[test]
+fn only_the_mark_only_agent_commands_leave_the_store_untouched() {
+    let case = Case::new("store-untouched");
+    let data_dir = case.data_dir();
+
+    case.run(&["begin", "proj", "7", "impl"]).assert_status(0);
+    case.run(&["touch", "proj", "7", "impl"]).assert_status(0);
+    case.run(&["list"]).assert_status(0);
+    case.run(&["cancel", "proj", "7", "impl"]).assert_status(0);
+
+    for name in ["data.json", "data.lock"] {
+        let path = data_dir.join(name);
+        assert!(
+            !path.exists(),
+            "{name} was created by a mark-only command: {path:?}"
+        );
+    }
+
+    case.run(&["item", "proj", "7", "impl", "did the thing", "30"])
+        .assert_status(0);
+    for name in ["data.json", "data.lock"] {
+        assert!(
+            data_dir.join(name).is_file(),
+            "the sandbox is not in effect — {name} landed somewhere else"
+        );
+    }
+}
+
+// --- begin -----------------------------------------------------------------
+
+#[test]
+fn begin_creates_a_mark() {
+    let case = Case::new("begin-creates");
+    let run = case.run(&["begin", "proj", "7", "impl"]);
+    run.assert_status(0);
+    run.assert_stdout_has("marked proj/7 impl");
+
+    let body = fs::read_to_string(case.mark_file("proj.7.impl")).expect("the mark file");
+    assert!(
+        body.trim().parse::<i64>().is_ok(),
+        "a mark holds a unix timestamp, got {body:?}"
+    );
+}
+
+#[test]
+fn begin_is_idempotent_and_keeps_the_original_start() {
+    let case = Case::new("begin-idempotent");
+    let before = now() - 600;
+    case.write_mark("proj.7.impl", before);
+
+    let run = case.run(&["begin", "proj", "7", "impl"]);
+    run.assert_status(0);
+    run.assert_stderr_has("already marked");
+    assert_eq!(
+        fs::read_to_string(case.mark_file("proj.7.impl")).unwrap(),
+        format!("{before}\n"),
+        "the original start"
+    );
+}
+
+// --- touch -----------------------------------------------------------------
+
+#[test]
+fn touch_without_a_mark_exits_64() {
+    let case = Case::new("touch-unmarked");
+    let run = case.run(&["touch", "proj", "7", "impl"]);
+    run.assert_status(64);
+    run.assert_stderr_has("nothing to touch");
+    assert_eq!(case.mark_count(), 0, "nothing was written");
+}
+
+#[test]
+fn touch_appends_one_beat_per_call() {
+    let case = Case::new("touch-appends");
+    case.write_mark("proj.7.impl", now());
+    let before = count_lines(&case.beats_file("proj.7.impl"));
+
+    for _ in 0..3 {
+        case.run(&["touch", "proj", "7", "impl"]).assert_status(0);
+    }
+
+    assert_eq!(
+        count_lines(&case.beats_file("proj.7.impl")),
+        before + 3,
+        "beat count"
+    );
+    // The mark itself is untouched — beats are a separate file, not a rewrite.
+    assert!(case.mark_file("proj.7.impl").is_file());
+}
+
+#[test]
+fn beats_live_in_a_subdirectory_not_as_a_mark_sibling() {
+    let case = Case::new("touch-subdirectory");
+    case.write_mark("proj.7.impl", now());
+    case.run(&["touch", "proj", "7", "impl"]).assert_status(0);
+
+    assert!(!case.mark_file("proj.7.impl.last").exists());
+    assert!(!case.mark_file("proj.7.impl.beats").exists());
+    assert!(case.beats_file("proj.7.impl").is_file());
+}
+
+// --- cancel ----------------------------------------------------------------
+
+#[test]
+fn cancel_removes_the_mark_and_leaves_the_others() {
+    let case = Case::new("cancel-removes");
+    case.write_mark("proj.7.impl", now());
+    case.write_mark("other.9.plan", now());
+    let before = case.mark_count();
+
+    let run = case.run(&["cancel", "proj", "7", "impl"]);
+    run.assert_status(0);
+    run.assert_stdout_has("dropped mark for proj/7 impl");
+    assert_eq!(case.mark_count(), before - 1, "mark count");
+    assert!(!case.mark_file("proj.7.impl").exists());
+    assert!(case.mark_file("other.9.plan").is_file());
+}
+
+/// `cancel` clears the mark and its `beats/` entry together.
+#[test]
+fn cancel_clears_the_mark_and_its_beats_file() {
+    let case = Case::new("cancel-clears-beats");
+    case.write_mark("proj.7.impl", now());
+    case.run(&["touch", "proj", "7", "impl"]).assert_status(0);
+    assert!(case.beats_file("proj.7.impl").is_file());
+
+    case.run(&["cancel", "proj", "7", "impl"]).assert_status(0);
+    assert!(!case.mark_file("proj.7.impl").exists());
+    assert!(!case.beats_file("proj.7.impl").exists());
+}
+
+// --- list ------------------------------------------------------------------
+
+#[test]
+fn list_reports_nothing_when_the_directory_is_empty() {
+    let case = Case::new("list-empty");
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    run.assert_stdout_has("No open marks.");
+    // The bare line, with no header and no emoji.
+    assert_eq!(run.stdout, "No open marks.\n");
+}
+
+#[test]
+fn list_shows_an_open_mark_as_a_house_style_row() {
+    let case = Case::new("list-row");
+    let start = now() - 600;
+    case.write_mark("proj.23.impl", start);
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    assert_eq!(
+        run.stdout,
+        format!(
+            "\u{1F916} Open marks:\n\n  proj/23 impl       - since {} (0h 10m)\n",
+            clock(start)
+        ),
+        "the header, the blank line and one padded row"
+    );
+}
+
+#[test]
+fn list_drops_the_issue_for_the_sentinel() {
+    let case = Case::new("list-sentinel");
+    case.write_mark("proj.-.plan", now());
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    run.assert_stdout_has("proj plan");
+    assert!(
+        !run.stdout.contains("proj/-"),
+        "the - sentinel leaked into the label: {:?}",
+        run.stdout
+    );
+}
+
+/// The house duration format: always `{h}h {m}m`, and never negative.
+#[test]
+fn list_renders_an_age_in_the_house_duration_format() {
+    let case = Case::new("list-ages");
+    case.write_mark("long.1.impl", now() - 126 * 60);
+    case.write_mark("short.2.impl", now() - 2 * 60);
+    case.write_mark("future.3.impl", now() + 600);
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    run.assert_stdout_has("(2h 6m)");
+    run.assert_stdout_has("(0h 2m)");
+    // A start in the future reads as `0h 0m`, not as `0h -10m`.
+    run.assert_stdout_has("(0h 0m)");
+    // No age is ever negative; the check is on the parenthesised age, not the row.
+    for line in run.stdout.lines().filter(|line| line.contains('(')) {
+        let age = &line[line.find('(').unwrap()..];
+        assert!(!age.contains('-'), "a negative age reached {age:?}");
+    }
+}
+
+#[test]
+fn list_still_shows_a_mark_whose_phase_contains_a_dot() {
+    let case = Case::new("list-dotted-phase");
+    case.write_mark("proj.23.impl.v2", now());
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    // The dot split is lossy by design; an imperfect label beats hiding an open mark.
+    run.assert_stdout_has("proj/23.impl v2");
+}
+
+#[test]
+fn list_shows_a_dotless_name_as_a_bare_project() {
+    let case = Case::new("list-dotless");
+    case.write_mark("solo", now());
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    run.assert_stdout_has("solo");
+}
+
+#[test]
+fn list_shows_a_mark_whose_phase_is_literally_last() {
+    let case = Case::new("list-phase-last");
+    case.run(&["begin", "proj", "-", "last"]).assert_status(0);
+    assert!(case.mark_file("proj.-.last").is_file());
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    // A name filter would hide this; the reader has none.
+    run.assert_stdout_has("proj last");
+}
+
+#[test]
+fn list_ignores_the_beats_subdirectory() {
+    let case = Case::new("list-ignores-beats");
+    case.write_mark("proj.7.impl", now());
+    case.run(&["touch", "proj", "7", "impl"]).assert_status(0);
+
+    let run = case.run(&["list"]);
+    run.assert_status(0);
+    run.assert_stdout_has("proj/7 impl");
+    assert!(
+        !run.stdout.contains("beats"),
+        "the beats directory was listed as a mark: {:?}",
+        run.stdout
+    );
+    // One row per regular file — a file-type test, never a name filter.
+    let rows = run
+        .stdout
+        .lines()
+        .filter(|line| line.starts_with("  "))
+        .count();
+    assert_eq!(rows, case.mark_count(), "one row per mark file");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,9 @@
 //! The shared harness for the `tt agent` integration tests.
 //!
-//! Every case runs in a throwaway `HOME` *and* `TT_MARK_DIR`, and [`Case::run`]
-//! refuses a command whose paths are not inside the sandbox. Time is fabricated at
-//! synthetic epochs; expectations are derived from the fixture, never written down.
+//! Every case runs in a throwaway `HOME`, `TT_MARK_DIR`, `TT_DATA_DIR` and
+//! `TT_CONFIG_FILE`, and [`Case::run`] refuses a command whose paths are not inside
+//! the sandbox. Time is fabricated at synthetic epochs; expectations are derived
+//! from the fixture, never written down.
 //!
 //! Each test binary compiles this module separately, so an item only one of them
 //! uses is `dead_code` in the other — hence the crate-level allow.
@@ -14,10 +15,13 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// One case's sandbox: a `HOME`, a mark directory inside it, and nothing else.
+/// One case's sandbox: a `HOME`, a mark directory, a store directory and a config
+/// file beside it, and nothing else.
 pub struct Case {
     pub home: PathBuf,
     pub marks: PathBuf,
+    pub data: PathBuf,
+    pub config: PathBuf,
 }
 
 pub struct Run {
@@ -32,9 +36,17 @@ impl Case {
         let _ = fs::remove_dir_all(&root);
         let home = root.join("home");
         let marks = root.join("marks");
+        let data = root.join("store");
+        let config = root.join("config.toml");
         fs::create_dir_all(&home).unwrap();
         fs::create_dir_all(&marks).unwrap();
-        Self { home, marks }
+        fs::create_dir_all(&data).unwrap();
+        Self {
+            home,
+            marks,
+            data,
+            config,
+        }
     }
 
     /// Run `tt agent <args>` with the sandbox in force. `env_clear`, not overrides:
@@ -64,9 +76,12 @@ impl Case {
     }
 
     fn run_full(&self, args: &[&str], mark_dir: bool, env: &[(&str, &str)]) -> Run {
+        let root = self.home.parent().unwrap();
         assert!(
             self.home.starts_with(std::env::temp_dir())
-                && self.marks.starts_with(self.home.parent().unwrap()),
+                && self.marks.starts_with(root)
+                && self.data.starts_with(root)
+                && self.config.starts_with(root),
             "sandbox paths escaped the scratch directory: {:?}",
             self.home
         );
@@ -74,6 +89,8 @@ impl Case {
         let mut command = Command::new(env!("CARGO_BIN_EXE_tt"));
         command.env_clear();
         command.env("HOME", &self.home);
+        command.env("TT_DATA_DIR", &self.data);
+        command.env("TT_CONFIG_FILE", &self.config);
         if mark_dir {
             command.env("TT_MARK_DIR", &self.marks);
         }
@@ -102,11 +119,9 @@ impl Case {
         self.marks.join("beats").join(key)
     }
 
-    /// Write a `config.toml` into the sandbox, at the path `config::load` reads.
+    /// Write the sandbox's `config.toml`, at the path `TT_CONFIG_FILE` names.
     pub fn write_config(&self, body: &str) {
-        let dir = self.home.join(".config/timetracker-rs");
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("config.toml"), body).unwrap();
+        fs::write(&self.config, body).unwrap();
     }
 
     /// Fabricate an open mark started at an absolute epoch.
@@ -168,10 +183,10 @@ impl Case {
         fs::write(dir.join("data.json"), json).unwrap();
     }
 
-    /// The sandbox's store directory — where `data.json` and `data.lock` would land.
+    /// The sandbox's store directory — where `data.json` and `data.lock` land,
+    /// because `TT_DATA_DIR` names it.
     pub fn data_dir(&self) -> PathBuf {
-        self.home
-            .join("Library/Application Support/com.timetracker.tt")
+        self.data.clone()
     }
 
     /// The sandbox's store, parsed back from its own JSON.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,339 @@
+//! The shared harness for the `tt agent` integration tests.
+//!
+//! Every case runs in a throwaway `HOME` *and* `TT_MARK_DIR`, and [`Case::run`]
+//! refuses a command whose paths are not inside the sandbox. Time is fabricated at
+//! synthetic epochs; expectations are derived from the fixture, never written down.
+//!
+//! Each test binary compiles this module separately, so an item only one of them
+//! uses is `dead_code` in the other — hence the crate-level allow.
+#![allow(dead_code)]
+
+use chrono::{DateTime, Local};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// One case's sandbox: a `HOME`, a mark directory inside it, and nothing else.
+pub struct Case {
+    pub home: PathBuf,
+    pub marks: PathBuf,
+}
+
+pub struct Run {
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Case {
+    pub fn new(name: &str) -> Self {
+        let root = std::env::temp_dir().join(format!("tt-agent-test-{name}"));
+        let _ = fs::remove_dir_all(&root);
+        let home = root.join("home");
+        let marks = root.join("marks");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&marks).unwrap();
+        Self { home, marks }
+    }
+
+    /// Run `tt agent <args>` with the sandbox in force. `env_clear`, not overrides:
+    /// an inherited `TT_MARK_DIR` would silently point a case at the live marks.
+    pub fn run(&self, args: &[&str]) -> Run {
+        let mut argv = vec!["agent"];
+        argv.extend_from_slice(args);
+        self.run_with(&argv, true)
+    }
+
+    /// Run `tt agent <args>` with **no** `TT_MARK_DIR`, exercising the default path.
+    pub fn run_in_cache(&self, args: &[&str]) -> Run {
+        let mut argv = vec!["agent"];
+        argv.extend_from_slice(args);
+        self.run_with(&argv, false)
+    }
+
+    /// Run `tt agent <args>` with one extra `KEY=value` that `env_clear` would strip.
+    pub fn run_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Run {
+        let mut argv = vec!["agent"];
+        argv.extend_from_slice(args);
+        self.run_full(&argv, true, env)
+    }
+
+    fn run_with(&self, args: &[&str], mark_dir: bool) -> Run {
+        self.run_full(args, mark_dir, &[])
+    }
+
+    fn run_full(&self, args: &[&str], mark_dir: bool, env: &[(&str, &str)]) -> Run {
+        assert!(
+            self.home.starts_with(std::env::temp_dir())
+                && self.marks.starts_with(self.home.parent().unwrap()),
+            "sandbox paths escaped the scratch directory: {:?}",
+            self.home
+        );
+
+        let mut command = Command::new(env!("CARGO_BIN_EXE_tt"));
+        command.env_clear();
+        command.env("HOME", &self.home);
+        if mark_dir {
+            command.env("TT_MARK_DIR", &self.marks);
+        }
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.args(args);
+
+        let Output {
+            status,
+            stdout,
+            stderr,
+        } = command.output().expect("the tt binary should run");
+        Run {
+            status: status.code(),
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        }
+    }
+
+    pub fn mark_file(&self, key: &str) -> PathBuf {
+        self.marks.join(key)
+    }
+
+    pub fn beats_file(&self, key: &str) -> PathBuf {
+        self.marks.join("beats").join(key)
+    }
+
+    /// Write a `config.toml` into the sandbox, at the path `config::load` reads.
+    pub fn write_config(&self, body: &str) {
+        let dir = self.home.join(".config/timetracker-rs");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("config.toml"), body).unwrap();
+    }
+
+    /// Fabricate an open mark started at an absolute epoch.
+    pub fn write_mark(&self, key: &str, start: i64) {
+        fs::write(self.mark_file(key), format!("{start}\n")).unwrap();
+    }
+
+    /// Run `tt <args>` with **no** `agent` prefix, for the store-reading commands.
+    pub fn run_bare(&self, args: &[&str]) -> Run {
+        self.run_with(args, true)
+    }
+
+    /// Lay a `data.json` into the sandbox from fabricated rows, at `schema_version:
+    /// 1` so the migrate preamble early-returns and the `project` fields survive.
+    pub fn write_store(&self, rows: &[StoreRow]) {
+        let entries: Vec<String> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, row)| {
+                let project = match row.project {
+                    Some(name) => format!("\"{name}\""),
+                    None => "null".to_string(),
+                };
+                let tags: Vec<String> =
+                    row.tags.iter().map(|tag| format!("\"{tag}\"")).collect();
+                let end = match row.end {
+                    Some(end) => format!("\"{}\"", stamp(end)),
+                    None => "null".to_string(),
+                };
+                format!(
+                    r#"{{"id":{},"description":"{}","project":{},"tags":[{}],"start_time":"{}","end_time":{},"idle":[]}}"#,
+                    i as u64 + 1,
+                    row.description,
+                    project,
+                    tags.join(","),
+                    stamp(row.start),
+                    end
+                )
+            })
+            .collect();
+
+        let dir = self.data_dir();
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("data.json"),
+            format!(
+                r#"{{"entries":[{}],"next_id":{},"schema_version":1}}"#,
+                entries.join(","),
+                rows.len() as u64 + 1
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Lay a `data.json` into the sandbox verbatim, for a store the migration must fix.
+    pub fn write_raw_store(&self, json: &str) {
+        let dir = self.data_dir();
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("data.json"), json).unwrap();
+    }
+
+    /// The sandbox's store directory — where `data.json` and `data.lock` would land.
+    pub fn data_dir(&self) -> PathBuf {
+        self.home
+            .join("Library/Application Support/com.timetracker.tt")
+    }
+
+    /// The sandbox's store, parsed back from its own JSON.
+    pub fn store(&self) -> Store {
+        let path = self.data_dir().join("data.json");
+        let body = fs::read_to_string(path).expect("the sandbox's data.json");
+        serde_json::from_str(&body).expect("data.json should parse")
+    }
+
+    /// Fabricate a heartbeat sequence at absolute epochs, so a long phase is free.
+    pub fn beats_at(&self, key: &str, beats: &[i64]) {
+        let file = self.beats_file(key);
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        let body: String = beats.iter().map(|beat| format!("{beat}\n")).collect();
+        fs::write(file, body).unwrap();
+    }
+
+    /// Regular files directly in the mark directory — the `beats` subdirectory is not one.
+    pub fn mark_count(&self) -> usize {
+        count_files(&self.marks)
+    }
+}
+
+pub fn count_files(dir: &Path) -> usize {
+    match fs::read_dir(dir) {
+        Ok(entries) => entries
+            .flatten()
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            .count(),
+        Err(_) => 0,
+    }
+}
+
+pub fn count_lines(path: &Path) -> usize {
+    fs::read_to_string(path).map_or(0, |body| body.lines().count())
+}
+
+pub fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+/// The `HH:MM` a fixture's own epoch renders as.
+pub fn clock(epoch: i64) -> String {
+    chrono::DateTime::from_timestamp(epoch, 0)
+        .unwrap()
+        .with_timezone(&chrono::Local)
+        .format("%H:%M")
+        .to_string()
+}
+
+/// One fabricated store row for [`Case::write_store`].
+pub struct StoreRow {
+    pub description: &'static str,
+    pub project: Option<&'static str>,
+    pub tags: &'static [&'static str],
+    pub start: i64,
+    /// Epoch seconds; `None` leaves the entry running.
+    pub end: Option<i64>,
+}
+
+/// An epoch second as the store's RFC 3339 local timestamp.
+pub fn stamp(epoch: i64) -> String {
+    DateTime::<chrono::Utc>::from_timestamp(epoch, 0)
+        .expect("a real epoch")
+        .with_timezone(&Local)
+        .to_rfc3339()
+}
+
+/// The store as `tt` writes it, with only the fields these tests assert on.
+#[derive(Debug, serde::Deserialize)]
+pub struct Store {
+    pub entries: Vec<Entry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Entry {
+    pub description: String,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub start_time: DateTime<Local>,
+    pub end_time: Option<DateTime<Local>>,
+    #[serde(default)]
+    pub idle: Vec<Idle>,
+}
+
+impl Entry {
+    /// How long this entry covers, in whole seconds.
+    pub fn seconds(&self) -> i64 {
+        self.end_time
+            .expect("a logged entry is closed")
+            .signed_duration_since(self.start_time)
+            .num_seconds()
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Idle {
+    pub start: DateTime<Local>,
+    pub end: DateTime<Local>,
+}
+
+impl Idle {
+    /// The recorded stretch as a raw `(from, to)` epoch pair.
+    pub fn epochs(&self) -> (i64, i64) {
+        (self.start.timestamp(), self.end.timestamp())
+    }
+}
+
+/// The rounding `tt` applies to a logged duration.
+pub fn round_quarter(minutes: i64) -> i64 {
+    (((minutes + 7) / 15) * 15).max(15)
+}
+
+/// The `- Duration:` tail `cli::log` prints for `minutes` — the figure it was asked
+/// for, never the stored span.
+pub fn logged_duration(minutes: i64) -> String {
+    let rounded = round_quarter(minutes);
+    format!("- Duration: {}h {}m", rounded / 60, rounded % 60)
+}
+
+impl Run {
+    pub fn assert_status(&self, expected: i32) {
+        assert_eq!(
+            self.status,
+            Some(expected),
+            "exit code (stderr: {:?}, stdout: {:?})",
+            self.stderr,
+            self.stdout
+        );
+    }
+
+    pub fn assert_stdout_has(&self, needle: &str) {
+        assert!(
+            self.stdout.contains(needle),
+            "stdout missing {needle:?}: {:?}",
+            self.stdout
+        );
+    }
+
+    /// The minutes `cli::log` said it logged, read off its own output — the requested
+    /// figure, before any split, never the stored span.
+    pub fn logged_minutes(&self) -> i64 {
+        let tail = self
+            .stdout
+            .split("- Duration: ")
+            .nth(1)
+            .unwrap_or_else(|| panic!("no logged duration in {:?}", self.stdout));
+        let (hours, rest) = tail.split_once('h').expect("`<h>h <m>m`");
+        let (minutes, _) = rest.trim_start().split_once('m').expect("`<h>h <m>m`");
+        hours.trim().parse::<i64>().unwrap() * 60 + minutes.trim().parse::<i64>().unwrap()
+    }
+
+    pub fn assert_stderr_has(&self, needle: &str) {
+        assert!(
+            self.stderr.contains(needle),
+            "stderr missing {needle:?}: {:?}",
+            self.stderr
+        );
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,6 +11,8 @@
 
 use chrono::{DateTime, Local};
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -119,6 +121,18 @@ impl Case {
         self.marks.join("beats").join(key)
     }
 
+    pub fn closing_file(&self, key: &str) -> PathBuf {
+        self.marks.join("closing").join(key)
+    }
+
+    /// Fabricate the leftover an unfinished close would have left, holding the
+    /// start its mark holds.
+    pub fn write_closing(&self, key: &str, start: i64) {
+        let file = self.closing_file(key);
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(file, format!("{start}\n")).unwrap();
+    }
+
     /// Write the sandbox's `config.toml`, at the path `TT_CONFIG_FILE` names.
     pub fn write_config(&self, body: &str) {
         fs::write(&self.config, body).unwrap();
@@ -207,6 +221,34 @@ impl Case {
     /// Regular files directly in the mark directory — the `beats` subdirectory is not one.
     pub fn mark_count(&self) -> usize {
         count_files(&self.marks)
+    }
+}
+
+/// One path's permission bits for the length of a scope, put back on drop whether
+/// the case passed or panicked. [`Case::new`] opens with `remove_dir_all`, so a
+/// mode left behind fails the **next** run of that case rather than this one.
+#[cfg(unix)]
+pub struct Mode {
+    path: PathBuf,
+    original: fs::Permissions,
+}
+
+#[cfg(unix)]
+impl Mode {
+    pub fn set(path: &Path, mode: u32) -> Self {
+        let original = fs::metadata(path).expect("the path to exist").permissions();
+        fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+        Self {
+            path: path.to_path_buf(),
+            original,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for Mode {
+    fn drop(&mut self) {
+        let _ = fs::set_permissions(&self.path, self.original.clone());
     }
 }
 

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -1,0 +1,84 @@
+//! `tt log` end to end, in a sandbox. The store and stdout are asserted against
+//! each other, never separately: the message states the span stored, not requested.
+
+mod common;
+
+use common::Case;
+
+fn printed_minutes(stdout: &str) -> i64 {
+    let tail = stdout
+        .split("- Duration: ")
+        .nth(1)
+        .unwrap_or_else(|| panic!("no logged duration in {stdout:?}"));
+    let (hours, rest) = tail.split_once('h').expect("`<h>h <m>m`");
+    let (minutes, _) = rest.trim_start().split_once('m').expect("`<h>h <m>m`");
+    hours.trim().parse::<i64>().unwrap() * 60 + minutes.trim().parse::<i64>().unwrap()
+}
+
+#[test]
+fn trim_reports_the_span_it_stored_and_not_the_span_it_was_asked_for() {
+    let case = Case::new("log-trim-message");
+    // `tt log` back-dates from its own `now`, so the hole is expressed relative to now.
+    let now = common::now();
+    let hole = (now - 40 * 60, now - 20 * 60);
+
+    let run = case.run_bare(&[
+        "log",
+        "-d",
+        "an hour with a hole in it",
+        "-t",
+        "60m",
+        &format!("--idle={}-{}", hole.0, hole.1),
+        "--trim",
+    ]);
+    run.assert_status(0);
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 2, "the hole is interior, so it cuts in two");
+    let stored: i64 = entries.iter().map(|entry| entry.seconds()).sum();
+    // One second of slack per piece: each is back-dated a moment after this test read
+    // the clock, so `num_seconds` truncates a fraction away. The *sum* is exact.
+    assert!(
+        (40 * 60 - entries.len() as i64..=40 * 60).contains(&stored),
+        "60 minutes less the 20-minute hole, got {stored}s: {entries:?}"
+    );
+    assert_eq!(
+        printed_minutes(&run.stdout),
+        40,
+        "the message states what the store holds, not the 60m it was asked for: {:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn a_plain_log_still_reports_the_span_it_was_asked_for() {
+    let case = Case::new("log-plain-message");
+
+    let run = case.run_bare(&["log", "-d", "no holes here", "-t", "45m"]);
+    run.assert_status(0);
+    assert_eq!(printed_minutes(&run.stdout), 45);
+    assert_eq!(case.store().entries[0].seconds(), 45 * 60);
+}
+
+#[test]
+fn idle_covering_the_whole_span_leaves_the_entry_and_reports_it_whole() {
+    // `trim_spans` declines rather than deleting the entry, so nothing is subtracted.
+    let case = Case::new("log-trim-declines");
+    let now = common::now();
+
+    let run = case.run_bare(&[
+        "log",
+        "-d",
+        "swallowed whole",
+        "-t",
+        "30m",
+        &format!("--idle={}-{}", now - 90 * 60, now + 90 * 60),
+        "--trim",
+    ]);
+    run.assert_status(0);
+
+    let entries = case.store().entries;
+    assert_eq!(entries.len(), 1, "nothing was split");
+    assert_eq!(entries[0].seconds(), 30 * 60);
+    assert_eq!(printed_minutes(&run.stdout), 30);
+}

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -1,0 +1,455 @@
+//! `tt report` end to end in a sandbox. The rollup axis is the entry's **project
+//! field**, never a tag, and every timestamp is fabricated at an absolute epoch so
+//! `--week`, `--since` and `--until` are testable without a clock.
+
+mod common;
+
+use chrono::{Datelike, Duration, Local, NaiveDate};
+use common::{Case, StoreRow, stamp};
+
+/// Midnight-anchored epochs in the local zone, as the store's dates are local.
+fn epoch_on(date: NaiveDate, hour: i64) -> i64 {
+    date.and_hms_opt(0, 0, 0)
+        .expect("midnight exists")
+        .and_local_timezone(Local)
+        .single()
+        .expect("an unambiguous local midnight")
+        .timestamp()
+        + hour * 3600
+}
+
+fn today() -> NaiveDate {
+    Local::now().date_naive()
+}
+
+fn days_ago(n: i64) -> NaiveDate {
+    today() - Duration::days(n)
+}
+
+/// One agent-shaped row: the tags a `tt agent` command writes, plus its project.
+fn agent_row(
+    description: &'static str,
+    project: &'static str,
+    tags: &'static [&'static str],
+    date: NaiveDate,
+    hour: i64,
+    minutes: i64,
+) -> StoreRow {
+    let start = epoch_on(date, hour);
+    StoreRow {
+        description,
+        project: Some(project),
+        tags,
+        start,
+        end: Some(start + minutes * 60),
+    }
+}
+
+#[test]
+fn the_default_scope_reports_today_and_leaves_other_days_out() {
+    let case = Case::new("report-today");
+    case.write_store(&[
+        agent_row(
+            "did today",
+            "tt",
+            &["tt/12", "impl", "agent"],
+            today(),
+            9,
+            30,
+        ),
+        agent_row(
+            "did last week",
+            "tt",
+            &["tt/11", "impl", "agent"],
+            days_ago(9),
+            9,
+            60,
+        ),
+    ]);
+
+    let run = case.run_bare(&["report"]);
+    run.assert_status(0);
+    run.assert_stdout_has("0h 30m");
+    assert!(
+        run.stdout.contains("tt/12"),
+        "today's item is listed: {:?}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains("tt/11"),
+        "a nine-day-old entry is not today's: {:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn an_agent_shaped_entry_reports_under_its_project_and_never_under_agent() {
+    let case = Case::new("report-project-axis");
+    case.write_store(&[agent_row(
+        "premium brand primitives",
+        "vinge",
+        &["vinge/12", "impl", "agent"],
+        today(),
+        9,
+        45,
+    )]);
+
+    let run = case.run_bare(&["report"]);
+    run.assert_status(0);
+    assert!(
+        run.stdout.contains("vinge"),
+        "grouped under the project field: {:?}",
+        run.stdout
+    );
+    // A project row is unindented, so a line *starting* with `agent` is the bug.
+    assert!(
+        !run.stdout.lines().any(|line| line.starts_with("agent")),
+        "the provenance tag is not a project: {:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn week_includes_the_monday_boundary_entry() {
+    let case = Case::new("report-week");
+    // The same arithmetic `TimeData::week_start` uses, so the boundary matches it.
+    let monday = today() - Duration::days(today().weekday().num_days_from_monday() as i64);
+
+    case.write_store(&[
+        agent_row(
+            "on the Monday",
+            "tt",
+            &["tt/1", "plan", "agent"],
+            monday,
+            9,
+            30,
+        ),
+        // The day before the week started, which --week must exclude.
+        agent_row(
+            "the Sunday before",
+            "tt",
+            &["tt/2", "plan", "agent"],
+            monday - Duration::days(1),
+            9,
+            30,
+        ),
+    ]);
+
+    let run = case.run_bare(&["report", "--week"]);
+    run.assert_status(0);
+    assert!(run.stdout.contains("tt/1"), "{:?}", run.stdout);
+    assert!(
+        !run.stdout.contains("tt/2"),
+        "the Sunday before is last week: {:?}",
+        run.stdout
+    );
+    assert!(
+        run.stdout.contains(&format!("Week of {monday}")),
+        "labelled by its Monday: {:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn since_and_until_bound_the_range_at_both_ends() {
+    let case = Case::new("report-since-until");
+    case.write_store(&[
+        agent_row(
+            "too early",
+            "tt",
+            &["tt/1", "plan", "agent"],
+            days_ago(10),
+            9,
+            30,
+        ),
+        agent_row(
+            "inside",
+            "tt",
+            &["tt/2", "plan", "agent"],
+            days_ago(5),
+            9,
+            30,
+        ),
+        agent_row(
+            "too late",
+            "tt",
+            &["tt/3", "plan", "agent"],
+            days_ago(1),
+            9,
+            30,
+        ),
+    ]);
+
+    let run = case.run_bare(&[
+        "report",
+        "--since",
+        &days_ago(7).to_string(),
+        "--until",
+        &days_ago(3).to_string(),
+    ]);
+    run.assert_status(0);
+    assert!(run.stdout.contains("tt/2"), "{:?}", run.stdout);
+    assert!(
+        !run.stdout.contains("tt/1"),
+        "before --since: {:?}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains("tt/3"),
+        "after --until: {:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn until_without_a_scope_is_a_usage_error() {
+    let case = Case::new("report-until-alone");
+    case.write_store(&[]);
+
+    let run = case.run_bare(&["report", "--until", &today().to_string()]);
+    assert_ne!(run.status, Some(0), "a usage error, not a quiet day report");
+}
+
+#[test]
+fn project_filters_on_the_field_not_on_a_tag() {
+    let case = Case::new("report-project-filter");
+    case.write_store(&[
+        agent_row(
+            "vinge work",
+            "vinge",
+            &["vinge/6", "impl", "agent"],
+            today(),
+            9,
+            30,
+        ),
+        agent_row(
+            "tt work",
+            "tt",
+            &["tt/12", "impl", "agent"],
+            today(),
+            11,
+            45,
+        ),
+    ]);
+
+    let run = case.run_bare(&["report", "--project", "vinge"]);
+    run.assert_status(0);
+    assert!(run.stdout.contains("vinge/6"), "{:?}", run.stdout);
+    assert!(
+        !run.stdout.contains("tt/12"),
+        "the other project is filtered out: {:?}",
+        run.stdout
+    );
+    assert!(
+        run.stdout.contains("— #vinge"),
+        "the label names the filter: {:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn json_carries_the_documented_keys_over_the_real_binary() {
+    let case = Case::new("report-json");
+    case.write_store(&[
+        agent_row(
+            "did the thing",
+            "vinge",
+            &["vinge/6", "plan", "agent"],
+            today(),
+            9,
+            30,
+        ),
+        StoreRow {
+            description: "hand-written, no project",
+            project: None,
+            tags: &[],
+            start: epoch_on(today(), 14),
+            end: Some(epoch_on(today(), 14) + 15 * 60),
+        },
+    ]);
+
+    let run = case.run_bare(&["report", "--json"]);
+    run.assert_status(0);
+
+    let json: serde_json::Value =
+        serde_json::from_str(&run.stdout).expect("--json emits parseable JSON");
+
+    assert_eq!(json["total_seconds"], 45 * 60);
+    assert_eq!(json["overlaps"], 0, "09:00 and 14:00 do not collide");
+    assert!(json["label"].is_string());
+
+    let projects = json["projects"].as_object().expect("an object");
+    assert!(projects.contains_key("vinge"));
+    assert!(
+        projects.contains_key("(no project)"),
+        "the field-less bucket, not `(untagged)`: {:?}",
+        projects.keys().collect::<Vec<_>>()
+    );
+    assert!(!projects.contains_key("agent"));
+
+    let item = &json["projects"]["vinge"]["items"]["vinge/6"];
+    assert_eq!(item["seconds"], 30 * 60);
+    assert_eq!(item["phases"]["plan"], 30 * 60);
+    assert_eq!(item["active"], false);
+    assert!(item["seconds"].is_i64(), "seconds are integers, not floats");
+}
+
+#[test]
+fn overlapping_back_dated_entries_are_warned_about_and_disjoint_ones_are_not() {
+    let case = Case::new("report-overlaps");
+    let start = epoch_on(today(), 9);
+
+    case.write_store(&[
+        StoreRow {
+            description: "first",
+            project: Some("tt"),
+            tags: &["tt/1", "impl"],
+            start,
+            end: Some(start + 60 * 60),
+        },
+        StoreRow {
+            description: "second, half inside the first",
+            project: Some("tt"),
+            tags: &["tt/2", "impl"],
+            start: start + 30 * 60,
+            end: Some(start + 90 * 60),
+        },
+    ]);
+
+    let run = case.run_bare(&["report"]);
+    run.assert_status(0);
+    assert!(
+        run.stdout.contains("1 overlapping span(s)"),
+        "the collision is reported: {:?}",
+        run.stdout
+    );
+
+    let disjoint = Case::new("report-no-overlaps");
+    disjoint.write_store(&[
+        agent_row("morning", "tt", &["tt/1", "impl", "agent"], today(), 9, 30),
+        agent_row(
+            "afternoon",
+            "tt",
+            &["tt/2", "impl", "agent"],
+            today(),
+            14,
+            30,
+        ),
+    ]);
+    let clean = disjoint.run_bare(&["report"]);
+    clean.assert_status(0);
+    assert!(
+        !clean.stdout.contains("overlapping"),
+        "nothing to warn about: {:?}",
+        clean.stdout
+    );
+}
+
+#[test]
+fn an_empty_scope_says_so_rather_than_printing_an_empty_tree() {
+    let case = Case::new("report-empty");
+    case.write_store(&[agent_row(
+        "long ago",
+        "tt",
+        &["tt/1", "impl", "agent"],
+        days_ago(30),
+        9,
+        30,
+    )]);
+
+    let run = case.run_bare(&["report"]);
+    run.assert_status(0);
+    assert!(
+        run.stdout.starts_with("No entries for Today,"),
+        "{:?}",
+        run.stdout
+    );
+}
+
+#[test]
+fn all_reports_every_entry_regardless_of_date() {
+    let case = Case::new("report-all");
+    case.write_store(&[
+        agent_row(
+            "ancient",
+            "tt",
+            &["tt/1", "impl", "agent"],
+            days_ago(200),
+            9,
+            30,
+        ),
+        agent_row("today", "tt", &["tt/2", "impl", "agent"], today(), 9, 30),
+    ]);
+
+    let run = case.run_bare(&["report", "--all"]);
+    run.assert_status(0);
+    run.assert_stdout_has("All entries");
+    assert!(run.stdout.contains("tt/1"), "{:?}", run.stdout);
+    assert!(run.stdout.contains("tt/2"), "{:?}", run.stdout);
+    run.assert_stdout_has("1h 0m");
+}
+
+#[test]
+fn report_leaves_the_store_untouched_byte_for_byte() {
+    // A read: no rewrite and no exclusive lock, so it cannot block `tt agent end`.
+    let case = Case::new("report-read-only");
+    case.write_store(&[agent_row(
+        "did the thing",
+        "tt",
+        &["tt/12", "impl", "agent"],
+        today(),
+        9,
+        30,
+    )]);
+
+    let path = case.data_dir().join("data.json");
+    let before = std::fs::read(&path).expect("the fabricated store");
+    let before_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+    case.run_bare(&["report"]).assert_status(0);
+
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        before,
+        "the store was rewritten by a read"
+    );
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().modified().unwrap(),
+        before_mtime,
+        "the store's mtime moved, so something wrote it"
+    );
+    // And no lock file was left behind by a writer that never needed to be one.
+    assert!(
+        !case.data_dir().join("data.lock").exists(),
+        "a read took the store's exclusive lock"
+    );
+}
+
+#[test]
+fn a_pre_project_store_still_reports_its_inferred_projects() {
+    // `report` migrates its own in-memory copy, so a pre-`project` store rolls up
+    // under the project inferred from its tags, without that being written back.
+    let case = Case::new("report-pre-project-store");
+    let start = epoch_on(today(), 9);
+    case.write_raw_store(&format!(
+        r#"{{"entries":[{{"id":1,"description":"premium brand primitives","project":null,"tags":["vinge","vinge/12","impl"],"start_time":"{}","end_time":"{}","idle":[]}}],"next_id":2,"schema_version":0}}"#,
+        stamp(start),
+        stamp(start + 45 * 60)
+    ));
+
+    let run = case.run_bare(&["report"]);
+    run.assert_status(0);
+    assert!(
+        run.stdout.contains("vinge"),
+        "the inferred project is the axis: {:?}",
+        run.stdout
+    );
+    run.assert_stdout_has("0h 45m");
+
+    // Inferred for the reader only: the file is still at version 0.
+    let stored = std::fs::read_to_string(case.data_dir().join("data.json")).unwrap();
+    assert!(
+        stored.contains(r#""schema_version":0"#),
+        "the migration was written back: {stored}"
+    );
+}


### PR DESCRIPTION
Unsolicited and large, so please treat it as a proposal. Each of the seven commits builds and passes the suite on its own, so any prefix of them stands alone — smaller, or not at all, are both fine answers.

## Adds

- **`tt agent begin|touch|end|item|cancel|list`** — marks a phase of work as a file keyed `project/issue/phase`. `end` measures to the phase's last heartbeat rather than to now, and refuses rather than guessing when it finds a long silence inside the phase. 15-minute rounding, 15-minute floor.
- **`tt report`** — rollup by project and item, with `--week`, `--all`, `--since/--until`, `--project`, `--json`. Counts overlapping spans.
- **`tt log --idle=<start>-<end>`** records a silent stretch; `--trim` splits the entry into the pieces between them, inside one store transaction.
- **TUI** — an Agents panel (`Shift-A`), a project summary (`Shift-S`), idle rows in the detail popover with `[t]` to trim one, and confirmation prompts on the destructive keys.
- **`[agent]` config** — the two thresholds `end` judges a phase against. Environment overrides the file, which overrides the default.
- **`AGENTS.md`** — the convention that makes the recorded numbers mean anything.

## Changes existing behaviour

- **Store writes are serialised** under one exclusive lock across load → edit → save. Two overlapping commands previously read the same snapshot, and the second save discarded the first's entry.
- **Entries gained `project` and `idle`**, plus `schema_version` and a one-shot migration that infers a missing project from the tags. An older store loads unchanged.
- **`tt log` gained `--project`, `--idle`, `--trim`.**
- **`d` in the TUI now asks before deleting.**

## Verification

29 → 215 tests across the seven commits, none failing, so it bisects. Clippy is below `main`'s count. `cargo fmt` was not run, so no unrelated reformatting is in the diff. The TUI surfaces were checked rendered in a pty, and the theme colours resolve to the same values as before.

Merges cleanly — `main` is an ancestor. Marks live in the app's own cache directory, with `TT_MARK_DIR` to override in tests.
