### PR TITLE
Reconcile activity ledger against marks and entries (#7)

### DIFF
--- a/src/activity.rs
+++ b/src/activity.rs
@@ -85,6 +85,64 @@ fn append_field(dir: &Path, session_id: &str, field: &str) -> io::Result<()> {
     writeln!(file, "{field}={}", Local::now().timestamp())
 }
 
+// --- reader -----------------------------------------------------------
+//
+// Read only, for `tt agent audit` (see `src/audit.rs`) — nothing here writes.
+
+/// One session's window, as read back from its file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Session {
+    pub project: Option<String>,
+    pub start: i64,
+    /// `None` while the session is still open.
+    pub end: Option<i64>,
+    /// How many `subagent=` markers were recorded.
+    pub subagents: usize,
+}
+
+/// Every session in `dir`. A file with no `start=` line is skipped — it is
+/// not a session this ledger recognises.
+pub fn read_sessions_in(dir: &Path) -> Vec<Session> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter_map(|e| read_session(&e.path()))
+        .collect()
+}
+
+fn read_session(path: &Path) -> Option<Session> {
+    let body = fs::read_to_string(path).ok()?;
+    let mut project = None;
+    let mut start = None;
+    let mut end = None;
+    let mut subagents = 0;
+
+    for line in body.lines() {
+        let Some((field, value)) = line.split_once('=') else {
+            continue;
+        };
+        match field {
+            "project" => project = Some(value.to_string()),
+            "start" => start = value.parse().ok(),
+            // The last `end=` line wins, so a Stop that fired more than once
+            // is measured to its final close.
+            "end" => end = value.parse().ok(),
+            "subagent" => subagents += 1,
+            _ => {}
+        }
+    }
+
+    Some(Session {
+        project,
+        start: start?,
+        end,
+        subagents,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,6 +244,61 @@ mod tests {
                 .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')),
             "{name:?} was not sanitised"
         );
+    }
+
+    // --- reader -------------------------------------------------------
+
+    #[test]
+    fn a_session_reads_back_its_project_start_end_and_subagent_count() {
+        let dir = sandbox("read-round-trip");
+        begin_in(&dir, "sess-1", Some("tt")).unwrap();
+        subagent_in(&dir, "sess-1").unwrap();
+        subagent_in(&dir, "sess-1").unwrap();
+        end_in(&dir, "sess-1").unwrap();
+
+        let sessions = read_sessions_in(&dir);
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.project.as_deref(), Some("tt"));
+        assert!(session.end.is_some());
+        assert_eq!(session.subagents, 2);
+    }
+
+    #[test]
+    fn a_session_with_no_end_reads_back_as_still_open() {
+        let dir = sandbox("read-open");
+        begin_in(&dir, "sess-1", None).unwrap();
+
+        let sessions = read_sessions_in(&dir);
+        assert_eq!(sessions[0].end, None);
+        assert_eq!(sessions[0].project, None);
+    }
+
+    #[test]
+    fn repeated_end_lines_read_back_as_the_last_one() {
+        let dir = sandbox("read-repeated-end");
+        let path = session_path(&dir, "sess-1");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(&path, "start=1000\nend=1100\nend=1200\n").unwrap();
+
+        assert_eq!(read_sessions_in(&dir)[0].end, Some(1200));
+    }
+
+    #[test]
+    fn a_file_with_no_start_line_is_not_a_session() {
+        let dir = sandbox("read-no-start");
+        let path = session_path(&dir, "garbage");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(&path, "project=tt\n").unwrap();
+
+        assert_eq!(read_sessions_in(&dir), Vec::new());
+    }
+
+    #[test]
+    fn a_missing_directory_reads_as_no_sessions() {
+        let dir = sandbox("read-missing");
+        fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(read_sessions_in(&dir), Vec::new());
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -14,10 +14,14 @@ use chrono::{DateTime, Local};
 use crate::tracker::IdleInterval;
 
 use crate::activity;
+use crate::audit;
 use crate::cli::{self, ActivityCommands, AgentCommands};
 use crate::config;
+use crate::duration;
 use crate::icons;
 use crate::marks::{self, Begin, Touch};
+use crate::storage;
+use crate::tracker;
 
 /// Run one `tt agent` subcommand.
 pub fn run(command: &AgentCommands) -> Result<()> {
@@ -69,6 +73,7 @@ pub fn run(command: &AgentCommands) -> Result<()> {
             *trim,
         ),
         AgentCommands::Activity(command) => activity_command(command),
+        AgentCommands::Audit => run_audit(),
     }
 }
 
@@ -177,6 +182,49 @@ fn list() -> Result<()> {
     println!("{} Open marks:\n", icons::agent());
     for row in marks::rows(&marks) {
         println!("  {}", row);
+    }
+    Ok(())
+}
+
+/// `tt agent audit`: reconcile the activity ledger against marks and logged
+/// entries, reporting activity with no evidence it was ever tracked. Missing
+/// or unreadable activity/mark directories read as empty rather than erroring
+/// — an audit must never fail over there being nothing to audit yet.
+fn run_audit() -> Result<()> {
+    let sessions = activity::activity_dir()
+        .map(|dir| activity::read_sessions_in(&dir))
+        .unwrap_or_default();
+    let marks = marks::open_marks();
+    let mut data = storage::load_data()?;
+    tracker::migrate(&mut data);
+
+    let flagged = audit::unaccounted(
+        &sessions,
+        &marks,
+        &data.entries,
+        chrono::Local::now(),
+        max_unvouched_minutes(),
+    );
+
+    if flagged.is_empty() {
+        println!("No unaccounted agent activity.");
+        return Ok(());
+    }
+
+    println!("{} Unaccounted agent activity:\n", icons::warning());
+    for item in &flagged {
+        let subagents = match item.subagents {
+            0 => String::new(),
+            1 => ", 1 subagent dispatch".to_string(),
+            n => format!(", {n} subagent dispatches"),
+        };
+        println!(
+            "  {} - since {} ({}{})",
+            item.project,
+            item.start.format("%H:%M"),
+            duration::format(item.end.signed_duration_since(item.start)),
+            subagents
+        );
     }
     Ok(())
 }

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,244 @@
+//! Reconciles the hook-only activity ledger against marks and logged
+//! entries — the `tt agent audit` command. See
+//! `docs/decisions/0001-agent-activity-tracking.md`.
+//!
+//! An activity window counts as accounted for when either a mark was open
+//! for its project overlapping any part of it, or a closed `#agent`-tagged
+//! entry covers it. Neither is **unaccounted agent activity**: real work
+//! that never got tracked at all.
+
+use chrono::{DateTime, Local};
+
+use crate::activity::Session;
+use crate::marks::Mark;
+use crate::tracker::TimeEntry;
+
+/// One activity window with no evidence it was tracked.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Unaccounted {
+    pub project: String,
+    pub start: DateTime<Local>,
+    pub end: DateTime<Local>,
+    pub subagents: usize,
+}
+
+/// Half-open interval overlap: touching endpoints do not count.
+fn overlaps(a_start: i64, a_end: i64, b_start: i64, b_end: i64) -> bool {
+    a_start < b_end && b_start < a_end
+}
+
+/// Every session below `floor_minutes` is not flagged — a one-line question
+/// should not trip the warning. A session with no project cannot be
+/// reconciled against anything, so it is skipped rather than assumed
+/// unaccounted.
+pub fn unaccounted(
+    sessions: &[Session],
+    marks: &[Mark],
+    entries: &[TimeEntry],
+    now: DateTime<Local>,
+    floor_minutes: i64,
+) -> Vec<Unaccounted> {
+    let now_epoch = now.timestamp();
+
+    let mut found: Vec<Unaccounted> = sessions
+        .iter()
+        .filter_map(|session| {
+            let project = session.project.as_deref()?;
+            let end_epoch = session.end.unwrap_or(now_epoch);
+            if (end_epoch - session.start) / 60 < floor_minutes {
+                return None;
+            }
+
+            let covered = covered_by_mark(project, session.start, end_epoch, marks, now_epoch)
+                || covered_by_entry(project, session.start, end_epoch, entries, now_epoch);
+            if covered {
+                return None;
+            }
+
+            Some(Unaccounted {
+                project: project.to_string(),
+                start: instant(session.start)?,
+                end: instant(end_epoch)?,
+                subagents: session.subagents,
+            })
+        })
+        .collect();
+
+    found.sort_by_key(|u| std::cmp::Reverse(u.start));
+    found
+}
+
+/// A mark still open covers everything from its own start up to `now`.
+fn covered_by_mark(project: &str, start: i64, end: i64, marks: &[Mark], now: i64) -> bool {
+    marks
+        .iter()
+        .filter(|mark| mark.project.eq_ignore_ascii_case(project))
+        .any(|mark| overlaps(mark.start.timestamp(), now, start, end))
+}
+
+fn covered_by_entry(project: &str, start: i64, end: i64, entries: &[TimeEntry], now: i64) -> bool {
+    entries
+        .iter()
+        .filter(|entry| entry.has_tag("agent"))
+        .filter(|entry| {
+            entry
+                .project
+                .as_deref()
+                .is_some_and(|p| p.eq_ignore_ascii_case(project))
+        })
+        .any(|entry| {
+            let entry_end = entry.end_time.map(|t| t.timestamp()).unwrap_or(now);
+            overlaps(entry.start_time.timestamp(), entry_end, start, end)
+        })
+}
+
+fn instant(epoch: i64) -> Option<DateTime<Local>> {
+    DateTime::from_timestamp(epoch, 0).map(|instant| instant.with_timezone(&Local))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn session(project: Option<&str>, start: i64, end: Option<i64>, subagents: usize) -> Session {
+        Session {
+            project: project.map(str::to_string),
+            start,
+            end,
+            subagents,
+        }
+    }
+
+    fn mark(project: &str, start: i64) -> Mark {
+        Mark {
+            project: project.to_string(),
+            issue: None,
+            phase: "impl".to_string(),
+            start: at(start),
+        }
+    }
+
+    fn entry(project: &str, start: i64, end: Option<i64>, tags: &[&str]) -> TimeEntry {
+        TimeEntry {
+            id: 1,
+            description: "x".to_string(),
+            project: Some(project.to_string()),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            start_time: at(start),
+            end_time: end.map(at),
+            idle: Vec::new(),
+        }
+    }
+
+    fn at(epoch: i64) -> DateTime<Local> {
+        Local.timestamp_opt(epoch, 0).unwrap()
+    }
+
+    const FLOOR: i64 = 120;
+    const HOUR: i64 = 3600;
+
+    #[test]
+    fn a_session_with_no_project_is_never_flagged() {
+        let sessions = vec![session(None, 0, Some(3 * HOUR), 0)];
+        assert!(unaccounted(&sessions, &[], &[], at(3 * HOUR), FLOOR).is_empty());
+    }
+
+    #[test]
+    fn a_session_under_the_floor_is_never_flagged() {
+        let sessions = vec![session(Some("tt"), 0, Some(60 * 60), 0)]; // 1h, floor 2h
+        assert!(unaccounted(&sessions, &[], &[], at(HOUR), FLOOR).is_empty());
+    }
+
+    #[test]
+    fn a_session_over_the_floor_with_no_coverage_is_flagged() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 2)];
+        let flagged = unaccounted(&sessions, &[], &[], at(3 * HOUR), FLOOR);
+        assert_eq!(flagged.len(), 1);
+        assert_eq!(flagged[0].project, "tt");
+        assert_eq!(flagged[0].subagents, 2);
+    }
+
+    #[test]
+    fn a_session_covered_by_an_overlapping_open_mark_is_not_flagged() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 0)];
+        let marks = vec![mark("tt", HOUR)];
+        assert!(unaccounted(&sessions, &marks, &[], at(3 * HOUR), FLOOR).is_empty());
+    }
+
+    #[test]
+    fn a_mark_for_a_different_project_does_not_cover() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 0)];
+        let marks = vec![mark("other", HOUR)];
+        assert_eq!(
+            unaccounted(&sessions, &marks, &[], at(3 * HOUR), FLOOR).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_mark_that_started_after_the_window_ended_does_not_cover() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 0)];
+        let marks = vec![mark("tt", 4 * HOUR)];
+        assert_eq!(
+            unaccounted(&sessions, &marks, &[], at(5 * HOUR), FLOOR).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_session_covered_by_a_closed_agent_tagged_entry_is_not_flagged() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 0)];
+        let entries = vec![entry("tt", 0, Some(3 * HOUR), &["tt", "impl", "agent"])];
+        assert!(unaccounted(&sessions, &[], &entries, at(3 * HOUR), FLOOR).is_empty());
+    }
+
+    #[test]
+    fn a_logged_entry_without_the_agent_tag_does_not_cover() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 0)];
+        let entries = vec![entry("tt", 0, Some(3 * HOUR), &["tt", "impl"])];
+        assert_eq!(
+            unaccounted(&sessions, &[], &entries, at(3 * HOUR), FLOOR).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_partial_overlap_with_a_logged_entry_still_covers() {
+        let sessions = vec![session(Some("tt"), 0, Some(3 * HOUR), 0)];
+        // Entry only covers the tail of the window, but any overlap counts.
+        let entries = vec![entry("tt", 2 * HOUR, Some(4 * HOUR), &["tt", "agent"])];
+        assert!(unaccounted(&sessions, &[], &entries, at(3 * HOUR), FLOOR).is_empty());
+    }
+
+    #[test]
+    fn a_still_open_session_is_measured_to_now() {
+        let sessions = vec![session(Some("tt"), 0, None, 0)];
+        let flagged = unaccounted(&sessions, &[], &[], at(3 * HOUR), FLOOR);
+        assert_eq!(flagged.len(), 1);
+        assert_eq!(flagged[0].end, at(3 * HOUR));
+    }
+
+    #[test]
+    fn a_still_open_entry_is_measured_to_now_when_checking_coverage() {
+        let sessions = vec![session(Some("tt"), 0, None, 0)];
+        let entries = vec![entry("tt", 0, None, &["tt", "agent"])];
+        assert!(unaccounted(&sessions, &[], &entries, at(3 * HOUR), FLOOR).is_empty());
+    }
+
+    #[test]
+    fn results_come_back_newest_first() {
+        let sessions = vec![
+            session(Some("older"), 0, Some(3 * HOUR), 0),
+            session(Some("newer"), HOUR, Some(4 * HOUR), 0),
+        ];
+        let flagged = unaccounted(&sessions, &[], &[], at(4 * HOUR), FLOOR);
+        assert_eq!(
+            flagged
+                .iter()
+                .map(|u| u.project.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newer", "older"]
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -185,6 +185,9 @@ pub enum AgentCommands {
     /// model. See docs/decisions/0001-agent-activity-tracking.md.
     #[command(hide = true, subcommand)]
     Activity(ActivityCommands),
+    /// Reconcile the activity ledger against marks and logged entries,
+    /// reporting activity with no evidence it was ever tracked.
+    Audit,
 }
 
 /// See [`AgentCommands::Activity`]. Keyed by Claude Code's own session id.
@@ -212,7 +215,8 @@ impl AgentCommands {
             | AgentCommands::Touch { .. }
             | AgentCommands::Cancel { .. }
             | AgentCommands::List
-            | AgentCommands::Activity(_) => false,
+            | AgentCommands::Activity(_)
+            | AgentCommands::Audit => false,
             AgentCommands::Item { .. } | AgentCommands::End { .. } => true,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 mod activity;
 mod agent;
+mod audit;
 mod cli;
 mod config;
 mod duration;


### PR DESCRIPTION
Implements #7 — depends on #6 (#10), so this PR targets `feat/activity-ledger`, not `main`. Rebase onto `main` once #10 merges.

## What this adds

- `src/activity.rs`: `read_sessions_in` — a reader for the activity ledger written by #6's hooks, parsing each session file back into a `Session { project, start, end, subagents }`.
- `src/audit.rs`: pure reconciliation logic, `unaccounted(sessions, marks, entries, now, floor_minutes) -> Vec<Unaccounted>`. A window counts as accounted for when either:
  - a mark is currently open for the same project, overlapping any part of the window (mark span = `[mark.start, now]` while open), or
  - a closed, `#agent`-tagged logged entry for the same project overlaps the window.
- `tt agent audit` (new, visible subcommand) — prints unaccounted windows in the house `list`-style format, or `No unaccounted agent activity.`

## Guardrails from the ADR (docs/decisions/0001-agent-activity-tracking.md)

- **Floor on window length** — reuses `agent.max_unvouched_minutes` (same config/env resolution `tt agent end` already uses), so a one-line question doesn't trip the warning.
- **Overlap, not exact match** — checks project + time overlap only, never phase/issue.
- **No separate subagent-window rollup needed** — `SubagentStop` already appends its marker into the *parent* session's own file (see #6), so there's no standalone subagent window to absorb into anything; it just falls out of the file format.
- A session with no resolved project is skipped (nothing to reconcile against), not assumed unaccounted.

## Testing

- `cargo test` — 268 passed, 0 failed (17 new tests: 5 in `activity.rs`'s reader, 12 in `audit.rs`)
- `cargo clippy --all-targets` — no new warnings
- Manual smoke test: backdated a 3-hour-old open session with no mark/entry — correctly flagged; a clean environment reports nothing.

Draft — depends on #10 merging or at least stabilizing first.