### PR TITLE
Add hook-only activity ledger (#6)

### DIFF
--- a/skills/tt-time-logging/scripts/install-hooks.mjs
+++ b/skills/tt-time-logging/scripts/install-hooks.mjs
@@ -4,17 +4,28 @@
 // `npx skills add` only copies SKILL.md (and this directory) into place — it
 // is tool-agnostic and knows nothing about Claude Code's hooks. Prose in a
 // skill is model-invoked and gets skipped under context pressure, so this
-// script wires two hooks into the user's *global* ~/.claude/settings.json —
-// not a project-local one, since the whole point is that they fire in every
+// script wires hooks into the user's *global* ~/.claude/settings.json — not a
+// project-local one, since the whole point is that they fire in every
 // session, in every project, not just the one the skill happened to be
 // installed into:
 //
 //   SessionStart - injects this skill's contract into every session's
-//                  context directly, unconditionally (no model judgment).
+//                  context directly, unconditionally (no model judgment);
+//                  also opens this session's `tt agent activity` window.
 //   Stop         - runs `tt agent list` and warns (non-blocking) if this
-//                  project has marks still open when the agent stops.
+//                  project has marks still open when the agent stops; also
+//                  closes this session's `tt agent activity` window.
+//   SubagentStop - records that one subagent dispatch finished during this
+//                  session's activity window.
 //
-// Both hook commands reference absolute paths under ~/.claude/hooks/, not
+// The activity-ledger hooks are a second, model-independent signal that a
+// session was active at all, reconciled against marks separately from this
+// contract — see docs/decisions/0001-agent-activity-tracking.md in the
+// timetracker-rs source repo. Each invocation is keyed by Claude Code's own
+// `session_id`, read from the hook's JSON payload on stdin — the one id
+// stable across a SessionStart/Stop pair.
+//
+// All hook commands reference absolute paths under ~/.claude/hooks/, not
 // paths relative to whatever cwd Claude Code happens to invoke hooks with —
 // a relative path silently fails to resolve on at least Windows.
 //
@@ -48,10 +59,12 @@ const settingsPath = join(claudeHome, "settings.json");
 const destDir = join(claudeHome, "hooks", "tt-time-logging");
 const skillMdDest = join(destDir, "SKILL.md");
 const stopCheckDest = join(destDir, "tt-stop-check.mjs");
+const activityHookDest = join(destDir, "tt-activity-hook.mjs");
 
 mkdirSync(destDir, { recursive: true });
 copyFileSync(join(skillDir, "SKILL.md"), skillMdDest);
 copyFileSync(join(scriptDir, "tt-stop-check.mjs"), stopCheckDest);
+copyFileSync(join(scriptDir, "tt-activity-hook.mjs"), activityHookDest);
 
 // Forward slashes only: Node's fs calls accept them on every OS, and it
 // sidesteps having to escape backslashes inside the nested JS string literal
@@ -59,6 +72,7 @@ copyFileSync(join(scriptDir, "tt-stop-check.mjs"), stopCheckDest);
 const toFwd = (p) => p.replace(/\\/g, "/");
 const skillMdAbs = toFwd(skillMdDest);
 const stopCheckAbs = toFwd(stopCheckDest);
+const activityHookAbs = toFwd(activityHookDest);
 
 let settings = {};
 if (existsSync(settingsPath)) {
@@ -68,10 +82,14 @@ if (existsSync(settingsPath)) {
 settings.hooks ??= {};
 settings.hooks.SessionStart ??= [];
 settings.hooks.Stop ??= [];
+settings.hooks.SubagentStop ??= [];
 
 const sessionStartCmd = `node -e "const fs=require('fs');process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'SessionStart',additionalContext:fs.readFileSync('${skillMdAbs}','utf8')}}))"`;
 // Quoted: an absolute home path can contain spaces (e.g. "C:/Users/John Doe/...").
 const stopCmd = `node "${stopCheckAbs}"`;
+const activityBeginCmd = `node "${activityHookAbs}" begin`;
+const activityEndCmd = `node "${activityHookAbs}" end`;
+const activitySubagentCmd = `node "${activityHookAbs}" subagent`;
 
 const hasCommand = (event, command) =>
   settings.hooks[event].some((entry) => entry.hooks?.some((h) => h.command === command));
@@ -82,14 +100,32 @@ if (!hasCommand("SessionStart", sessionStartCmd)) {
   });
 }
 
+if (!hasCommand("SessionStart", activityBeginCmd)) {
+  settings.hooks.SessionStart.push({
+    hooks: [{ type: "command", command: activityBeginCmd, statusMessage: "Opening tt activity window" }],
+  });
+}
+
 if (!hasCommand("Stop", stopCmd)) {
   settings.hooks.Stop.push({
     hooks: [{ type: "command", command: stopCmd, statusMessage: "Checking for unclosed tt marks" }],
   });
 }
 
+if (!hasCommand("Stop", activityEndCmd)) {
+  settings.hooks.Stop.push({
+    hooks: [{ type: "command", command: activityEndCmd, statusMessage: "Closing tt activity window" }],
+  });
+}
+
+if (!hasCommand("SubagentStop", activitySubagentCmd)) {
+  settings.hooks.SubagentStop.push({
+    hooks: [{ type: "command", command: activitySubagentCmd, statusMessage: "Recording tt subagent activity" }],
+  });
+}
+
 writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
 
 console.log(`tt-time-logging hooks installed into ${settingsPath}.`);
-console.log(`Contract and stop-check script copied into ${destDir}.`);
+console.log(`Contract, stop-check and activity-hook scripts copied into ${destDir}.`);
 console.log("Restart Claude Code or open /hooks once so the new settings file is picked up.");

--- a/skills/tt-time-logging/scripts/install-hooks.mjs
+++ b/skills/tt-time-logging/scripts/install-hooks.mjs
@@ -2,34 +2,23 @@
 // Claude-Code-specific enforcement for the tt-time-logging skill.
 //
 // `npx skills add` only copies SKILL.md (and this directory) into place — it
-// is tool-agnostic and knows nothing about Claude Code's hooks. Prose in a
-// skill is model-invoked and gets skipped under context pressure, so this
-// script wires hooks into the user's *global* ~/.claude/settings.json — not a
-// project-local one, since the whole point is that they fire in every
-// session, in every project, not just the one the skill happened to be
-// installed into:
+// knows nothing about Claude Code's hooks, and prose alone gets skipped under
+// context pressure. This script wires hooks into the user's *global*
+// ~/.claude/settings.json (not project-local, since they must fire in every
+// session):
 //
-//   SessionStart - injects this skill's contract into every session's
-//                  context directly, unconditionally (no model judgment);
-//                  also opens this session's `tt agent activity` window.
-//   Stop         - runs `tt agent list` and warns (non-blocking) if this
-//                  project has marks still open when the agent stops; also
-//                  closes this session's `tt agent activity` window.
-//   SubagentStop - records that one subagent dispatch finished during this
-//                  session's activity window.
+//   SessionStart - injects this skill's contract; opens the activity window.
+//   Stop         - warns about open marks; closes the activity window.
+//   SubagentStop - records a subagent dispatch on the activity window.
 //
-// The activity-ledger hooks are a second, model-independent signal that a
-// session was active at all, reconciled against marks separately from this
-// contract — see docs/decisions/0001-agent-activity-tracking.md in the
-// timetracker-rs source repo. Each invocation is keyed by Claude Code's own
-// `session_id`, read from the hook's JSON payload on stdin — the one id
-// stable across a SessionStart/Stop pair.
+// The activity ledger is a second, model-independent signal that a session
+// was active — see docs/decisions/0001-agent-activity-tracking.md. Keyed by
+// Claude Code's own `session_id`, read off the hook's stdin JSON.
 //
-// All hook commands reference absolute paths under ~/.claude/hooks/, not
-// paths relative to whatever cwd Claude Code happens to invoke hooks with —
-// a relative path silently fails to resolve on at least Windows.
+// All hook commands use absolute paths under ~/.claude/hooks/ — relative
+// paths silently fail to resolve on at least Windows.
 //
-// Safe to re-run: both entries are added only if not already present.
+// Safe to re-run: entries are added only if not already present.
 //
 // Usage (from anywhere, after `npx skills add ...`):
 //   node <wherever the skill landed>/scripts/install-hooks.mjs

--- a/skills/tt-time-logging/scripts/tt-activity-hook.mjs
+++ b/skills/tt-time-logging/scripts/tt-activity-hook.mjs
@@ -1,18 +1,14 @@
 #!/usr/bin/env node
 // SessionStart/Stop/SubagentStop hook: writes to `tt`'s hook-only activity
-// ledger (`tt agent activity …`), a second, model-independent signal that a
-// session was active — see
-// docs/decisions/0001-agent-activity-tracking.md in the timetracker-rs
-// source repo. Installed by install-hooks.mjs.
+// ledger (`tt agent activity …`) — see
+// docs/decisions/0001-agent-activity-tracking.md. Installed by
+// install-hooks.mjs.
 //
 // Usage: node tt-activity-hook.mjs <begin|end|subagent>
 //
-// The event name maps straight onto the `tt agent activity` subcommand.
-// Claude Code passes the hook's JSON payload on stdin; `session_id` there is
-// the one id stable across a SessionStart/Stop pair for one session, so it is
-// the key every activity entry is filed under. A payload that cannot be read
-// or parsed, or carries no `session_id`, is silently skipped — a hook must
-// never fail the harness event it is attached to.
+// `session_id` (read from the hook's JSON payload on stdin) is the key every
+// entry is filed under. Missing or unparseable payload: silently skipped —
+// a hook must never fail the harness event it's attached to.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -65,9 +61,7 @@ if (event === "begin") {
 try {
   execFileSync("tt", args, { stdio: "ignore" });
 } catch {
-  // A hook must never fail the harness event over `tt` being missing or
-  // erroring — the SessionStart/Stop contract itself already warns about
-  // that separately.
+  // never fail the harness event over `tt` being missing or erroring
 }
 
 process.stdout.write("{}");

--- a/skills/tt-time-logging/scripts/tt-activity-hook.mjs
+++ b/skills/tt-time-logging/scripts/tt-activity-hook.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// SessionStart/Stop/SubagentStop hook: writes to `tt`'s hook-only activity
+// ledger (`tt agent activity …`), a second, model-independent signal that a
+// session was active — see
+// docs/decisions/0001-agent-activity-tracking.md in the timetracker-rs
+// source repo. Installed by install-hooks.mjs.
+//
+// Usage: node tt-activity-hook.mjs <begin|end|subagent>
+//
+// The event name maps straight onto the `tt agent activity` subcommand.
+// Claude Code passes the hook's JSON payload on stdin; `session_id` there is
+// the one id stable across a SessionStart/Stop pair for one session, so it is
+// the key every activity entry is filed under. A payload that cannot be read
+// or parsed, or carries no `session_id`, is silently skipped — a hook must
+// never fail the harness event it is attached to.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+function readStdin() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function projectName() {
+  if (process.env.TT_PROJECT) return process.env.TT_PROJECT;
+  try {
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+    }).trim();
+    return root.split(/[\\/]/).pop();
+  } catch {
+    return null;
+  }
+}
+
+const event = process.argv[2];
+if (!["begin", "end", "subagent"].includes(event)) {
+  process.stdout.write("{}");
+  process.exit(0);
+}
+
+let sessionId;
+try {
+  const payload = JSON.parse(readStdin());
+  sessionId = payload.session_id;
+} catch {
+  sessionId = undefined;
+}
+
+if (!sessionId) {
+  process.stdout.write("{}");
+  process.exit(0);
+}
+
+const args = ["agent", "activity", event, sessionId];
+if (event === "begin") {
+  const project = projectName();
+  if (project) args.push(project);
+}
+
+try {
+  execFileSync("tt", args, { stdio: "ignore" });
+} catch {
+  // A hook must never fail the harness event over `tt` being missing or
+  // erroring — the SessionStart/Stop contract itself already warns about
+  // that separately.
+}
+
+process.stdout.write("{}");

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,0 +1,233 @@
+//! Reader and writer for the hook-only activity ledger.
+//!
+//! Alongside `marks/`, `activity/` holds one file per Claude Code session,
+//! keyed by the harness's own session id — never a phase, an issue, or a
+//! project's own choice of anything. It is written only by the
+//! `SessionStart`/`Stop`/`SubagentStop` hooks (see
+//! `skills/tt-time-logging/scripts/`), never by the agent's own judgment, so
+//! its presence proves a session was active regardless of whether the model
+//! ever called `tt agent begin`. See
+//! `docs/decisions/0001-agent-activity-tracking.md` for why this exists
+//! alongside marks rather than replacing them.
+//!
+//! An entry carries no phase, no issue, no summary — just a start, an
+//! optional end, and every subagent dispatch that finished during the
+//! session. That is all a hook can know without the model's judgment.
+
+use chrono::Local;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// The directory activity entries live in: `$TT_ACTIVITY_DIR` when set and
+/// non-empty, else `activity` inside this app's cache directory — a sibling of
+/// `marks`. `None` only when there is no home directory to resolve.
+pub fn activity_dir() -> Option<PathBuf> {
+    resolve_activity_dir(std::env::var_os("TT_ACTIVITY_DIR"), cache_dir())
+}
+
+/// Same cache root [`crate::marks::mark_dir`] resolves from, so a sandboxed
+/// `HOME` redirects activity entries the same way it redirects marks.
+fn cache_dir() -> Option<PathBuf> {
+    let dirs = directories::ProjectDirs::from("com", "timetracker", "tt")?;
+    Some(dirs.cache_dir().to_path_buf())
+}
+
+/// The env-free half of [`activity_dir`], taking the resolved cache root.
+fn resolve_activity_dir(activity_dir: Option<OsString>, cache: Option<PathBuf>) -> Option<PathBuf> {
+    match activity_dir {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => Some(cache?.join("activity")),
+    }
+}
+
+/// The sanitised filename for one session: `session_id` with every character
+/// outside `[A-Za-z0-9._-]` replaced by `_`, the same rule [`crate::marks`]
+/// applies to a mark's key.
+fn session_key(session_id: &str) -> String {
+    session_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn session_path(dir: &Path, session_id: &str) -> PathBuf {
+    dir.join(session_key(session_id))
+}
+
+/// `SessionStart`: open this session's activity window, holding its start
+/// epoch and resolved project. Idempotent — an existing file for this session
+/// id is left byte-identical, so a hook that fires twice for one id never
+/// overwrites the real start.
+pub fn begin_in(dir: &Path, session_id: &str, project: Option<&str>) -> io::Result<()> {
+    fs::create_dir_all(dir)?;
+    let path = session_path(dir, session_id);
+    let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    writeln!(file, "start={}", Local::now().timestamp())?;
+    if let Some(project) = project {
+        writeln!(file, "project={project}")?;
+    }
+    Ok(())
+}
+
+/// `Stop`: append this session's end epoch. Appended, never overwritten, so a
+/// `Stop` that fires more than once records every close rather than losing
+/// the first. The file is created bare if `Stop` somehow fires with no prior
+/// `begin_in` — e.g. the hook was installed mid-session — so an end is never
+/// lost for want of a start.
+pub fn end_in(dir: &Path, session_id: &str) -> io::Result<()> {
+    append_field(dir, session_id, "end")
+}
+
+/// `SubagentStop`: append a marker that one subagent dispatch finished during
+/// this session's window. Carries no start of its own — `SubagentStop` alone
+/// cannot know when its dispatch began — so this is evidence a dispatch
+/// happened, not a nested window with its own span.
+pub fn subagent_in(dir: &Path, session_id: &str) -> io::Result<()> {
+    append_field(dir, session_id, "subagent")
+}
+
+fn append_field(dir: &Path, session_id: &str, field: &str) -> io::Result<()> {
+    fs::create_dir_all(dir)?;
+    let path = session_path(dir, session_id);
+    let mut file = OpenOptions::new().append(true).create(true).open(&path)?;
+    writeln!(file, "{field}={}", Local::now().timestamp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sandbox(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-activity-test-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn read(dir: &Path, session_id: &str) -> String {
+        fs::read_to_string(session_path(dir, session_id)).unwrap()
+    }
+
+    #[test]
+    fn begin_writes_start_and_project() {
+        let dir = sandbox("begin");
+        begin_in(&dir, "sess-1", Some("timetracker")).unwrap();
+
+        let body = read(&dir, "sess-1");
+        assert!(body.lines().any(|l| l.starts_with("start=")));
+        assert_eq!(
+            body.lines().find(|l| l.starts_with("project=")),
+            Some("project=timetracker")
+        );
+    }
+
+    #[test]
+    fn begin_with_no_project_writes_no_project_line() {
+        let dir = sandbox("begin-no-project");
+        begin_in(&dir, "sess-1", None).unwrap();
+
+        let body = read(&dir, "sess-1");
+        assert!(!body.lines().any(|l| l.starts_with("project=")));
+    }
+
+    #[test]
+    fn a_second_begin_leaves_the_first_start_untouched() {
+        let dir = sandbox("begin-twice");
+        begin_in(&dir, "sess-1", Some("first")).unwrap();
+        let first = read(&dir, "sess-1");
+
+        begin_in(&dir, "sess-1", Some("second")).unwrap();
+        assert_eq!(
+            read(&dir, "sess-1"),
+            first,
+            "the original start was rewritten"
+        );
+    }
+
+    #[test]
+    fn end_appends_without_disturbing_start() {
+        let dir = sandbox("end");
+        begin_in(&dir, "sess-1", Some("tt")).unwrap();
+        end_in(&dir, "sess-1").unwrap();
+
+        let body = read(&dir, "sess-1");
+        let lines: Vec<&str> = body.lines().collect();
+        assert!(lines[0].starts_with("start="));
+        assert!(lines.iter().any(|l| l.starts_with("end=")));
+    }
+
+    #[test]
+    fn end_with_no_prior_begin_still_records_something() {
+        let dir = sandbox("end-no-begin");
+        end_in(&dir, "sess-1").unwrap();
+
+        let body = read(&dir, "sess-1");
+        assert!(body.lines().any(|l| l.starts_with("end=")));
+    }
+
+    #[test]
+    fn subagent_markers_accumulate_one_per_dispatch() {
+        let dir = sandbox("subagent");
+        begin_in(&dir, "sess-1", Some("tt")).unwrap();
+        subagent_in(&dir, "sess-1").unwrap();
+        subagent_in(&dir, "sess-1").unwrap();
+
+        let body = read(&dir, "sess-1");
+        assert_eq!(
+            body.lines().filter(|l| l.starts_with("subagent=")).count(),
+            2
+        );
+    }
+
+    #[test]
+    fn a_session_id_with_unsafe_characters_is_sanitised() {
+        let dir = sandbox("sanitise");
+        begin_in(&dir, "weird/id:with*chars", Some("tt")).unwrap();
+
+        let entries: Vec<_> = fs::read_dir(&dir).unwrap().flatten().collect();
+        assert_eq!(entries.len(), 1);
+        let name = entries[0].file_name();
+        assert!(
+            name.to_str()
+                .unwrap()
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')),
+            "{name:?} was not sanitised"
+        );
+    }
+
+    #[test]
+    fn the_default_directory_is_activity_inside_the_app_cache_dir() {
+        let cache = || Some(PathBuf::from("cache"));
+        assert_eq!(
+            resolve_activity_dir(None, cache()),
+            Some(PathBuf::from("cache").join("activity"))
+        );
+        assert_eq!(
+            resolve_activity_dir(Some("".into()), cache()),
+            Some(PathBuf::from("cache").join("activity")),
+            "an empty TT_ACTIVITY_DIR is no setting at all"
+        );
+        assert_eq!(
+            resolve_activity_dir(Some("elsewhere".into()), cache()),
+            Some(PathBuf::from("elsewhere"))
+        );
+        assert_eq!(
+            resolve_activity_dir(None, None),
+            None,
+            "no cache dir, no default"
+        );
+    }
+}

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,18 +1,10 @@
 //! Reader and writer for the hook-only activity ledger.
 //!
 //! Alongside `marks/`, `activity/` holds one file per Claude Code session,
-//! keyed by the harness's own session id — never a phase, an issue, or a
-//! project's own choice of anything. It is written only by the
-//! `SessionStart`/`Stop`/`SubagentStop` hooks (see
-//! `skills/tt-time-logging/scripts/`), never by the agent's own judgment, so
-//! its presence proves a session was active regardless of whether the model
-//! ever called `tt agent begin`. See
-//! `docs/decisions/0001-agent-activity-tracking.md` for why this exists
-//! alongside marks rather than replacing them.
-//!
-//! An entry carries no phase, no issue, no summary — just a start, an
-//! optional end, and every subagent dispatch that finished during the
-//! session. That is all a hook can know without the model's judgment.
+//! keyed by the harness's own session id. Written only by hooks (see
+//! `skills/tt-time-logging/scripts/`), never by the model, so its presence
+//! proves a session was active even if `tt agent begin` was never called.
+//! See `docs/decisions/0001-agent-activity-tracking.md`.
 
 use chrono::Local;
 use std::ffi::OsString;
@@ -20,21 +12,18 @@ use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-/// The directory activity entries live in: `$TT_ACTIVITY_DIR` when set and
-/// non-empty, else `activity` inside this app's cache directory — a sibling of
-/// `marks`. `None` only when there is no home directory to resolve.
+/// `$TT_ACTIVITY_DIR` when set, else `activity` inside the cache dir —
+/// a sibling of `marks`.
 pub fn activity_dir() -> Option<PathBuf> {
     resolve_activity_dir(std::env::var_os("TT_ACTIVITY_DIR"), cache_dir())
 }
 
-/// Same cache root [`crate::marks::mark_dir`] resolves from, so a sandboxed
-/// `HOME` redirects activity entries the same way it redirects marks.
+/// Same cache root [`crate::marks::mark_dir`] resolves from.
 fn cache_dir() -> Option<PathBuf> {
     let dirs = directories::ProjectDirs::from("com", "timetracker", "tt")?;
     Some(dirs.cache_dir().to_path_buf())
 }
 
-/// The env-free half of [`activity_dir`], taking the resolved cache root.
 fn resolve_activity_dir(activity_dir: Option<OsString>, cache: Option<PathBuf>) -> Option<PathBuf> {
     match activity_dir {
         Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
@@ -42,9 +31,7 @@ fn resolve_activity_dir(activity_dir: Option<OsString>, cache: Option<PathBuf>) 
     }
 }
 
-/// The sanitised filename for one session: `session_id` with every character
-/// outside `[A-Za-z0-9._-]` replaced by `_`, the same rule [`crate::marks`]
-/// applies to a mark's key.
+/// Sanitised the same way [`crate::marks::mark_key`] sanitises a mark's key.
 fn session_key(session_id: &str) -> String {
     session_id
         .chars()
@@ -62,10 +49,8 @@ fn session_path(dir: &Path, session_id: &str) -> PathBuf {
     dir.join(session_key(session_id))
 }
 
-/// `SessionStart`: open this session's activity window, holding its start
-/// epoch and resolved project. Idempotent — an existing file for this session
-/// id is left byte-identical, so a hook that fires twice for one id never
-/// overwrites the real start.
+/// `SessionStart`: open this session's window. Idempotent — an existing file
+/// is left untouched, so a hook firing twice never overwrites the real start.
 pub fn begin_in(dir: &Path, session_id: &str, project: Option<&str>) -> io::Result<()> {
     fs::create_dir_all(dir)?;
     let path = session_path(dir, session_id);
@@ -81,19 +66,14 @@ pub fn begin_in(dir: &Path, session_id: &str, project: Option<&str>) -> io::Resu
     Ok(())
 }
 
-/// `Stop`: append this session's end epoch. Appended, never overwritten, so a
-/// `Stop` that fires more than once records every close rather than losing
-/// the first. The file is created bare if `Stop` somehow fires with no prior
-/// `begin_in` — e.g. the hook was installed mid-session — so an end is never
-/// lost for want of a start.
+/// `Stop`: append this session's end epoch. A missing session file is
+/// created bare, so an end is never lost for want of a prior `begin_in`.
 pub fn end_in(dir: &Path, session_id: &str) -> io::Result<()> {
     append_field(dir, session_id, "end")
 }
 
-/// `SubagentStop`: append a marker that one subagent dispatch finished during
-/// this session's window. Carries no start of its own — `SubagentStop` alone
-/// cannot know when its dispatch began — so this is evidence a dispatch
-/// happened, not a nested window with its own span.
+/// `SubagentStop`: mark that one subagent dispatch finished. No start of its
+/// own — just evidence a dispatch happened, not a windowed span.
 pub fn subagent_in(dir: &Path, session_id: &str) -> io::Result<()> {
     append_field(dir, session_id, "subagent")
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -72,9 +72,8 @@ pub fn run(command: &AgentCommands) -> Result<()> {
     }
 }
 
-/// The activity directory, silently doing nothing if it cannot be resolved —
-/// a hook must never fail the harness event it is attached to over a missing
-/// home directory.
+/// Silently does nothing if the activity dir can't be resolved — a hook must
+/// never fail the harness event it's attached to.
 fn activity_command(command: &ActivityCommands) -> Result<()> {
     let Some(dir) = activity::activity_dir() else {
         return Ok(());

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,7 +13,8 @@ use chrono::{DateTime, Local};
 
 use crate::tracker::IdleInterval;
 
-use crate::cli::{self, AgentCommands};
+use crate::activity;
+use crate::cli::{self, ActivityCommands, AgentCommands};
 use crate::config;
 use crate::icons;
 use crate::marks::{self, Begin, Touch};
@@ -67,7 +68,26 @@ pub fn run(command: &AgentCommands) -> Result<()> {
             *full,
             *trim,
         ),
+        AgentCommands::Activity(command) => activity_command(command),
     }
+}
+
+/// The activity directory, silently doing nothing if it cannot be resolved —
+/// a hook must never fail the harness event it is attached to over a missing
+/// home directory.
+fn activity_command(command: &ActivityCommands) -> Result<()> {
+    let Some(dir) = activity::activity_dir() else {
+        return Ok(());
+    };
+    match command {
+        ActivityCommands::Begin {
+            session_id,
+            project,
+        } => activity::begin_in(&dir, session_id, project.as_deref())?,
+        ActivityCommands::End { session_id } => activity::end_in(&dir, session_id)?,
+        ActivityCommands::Subagent { session_id } => activity::subagent_in(&dir, session_id)?,
+    }
+    Ok(())
 }
 
 /// The mark directory, or an error — a `begin` must never silently record

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,6 +181,29 @@ pub enum AgentCommands {
         #[arg(long)]
         trim: bool,
     },
+    /// The hook-only activity ledger, hidden from `--help`: written by
+    /// Claude Code's SessionStart/Stop/SubagentStop hooks, never by an
+    /// agent's own judgment. See docs/decisions/0001-agent-activity-tracking.md.
+    #[command(hide = true, subcommand)]
+    Activity(ActivityCommands),
+}
+
+/// See [`AgentCommands::Activity`]. Each hook invocation names the harness's
+/// own session id, the one stable key across a SessionStart/Stop pair.
+#[derive(Subcommand)]
+pub enum ActivityCommands {
+    /// SessionStart: open this session's activity window.
+    Begin {
+        session_id: String,
+        /// Resolved the same way the skill resolves it: `$TT_PROJECT`, else
+        /// the repo directory name, else omitted.
+        project: Option<String>,
+    },
+    /// Stop: close this session's activity window.
+    End { session_id: String },
+    /// SubagentStop: record that one subagent dispatch finished during this
+    /// session's window.
+    Subagent { session_id: String },
 }
 
 impl AgentCommands {
@@ -193,7 +216,8 @@ impl AgentCommands {
             AgentCommands::Begin { .. }
             | AgentCommands::Touch { .. }
             | AgentCommands::Cancel { .. }
-            | AgentCommands::List => false,
+            | AgentCommands::List
+            | AgentCommands::Activity(_) => false,
             AgentCommands::Item { .. } | AgentCommands::End { .. } => true,
         }
     }
@@ -219,10 +243,7 @@ fn parse_idle(value: &str) -> Result<IdleInterval, String> {
     let start = stamp("start", start)?;
     let end = stamp("end", end)?;
     if end < start {
-        return Err(format!(
-            "idle interval ends before it starts: `{}`",
-            value
-        ));
+        return Err(format!("idle interval ends before it starts: `{}`", value));
     }
     Ok(IdleInterval::new(start, end))
 }
@@ -290,9 +311,9 @@ pub fn start(description: Vec<String>, project: Option<String>) -> Result<()> {
 
 pub fn stop() -> Result<()> {
     let stopped = with_data(|data| {
-        let info = data.active_entry().map(|e| {
-            (e.description.clone(), e.format_duration())
-        });
+        let info = data
+            .active_entry()
+            .map(|e| (e.description.clone(), e.format_duration()));
 
         if data.stop_active() {
             Ok(info)
@@ -302,7 +323,12 @@ pub fn stop() -> Result<()> {
     })?;
 
     if let Some((desc, dur)) = stopped {
-        println!("{}  Stopped: \"{}\" - Duration: {}", icons::stopped(), desc, dur);
+        println!(
+            "{}  Stopped: \"{}\" - Duration: {}",
+            icons::stopped(),
+            desc,
+            dur
+        );
     } else {
         println!("No active task to stop.");
     }
@@ -383,7 +409,11 @@ pub fn today() -> Result<()> {
 
     println!("{} Today's entries:\n", icons::calendar());
     for entry in &today_entries {
-        let status = if entry.is_active() { entry.status_icon() } else { "  " };
+        let status = if entry.is_active() {
+            entry.status_icon()
+        } else {
+            "  "
+        };
         let tags_display = if entry.tags.is_empty() {
             String::new()
         } else {
@@ -414,7 +444,11 @@ pub fn list(limit: Option<usize>) -> Result<()> {
 
     println!("{} All entries:\n", icons::list());
     for entry in data.entries.iter().rev().take(limit) {
-        let status = if entry.is_active() { entry.status_icon() } else { "  " };
+        let status = if entry.is_active() {
+            entry.status_icon()
+        } else {
+            "  "
+        };
         let tags_display = if entry.tags.is_empty() {
             String::new()
         } else {
@@ -438,7 +472,11 @@ pub fn status() -> Result<()> {
     let data = load_data()?;
 
     if let Some(active) = data.active_entry() {
-        println!("{}  Currently tracking: \"{}\"", icons::active(), active.description);
+        println!(
+            "{}  Currently tracking: \"{}\"",
+            icons::active(),
+            active.description
+        );
         if let Some(project) = &active.project {
             println!("   Project: {}", project);
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,28 +181,23 @@ pub enum AgentCommands {
         #[arg(long)]
         trim: bool,
     },
-    /// The hook-only activity ledger, hidden from `--help`: written by
-    /// Claude Code's SessionStart/Stop/SubagentStop hooks, never by an
-    /// agent's own judgment. See docs/decisions/0001-agent-activity-tracking.md.
+    /// Hook-only activity ledger, hidden from `--help` — never called by the
+    /// model. See docs/decisions/0001-agent-activity-tracking.md.
     #[command(hide = true, subcommand)]
     Activity(ActivityCommands),
 }
 
-/// See [`AgentCommands::Activity`]. Each hook invocation names the harness's
-/// own session id, the one stable key across a SessionStart/Stop pair.
+/// See [`AgentCommands::Activity`]. Keyed by Claude Code's own session id.
 #[derive(Subcommand)]
 pub enum ActivityCommands {
     /// SessionStart: open this session's activity window.
     Begin {
         session_id: String,
-        /// Resolved the same way the skill resolves it: `$TT_PROJECT`, else
-        /// the repo directory name, else omitted.
         project: Option<String>,
     },
     /// Stop: close this session's activity window.
     End { session_id: String },
-    /// SubagentStop: record that one subagent dispatch finished during this
-    /// session's window.
+    /// SubagentStop: record that one subagent dispatch finished.
     Subagent { session_id: String },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+mod activity;
 mod agent;
 mod cli;
 mod config;


### PR DESCRIPTION
Implements #6 — foundational piece of the activity-ledger ADR (`docs/decisions/0001-agent-activity-tracking.md`).

## What this adds

- `src/activity.rs`: a new `activity/` directory alongside `marks/`, owning the file format the same way `marks.rs` owns the mark format. One file per Claude Code session, keyed by the harness's own `session_id`, holding:
  - `start=<epoch>` on `SessionStart`
  - `end=<epoch>` appended on `Stop`
  - `subagent=<epoch>` appended once per dispatch on `SubagentStop`
- A hidden `tt agent activity begin|end|subagent <session_id> [project]` subcommand so hooks call into the one place that owns the format, instead of reimplementing path resolution/sanitisation in JS.
- `skills/tt-time-logging/scripts/tt-activity-hook.mjs`: reads `session_id` off the hook's stdin JSON and shells out to `tt agent activity <event>`.
- `install-hooks.mjs` updated to also wire `SessionStart`/`Stop`/`SubagentStop` to the new script, alongside the existing contract-injection and stop-check hooks.

## Design notes / open questions

- `SubagentStop` only records a bare marker (`subagent=<epoch>`), not a start/end window — a `SubagentStop`-only hook can't know when its dispatch began. Good enough as "something happened," per the ADR's own scope, but only a partial nested window.
- Directory resolution mirrors `marks.rs`: `$TT_ACTIVITY_DIR` override, else `activity/` inside the same cache dir as `marks/`.
- No reconciliation logic yet — that's #7. This PR only makes the independent signal exist.

## Testing

- `cargo test` — 251 passed, 0 failed
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt` — clean

Draft while #7 (reconciliation) design settles, since the file format here is what #7 will read back.