### PR TITLE
Warn immediately on unaccounted activity at Stop (#9)

### DIFF
--- a/skills/tt-time-logging/scripts/tt-stop-check.mjs
+++ b/skills/tt-time-logging/scripts/tt-stop-check.mjs
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
-// Stop hook: warns (never blocks) if this project has tt agent marks still
-// open when the agent stops, so a forgotten `tt agent end` doesn't silently
-// lose the phase. Installed by install-hooks.mjs.
+// Stop hook: warns (never blocks) about two things when the agent stops —
+// installed by install-hooks.mjs.
+//
+//   1. tt agent marks still open for this project — a forgotten
+//      `tt agent end` doesn't silently lose the phase.
+//   2. this session's own activity window being unaccounted for — see
+//      docs/decisions/0001-agent-activity-tracking.md and
+//      `tt agent activity check`. Catches the gap immediately rather than
+//      waiting for the next `tt agent audit`.
 
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 function projectName() {
   try {
@@ -14,30 +21,54 @@ function projectName() {
   }
 }
 
+function sessionId() {
+  try {
+    return JSON.parse(readFileSync(0, "utf8")).session_id;
+  } catch {
+    return undefined;
+  }
+}
+
+const messages = [];
+
 const proj = projectName();
-if (!proj) {
-  process.stdout.write("{}");
-  process.exit(0);
+if (proj) {
+  let list = "";
+  try {
+    list = execSync("tt agent list", { encoding: "utf8" });
+  } catch (e) {
+    list = e.stdout?.toString() ?? "";
+  }
+
+  const openLines = list.split("\n").filter((line) => line.includes(proj));
+  if (openLines.length > 0) {
+    messages.push(
+      `tt-time-logging: open mark(s) for '${proj}' are still unclosed. ` +
+        `Close with 'tt agent end <project> <issue> <phase> "<summary>"' ` +
+        `(or 'tt agent cancel' if it shouldn't be logged) before stopping.\n` +
+        openLines.join("\n"),
+    );
+  }
 }
 
-let list = "";
-try {
-  list = execSync("tt agent list", { encoding: "utf8" });
-} catch (e) {
-  list = e.stdout?.toString() ?? "";
+const session = sessionId();
+if (session) {
+  let checked = "";
+  try {
+    checked = execFileSync("tt", ["agent", "activity", "check", session], {
+      encoding: "utf8",
+    });
+  } catch {
+    checked = "";
+  }
+  if (checked.trim()) {
+    messages.push(
+      `tt-time-logging: this session's activity is unaccounted for — no open mark ` +
+        `or logged #agent entry covers it:\n${checked.trim()}`,
+    );
+  }
 }
 
-const openLines = list
-  .split("\n")
-  .filter((line) => line.includes(proj));
-
-if (openLines.length > 0) {
-  const msg =
-    `tt-time-logging: open mark(s) for '${proj}' are still unclosed. ` +
-    `Close with 'tt agent end <project> <issue> <phase> "<summary>"' ` +
-    `(or 'tt agent cancel' if it shouldn't be logged) before stopping.\n` +
-    openLines.join("\n");
-  process.stdout.write(JSON.stringify({ systemMessage: msg }));
-} else {
-  process.stdout.write("{}");
-}
+process.stdout.write(
+  messages.length > 0 ? JSON.stringify({ systemMessage: messages.join("\n\n") }) : "{}",
+);

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -87,7 +87,8 @@ fn append_field(dir: &Path, session_id: &str, field: &str) -> io::Result<()> {
 
 // --- reader -----------------------------------------------------------
 //
-// Read only, for `tt agent audit` (see `src/audit.rs`) — nothing here writes.
+// Read only, for `tt agent audit` and `tt agent activity check` (see
+// `src/audit.rs`) — nothing here writes.
 
 /// One session's window, as read back from its file.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -111,6 +112,12 @@ pub fn read_sessions_in(dir: &Path) -> Vec<Session> {
         .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
         .filter_map(|e| read_session(&e.path()))
         .collect()
+}
+
+/// One session by its own id — for `Stop` checking its own window rather
+/// than every session in `dir`.
+pub fn read_session_in(dir: &Path, session_id: &str) -> Option<Session> {
+    read_session(&session_path(dir, session_id))
 }
 
 fn read_session(path: &Path) -> Option<Session> {
@@ -292,6 +299,17 @@ mod tests {
         fs::write(&path, "project=tt\n").unwrap();
 
         assert_eq!(read_sessions_in(&dir), Vec::new());
+    }
+
+    #[test]
+    fn a_single_session_reads_back_by_its_own_id() {
+        let dir = sandbox("read-single");
+        begin_in(&dir, "sess-1", Some("tt")).unwrap();
+        begin_in(&dir, "sess-2", Some("other")).unwrap();
+
+        let session = read_session_in(&dir, "sess-1").unwrap();
+        assert_eq!(session.project.as_deref(), Some("tt"));
+        assert_eq!(read_session_in(&dir, "no-such-session"), None);
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -90,6 +90,32 @@ fn activity_command(command: &ActivityCommands) -> Result<()> {
         } => activity::begin_in(&dir, session_id, project.as_deref())?,
         ActivityCommands::End { session_id } => activity::end_in(&dir, session_id)?,
         ActivityCommands::Subagent { session_id } => activity::subagent_in(&dir, session_id)?,
+        ActivityCommands::Check { session_id } => return check_session(&dir, session_id),
+    }
+    Ok(())
+}
+
+/// `tt agent activity check <session_id>`: the same reconciliation as
+/// `tt agent audit`, narrowed to one session, so the `Stop` hook can warn
+/// immediately rather than waiting for the next `audit` run. Silent when the
+/// session is accounted for, unknown, or has no resolved project.
+fn check_session(dir: &std::path::Path, session_id: &str) -> Result<()> {
+    let Some(session) = activity::read_session_in(dir, session_id) else {
+        return Ok(());
+    };
+    let marks = marks::open_marks();
+    let mut data = storage::load_data()?;
+    tracker::migrate(&mut data);
+
+    let flagged = audit::unaccounted(
+        &[session],
+        &marks,
+        &data.entries,
+        chrono::Local::now(),
+        max_unvouched_minutes(),
+    );
+    for item in &flagged {
+        println!("{}", unaccounted_row(item));
     }
     Ok(())
 }
@@ -213,20 +239,26 @@ fn run_audit() -> Result<()> {
 
     println!("{} Unaccounted agent activity:\n", icons::warning());
     for item in &flagged {
-        let subagents = match item.subagents {
-            0 => String::new(),
-            1 => ", 1 subagent dispatch".to_string(),
-            n => format!(", {n} subagent dispatches"),
-        };
-        println!(
-            "  {} - since {} ({}{})",
-            item.project,
-            item.start.format("%H:%M"),
-            duration::format(item.end.signed_duration_since(item.start)),
-            subagents
-        );
+        println!("  {}", unaccounted_row(item));
     }
     Ok(())
+}
+
+/// `<project> - since HH:MM (Xh Ym)`, with a trailing subagent-dispatch count
+/// when there were any. Shared by `tt agent audit` and `tt agent activity check`.
+fn unaccounted_row(item: &audit::Unaccounted) -> String {
+    let subagents = match item.subagents {
+        0 => String::new(),
+        1 => ", 1 subagent dispatch".to_string(),
+        n => format!(", {n} subagent dispatches"),
+    };
+    format!(
+        "{} - since {} ({}{})",
+        item.project,
+        item.start.format("%H:%M"),
+        duration::format(item.end.signed_duration_since(item.start)),
+        subagents
+    )
 }
 
 /// `tt agent item <project> <issue|-> <phase> <summary> <minutes>`: log one

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,6 +202,10 @@ pub enum ActivityCommands {
     End { session_id: String },
     /// SubagentStop: record that one subagent dispatch finished.
     Subagent { session_id: String },
+    /// Stop: report this one session's window if it is unaccounted for,
+    /// silent otherwise. Same reconciliation as `tt agent audit`, narrowed
+    /// to a single session so the Stop hook can warn immediately.
+    Check { session_id: String },
 }
 
 impl AgentCommands {


### PR DESCRIPTION
Implements #9 — depends on #6 (#10) and #7 (#11), so this PR targets `feat/activity-reconciliation`. Rebase onto `main` once those merge.

## What this adds

- `activity::read_session_in(dir, session_id)` — reads exactly one session file by id, instead of scanning the whole directory (`read_sessions_in`, from #7).
- `tt agent activity check <session_id>` (hidden, hook-only) — runs `audit::unaccounted` narrowed to a single session. Prints one line if that session's window is unaccounted for; silent when it's covered, unknown, or has no resolved project.
- `agent::unaccounted_row` — factored the `<project> - since HH:MM (Xh Ym)` line out of `tt agent audit` so `check` reuses it instead of duplicating the format.
- `tt-stop-check.mjs` — now reads `session_id` off the Stop hook's stdin JSON (previously unused) and also runs `tt agent activity check`, folding its message in alongside the existing open-marks warning. Additive: the open-marks check is untouched, and if `tt` or the activity dir aren't available it just prints `{}` on that half same as before.

## Testing

- `cargo test` — 269 passed, 0 failed (3 new tests: `read_session_in`)
- `cargo clippy --all-targets` — no new warnings
- Manual end-to-end: backdated a 3h open session with no mark → Stop hook printed the combined warning. Opened a covering mark 2s before the check → warning disappeared (`{}`). Verified the "same-second" edge case where a mark opened in the identical wall-clock second as the check briefly doesn't count as covering — self-resolves a moment later, not something a real Stop event would hit in practice.

Draft — depends on #10 and #11 merging or stabilizing first.