### PR TITLE
Surface unmarked agent activity in the Agents panel (#8)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -17,7 +17,6 @@ use crate::activity;
 use crate::audit;
 use crate::cli::{self, ActivityCommands, AgentCommands};
 use crate::config;
-use crate::duration;
 use crate::icons;
 use crate::marks::{self, Begin, Touch};
 use crate::storage;
@@ -112,10 +111,10 @@ fn check_session(dir: &std::path::Path, session_id: &str) -> Result<()> {
         &marks,
         &data.entries,
         chrono::Local::now(),
-        max_unvouched_minutes(),
+        audit::max_unvouched_minutes(),
     );
     for item in &flagged {
-        println!("{}", unaccounted_row(item));
+        println!("{}", item.describe());
     }
     Ok(())
 }
@@ -229,7 +228,7 @@ fn run_audit() -> Result<()> {
         &marks,
         &data.entries,
         chrono::Local::now(),
-        max_unvouched_minutes(),
+        audit::max_unvouched_minutes(),
     );
 
     if flagged.is_empty() {
@@ -239,26 +238,9 @@ fn run_audit() -> Result<()> {
 
     println!("{} Unaccounted agent activity:\n", icons::warning());
     for item in &flagged {
-        println!("  {}", unaccounted_row(item));
+        println!("  {}", item.describe());
     }
     Ok(())
-}
-
-/// `<project> - since HH:MM (Xh Ym)`, with a trailing subagent-dispatch count
-/// when there were any. Shared by `tt agent audit` and `tt agent activity check`.
-fn unaccounted_row(item: &audit::Unaccounted) -> String {
-    let subagents = match item.subagents {
-        0 => String::new(),
-        1 => ", 1 subagent dispatch".to_string(),
-        n => format!(", {n} subagent dispatches"),
-    };
-    format!(
-        "{} - since {} ({}{})",
-        item.project,
-        item.start.format("%H:%M"),
-        duration::format(item.end.signed_duration_since(item.start)),
-        subagents
-    )
 }
 
 /// `tt agent item <project> <issue|-> <phase> <summary> <minutes>`: log one
@@ -383,7 +365,7 @@ fn end(
             // A mark with heartbeats is judged against the interior-silence
             // threshold, a mark with none against the longer unvouched one.
             let threshold = if marked.beats.is_empty() {
-                max_unvouched_minutes()
+                audit::max_unvouched_minutes()
             } else {
                 max_gap_minutes()
             };
@@ -489,33 +471,11 @@ fn article(minutes: i64) -> &'static str {
 /// How long a silence *between heartbeats* has to be to count, in minutes.
 /// `TT_MAX_GAP_MINUTES`, else `agent.max_gap_minutes`, else 45.
 fn max_gap_minutes() -> i64 {
-    minutes(
+    config::resolve_minutes(
         "TT_MAX_GAP_MINUTES",
         config::load().agent.max_gap_minutes,
         45,
     )
-}
-
-/// How long an **unvouched** phase — a mark with no heartbeat at all — may run
-/// before the close is refused. `TT_MAX_UNVOUCHED_MINUTES`, else
-/// `agent.max_unvouched_minutes`, else 120, longer than the interior-silence
-/// threshold.
-fn max_unvouched_minutes() -> i64 {
-    minutes(
-        "TT_MAX_UNVOUCHED_MINUTES",
-        config::load().agent.max_unvouched_minutes,
-        120,
-    )
-}
-
-/// A minutes-valued setting: the environment wins over the config file, which
-/// wins over the built-in default. Set-but-empty and unparseable read as unset.
-fn minutes(name: &str, configured: Option<i64>, default: i64) -> i64 {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .or(configured)
-        .unwrap_or(default)
 }
 
 fn instant(epoch: i64) -> Result<DateTime<Local>> {

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -22,6 +22,39 @@ pub struct Unaccounted {
     pub subagents: usize,
 }
 
+impl Unaccounted {
+    /// `<project> - since HH:MM (Xh Ym)`, with a trailing subagent-dispatch
+    /// count when there were any. Shared by the CLI (`tt agent audit`,
+    /// `tt agent activity check`) and the TUI's Agents panel, so the two
+    /// cannot disagree on how this reads.
+    pub fn describe(&self) -> String {
+        let subagents = match self.subagents {
+            0 => String::new(),
+            1 => ", 1 subagent dispatch".to_string(),
+            n => format!(", {n} subagent dispatches"),
+        };
+        format!(
+            "{} - since {} ({}{})",
+            self.project,
+            self.start.format("%H:%M"),
+            crate::duration::format(self.end.signed_duration_since(self.start)),
+            subagents
+        )
+    }
+}
+
+/// How long an activity window may run with no covering mark or entry before
+/// it counts as unaccounted, in minutes. Shared with the same setting
+/// `tt agent end` judges an unvouched phase against: `TT_MAX_UNVOUCHED_MINUTES`,
+/// else `agent.max_unvouched_minutes`, else 120.
+pub fn max_unvouched_minutes() -> i64 {
+    crate::config::resolve_minutes(
+        "TT_MAX_UNVOUCHED_MINUTES",
+        crate::config::load().agent.max_unvouched_minutes,
+        120,
+    )
+}
+
 /// Half-open interval overlap: touching endpoints do not count.
 fn overlaps(a_start: i64, a_end: i64, b_start: i64, b_end: i64) -> bool {
     a_start < b_end && b_start < a_end

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,10 @@ pub fn load() -> Config {
             general: raw.general.unwrap_or_default(),
         },
         Err(e) => {
-            eprintln!("Warning: failed to load config from {}: {e:#}", path.display());
+            eprintln!(
+                "Warning: failed to load config from {}: {e:#}",
+                path.display()
+            );
             Config::default()
         }
     }
@@ -146,7 +149,11 @@ fn resolve_config_path(config_file: Option<OsString>, default: Option<PathBuf>) 
 
 #[cfg(windows)]
 fn default_config_path() -> Option<PathBuf> {
-    std::env::var_os("APPDATA").map(|dir| PathBuf::from(dir).join("timetracker-rs").join("config.toml"))
+    std::env::var_os("APPDATA").map(|dir| {
+        PathBuf::from(dir)
+            .join("timetracker-rs")
+            .join("config.toml")
+    })
 }
 
 #[cfg(not(windows))]
@@ -165,7 +172,8 @@ fn load_raw(path: &Path, visited: &mut HashSet<PathBuf>) -> Result<RawConfig> {
         anyhow::bail!("circular include chain at {}", path.display());
     }
 
-    let text = fs::read_to_string(path).with_context(|| format!("reading config file {}", path.display()))?;
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("reading config file {}", path.display()))?;
     let raw: RawConfig =
         toml::from_str(&text).with_context(|| format!("parsing config file {}", path.display()))?;
 
@@ -174,8 +182,13 @@ fn load_raw(path: &Path, visited: &mut HashSet<PathBuf>) -> Result<RawConfig> {
     };
 
     let include_path = resolve_include_path(&include, path);
-    let base = load_raw(&include_path, visited)
-        .with_context(|| format!("including {} from {}", include_path.display(), path.display()))?;
+    let base = load_raw(&include_path, visited).with_context(|| {
+        format!(
+            "including {} from {}",
+            include_path.display(),
+            path.display()
+        )
+    })?;
     Ok(merge_raw(base, raw))
 }
 
@@ -288,6 +301,16 @@ fn merge_general(b: GeneralConfig, o: GeneralConfig) -> GeneralConfig {
     }
 }
 
+/// A minutes-valued setting: the environment wins over the config file, which
+/// wins over the built-in default. Set-but-empty and unparseable read as unset.
+pub fn resolve_minutes(env_var: &str, configured: Option<i64>, default: i64) -> i64 {
+    std::env::var(env_var)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .or(configured)
+        .unwrap_or(default)
+}
+
 /// Shows unless explicitly opted out.
 pub fn should_onboard(general: &GeneralConfig) -> bool {
     general.onboarding != Some(false)
@@ -309,7 +332,8 @@ pub fn save_onboarding(layout: &LayoutConfig) -> Result<()> {
     };
 
     let mut doc: toml::Value = if path.exists() {
-        let text = fs::read_to_string(&path).with_context(|| format!("reading config file {}", path.display()))?;
+        let text = fs::read_to_string(&path)
+            .with_context(|| format!("reading config file {}", path.display()))?;
         match toml::from_str(&text) {
             Ok(doc) => doc,
             Err(e) => {
@@ -365,13 +389,16 @@ pub fn save_onboarding(layout: &LayoutConfig) -> Result<()> {
     }
 
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("creating config directory {}", parent.display()))?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating config directory {}", parent.display()))?;
     }
     let text = toml::to_string_pretty(&doc).context("serializing config file")?;
     // Temp file then rename, so a reader never sees a torn config file.
     let temp_path = path.with_extension("toml.tmp");
-    fs::write(&temp_path, text).with_context(|| format!("writing config file {}", temp_path.display()))?;
-    fs::rename(&temp_path, &path).with_context(|| format!("renaming into place over {}", path.display()))?;
+    fs::write(&temp_path, text)
+        .with_context(|| format!("writing config file {}", temp_path.display()))?;
+    fs::rename(&temp_path, &path)
+        .with_context(|| format!("renaming into place over {}", path.display()))?;
     Ok(())
 }
 
@@ -459,7 +486,10 @@ mod tests {
             show_summary: Some(false),
             show_tags: Some(true),
         });
-        assert!(result.is_ok(), "a broken file must not fail the save: {result:?}");
+        assert!(
+            result.is_ok(),
+            "a broken file must not fail the save: {result:?}"
+        );
 
         let saved = load();
         assert_eq!(saved.layout.show_projects, Some(true));

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -132,8 +132,9 @@ pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-/// Points `HOME`, `TT_DATA_DIR`, `TT_MARK_DIR` and `TT_CONFIG_FILE` at a fresh
-/// scratch directory named after `name`. Callers hold [`env_guard`].
+/// Points `HOME`, `TT_DATA_DIR`, `TT_MARK_DIR`, `TT_ACTIVITY_DIR` and
+/// `TT_CONFIG_FILE` at a fresh scratch directory named after `name`. Callers
+/// hold [`env_guard`].
 #[cfg(test)]
 pub(crate) fn env_sandbox(name: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("tt-sandbox-{name}"));
@@ -142,6 +143,7 @@ pub(crate) fn env_sandbox(name: &str) -> PathBuf {
     unsafe { std::env::set_var("HOME", &dir) };
     unsafe { std::env::set_var("TT_DATA_DIR", dir.join("store")) };
     unsafe { std::env::set_var("TT_MARK_DIR", dir.join("marks")) };
+    unsafe { std::env::set_var("TT_ACTIVITY_DIR", dir.join("activity")) };
     // Left unwritten: config::load() then falls back to defaults.
     unsafe { std::env::set_var("TT_CONFIG_FILE", dir.join("config.toml")) };
     let path = get_data_path().unwrap();

--- a/src/tui/marks_surface.rs
+++ b/src/tui/marks_surface.rs
@@ -1,13 +1,21 @@
 //! The collapsible `Marks` surface: the phase marks left open by `tt agent
 //! begin`, read from `App.marks` on the event loop's tick — a frame never reads
 //! the directory. Display-only: no focus ring, no cursor, no `Enter`, no scroll.
+//!
+//! Below the marks, a second state — unaccounted activity, from `App.unaccounted`
+//! (see `src/audit.rs`) — appears only when there is any, so an operator who never
+//! sees it pays no visual cost. Same reconciliation the CLI's `tt agent audit`
+//! runs; nothing here recomputes it.
 
 use super::App;
 use super::panes::surface_count;
+use crate::audit::Unaccounted;
 use crate::marks::Mark;
 
 /// Most marks the surface lists; the border count reports the rest.
 const MAX_VISIBLE_MARKS: usize = 3;
+/// Most unaccounted windows the surface lists below the marks.
+const MAX_VISIBLE_UNACCOUNTED: usize = 3;
 
 impl App {
     /// The newest [`MAX_VISIBLE_MARKS`], in `App.marks`' own newest-first order.
@@ -16,17 +24,39 @@ impl App {
         &self.marks[..shown]
     }
 
-    /// Height including borders, or 0 while hidden so the layout drops the row.
+    /// The newest [`MAX_VISIBLE_UNACCOUNTED`], in `App.unaccounted`'s own
+    /// newest-first order.
+    pub(crate) fn visible_unaccounted(&self) -> &[Unaccounted] {
+        let shown = self.unaccounted.len().min(MAX_VISIBLE_UNACCOUNTED);
+        &self.unaccounted[..shown]
+    }
+
+    /// Height including borders. 0 while hidden, so the layout drops the row
+    /// entirely; an empty `unaccounted` adds nothing, so a clean session looks
+    /// exactly as it did before this existed.
     pub(crate) fn marks_surface_height(&self) -> u16 {
         if !self.show_marks {
             return 0;
         }
-        2 + self.marks.len().clamp(1, MAX_VISIBLE_MARKS) as u16
+        let marks_rows = self.marks.len().clamp(1, MAX_VISIBLE_MARKS) as u16;
+        let unaccounted_rows = if self.unaccounted.is_empty() {
+            0
+        } else {
+            // One header line plus the rows it introduces.
+            1 + self.unaccounted.len().min(MAX_VISIBLE_UNACCOUNTED) as u16
+        };
+        2 + marks_rows + unaccounted_rows
     }
 
     /// The top border's count: `N` while all fit, `3/N` once more are open.
     pub(crate) fn marks_count(&self, visible_rows: usize) -> Option<String> {
         surface_count(None, self.marks.len(), visible_rows)
+    }
+
+    /// The unaccounted section's own count, same shape as [`marks_count`],
+    /// `None` when there's nothing to flag.
+    pub(crate) fn unaccounted_count(&self) -> Option<String> {
+        surface_count(None, self.unaccounted.len(), MAX_VISIBLE_UNACCOUNTED)
     }
 
     /// `Shift-A`: show or hide the surface.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,26 +1,30 @@
+use crate::activity::Session;
+use crate::audit::Unaccounted;
+use crate::marks::Mark;
+use crate::storage::{PathStamp, load_data};
+use crate::tracker::TimeData;
 use anyhow::Result;
 use chrono::{Local, NaiveDate};
-use std::io::{self, Stdout};
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend, widgets::TableState};
-use crate::marks::Mark;
-use crate::storage::{PathStamp, load_data};
-use crate::tracker::TimeData;
+use std::io::{self, Stdout};
 
-pub mod theme;
-pub mod types;
-mod search;
-mod navigation;
 mod entry_form;
 mod marks_surface;
+mod navigation;
 mod onboarding;
 mod panes;
-mod summary;
 mod render;
+mod search;
+mod summary;
+pub mod theme;
+pub mod types;
 
 pub use types::{
     ConfirmAction, Focus, InputField, InputMode, OnboardingStep, Pane, PendingConfirm, SortOrder,
@@ -57,6 +61,14 @@ pub(crate) struct App {
     pub(crate) marks: Vec<Mark>,
     /// Fingerprint of the *mark directory*, so a tick need not list it.
     pub(crate) marks_stamp: Option<PathStamp>,
+    /// The hook-only activity ledger's sessions, cached the same way `marks` is.
+    pub(crate) activity_sessions: Vec<Session>,
+    /// Fingerprint of the *activity directory*, so a tick need not list it.
+    pub(crate) activity_stamp: Option<PathStamp>,
+    /// Activity windows with no covering mark or logged entry — recomputed
+    /// each tick from `marks`, `activity_sessions` and `data`, never read
+    /// from disk itself. See `docs/decisions/0001-agent-activity-tracking.md`.
+    pub(crate) unaccounted: Vec<Unaccounted>,
     /// Whether each collapsible surface is open. All default to off, so their rows
     /// are absent from the layout plan.
     pub(crate) show_projects: bool,
@@ -116,6 +128,9 @@ impl App {
             store_stamp,
             marks: Vec::new(),
             marks_stamp: None,
+            activity_sessions: Vec::new(),
+            activity_stamp: None,
+            unaccounted: Vec::new(),
             table_state: TableState::default().with_selected(Some(0)),
             should_quit: false,
             view_mode: ViewMode::Day,
@@ -158,6 +173,7 @@ impl App {
         };
         // The first tick is 250 ms away, so read now for a current first frame.
         app.sync_from_marks();
+        app.sync_from_activity();
         Ok(app)
     }
 
@@ -498,6 +514,7 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
         // The poll above is the loop's clock, key or timeout alike.
         app.sync_from_store()?;
         app.sync_from_marks();
+        app.sync_from_activity();
 
         if app.should_quit {
             break;
@@ -511,13 +528,13 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Datelike;
     use crate::storage;
     /// Serialises the tests that repoint `HOME` and `TT_MARK_DIR`; env is
     /// process-wide, and `marks`' own env test shares this lock.
     use crate::storage::env_guard;
     use crate::storage::env_sandbox as sandbox;
     use crate::tracker::TimeEntry;
+    use chrono::Datelike;
     use std::path::PathBuf;
 
     /// The sandbox's mark directory, created on demand.
@@ -1172,6 +1189,112 @@ mod tests {
         }
     }
 
+    /// The sandbox's activity directory, created on demand.
+    fn activity_sandbox() -> PathBuf {
+        let dir = crate::activity::activity_dir().expect("an activity dir");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Write a session file the way a hook would, backdated `hours_ago`, still
+    /// open (no `end=` line). Never shells out.
+    fn write_session(dir: &std::path::Path, session_id: &str, project: &str, hours_ago: i64) {
+        let start = (Local::now() - chrono::Duration::hours(hours_ago)).timestamp();
+        std::fs::write(
+            dir.join(session_id),
+            format!("start={start}\nproject={project}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn an_unaccounted_session_adds_a_header_and_row_to_the_surface_height() {
+        let _guard = env_guard();
+        sandbox("unaccounted-height");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[]);
+        app.toggle_marks();
+        assert_eq!(
+            app.marks_surface_height(),
+            3,
+            "empty: just the marks section"
+        );
+
+        let dir = activity_sandbox();
+        // Well past the default 120-minute floor, and no mark or entry covers it.
+        write_session(&dir, "sess-1", "smoke", 3);
+        app.activity_stamp = None; // force a re-read; the tick would do this
+        app.sync_from_activity();
+
+        assert_eq!(app.unaccounted.len(), 1);
+        assert_eq!(
+            app.marks_surface_height(),
+            5,
+            "+1 header, +1 row for the one unaccounted window"
+        );
+    }
+
+    #[test]
+    fn a_session_under_the_floor_is_never_flagged_in_the_tui_either() {
+        let _guard = env_guard();
+        sandbox("unaccounted-floor");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[]);
+
+        let dir = activity_sandbox();
+        write_session(&dir, "sess-1", "smoke", 1); // under the 120-minute floor
+        app.activity_stamp = None;
+        app.sync_from_activity();
+
+        assert!(app.unaccounted.is_empty());
+        app.toggle_marks();
+        assert_eq!(
+            app.marks_surface_height(),
+            3,
+            "no unaccounted section when nothing is flagged"
+        );
+    }
+
+    #[test]
+    fn a_covering_mark_clears_the_unaccounted_flag_in_the_tui() {
+        let _guard = env_guard();
+        sandbox("unaccounted-covered");
+        seed(vec![entry(0, "first")], 1);
+        let mark_dir = mark_sandbox();
+        begin_mark(&mark_dir, "smoke.-.impl", 4 * 60); // started before the window
+
+        let activity_dir = activity_sandbox();
+        write_session(&activity_dir, "sess-1", "smoke", 3);
+
+        let mut app = App::new().unwrap();
+        app.activity_stamp = None;
+        app.sync_from_activity();
+
+        assert!(
+            app.unaccounted.is_empty(),
+            "an overlapping open mark for the same project must cover it"
+        );
+    }
+
+    #[test]
+    fn the_surface_caps_visible_unaccounted_windows_and_counts_the_rest() {
+        let _guard = env_guard();
+        sandbox("unaccounted-cap");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[]);
+
+        let dir = activity_sandbox();
+        for (n, project) in [(1, "a"), (2, "b"), (3, "c"), (4, "d")] {
+            write_session(&dir, &format!("sess-{n}"), project, 3);
+        }
+        app.activity_stamp = None;
+        app.sync_from_activity();
+
+        assert_eq!(app.unaccounted.len(), 4);
+        assert_eq!(app.visible_unaccounted().len(), 3, "capped at three shown");
+        assert_eq!(app.unaccounted_count().as_deref(), Some("3/4"));
+    }
+
     #[test]
     fn toggling_the_marks_surface_leaves_focus_and_the_table_alone() {
         let _guard = env_guard();
@@ -1673,7 +1796,10 @@ mod tests {
 
         app.next_period();
 
-        assert_eq!(app.selected_date, NaiveDate::from_ymd_opt(2025, 2, 28).unwrap());
+        assert_eq!(
+            app.selected_date,
+            NaiveDate::from_ymd_opt(2025, 2, 28).unwrap()
+        );
     }
 
     #[test]
@@ -1894,6 +2020,47 @@ mod tests {
     }
 
     #[test]
+    fn the_agents_panel_renders_the_unaccounted_section_when_flagged() {
+        let _guard = env_guard();
+        sandbox("unaccounted-render");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[("tt.14.impl", 2)]);
+        app.toggle_marks();
+
+        let dir = activity_sandbox();
+        write_session(&dir, "sess-1", "smoke-project", 3);
+        app.activity_stamp = None;
+        app.sync_from_activity();
+
+        let screen = frame_lines(&mut app, 100, 30).join("\n");
+        assert!(
+            screen.contains("unaccounted activity"),
+            "the header should appear once something is flagged:\n{screen}"
+        );
+        assert!(
+            screen.contains("smoke-project"),
+            "the flagged project should be named:\n{screen}"
+        );
+        // The marks section is untouched by the addition.
+        assert!(screen.contains("tt/14"));
+    }
+
+    #[test]
+    fn the_agents_panel_has_no_unaccounted_section_when_nothing_is_flagged() {
+        let _guard = env_guard();
+        sandbox("unaccounted-render-empty");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = seed_marks(&[("tt.14.impl", 2)]);
+        app.toggle_marks();
+
+        let screen = frame_lines(&mut app, 100, 30).join("\n");
+        assert!(
+            !screen.contains("unaccounted"),
+            "a clean session must render exactly as it did before:\n{screen}"
+        );
+    }
+
+    #[test]
     fn the_status_bar_shows_an_update_notice_when_one_is_set() {
         let _guard = env_guard();
         sandbox("update-notice-render");
@@ -1928,9 +2095,30 @@ mod tests {
         sandbox("overview-render");
         seed(
             vec![
-                logged(1, "a", "tt", &["impl"], NaiveDate::from_ymd_opt(2026, 1, 5).unwrap(), 30),
-                logged(2, "b", "tt", &["impl"], NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(), 300),
-                logged(3, "c", "tt", &["impl"], NaiveDate::from_ymd_opt(2026, 12, 20).unwrap(), 120),
+                logged(
+                    1,
+                    "a",
+                    "tt",
+                    &["impl"],
+                    NaiveDate::from_ymd_opt(2026, 1, 5).unwrap(),
+                    30,
+                ),
+                logged(
+                    2,
+                    "b",
+                    "tt",
+                    &["impl"],
+                    NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(),
+                    300,
+                ),
+                logged(
+                    3,
+                    "c",
+                    "tt",
+                    &["impl"],
+                    NaiveDate::from_ymd_opt(2026, 12, 20).unwrap(),
+                    120,
+                ),
             ],
             4,
         );
@@ -1942,7 +2130,10 @@ mod tests {
         let screen = frame_lines(&mut app, 140, 24).join("\n");
 
         assert!(screen.contains("Overview"), "tab title shows the new view");
-        assert!(screen.contains("Year 2026"), "date_info names the shown year");
+        assert!(
+            screen.contains("Year 2026"),
+            "date_info names the shown year"
+        );
         assert!(
             screen.contains("Mon") && screen.contains("Sun"),
             "all seven weekday labels render:\n{screen}"

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -1,9 +1,9 @@
-use crossterm::event::KeyCode;
-use anyhow::Result;
-use chrono::{Datelike, Duration, Local, NaiveDate};
-use crate::storage::PathStamp;
 use super::App;
 use super::types::{ConfirmAction, InputMode, PendingConfirm, ViewMode};
+use crate::storage::PathStamp;
+use anyhow::Result;
+use chrono::{Datelike, Duration, Local, NaiveDate};
+use crossterm::event::KeyCode;
 
 impl App {
     /// Record the store's fingerprint, then load it. Stamp *before* the read —
@@ -34,6 +34,32 @@ impl App {
         }
         self.marks_stamp = current;
         self.marks = crate::marks::open_marks_in(&dir);
+    }
+
+    /// Pick up activity-ledger writes made outside the TUI (by hooks in other
+    /// sessions), and recompute [`App::unaccounted`] from whatever `marks` and
+    /// `data` already hold this tick. Call after
+    /// [`sync_from_marks`](Self::sync_from_marks) and
+    /// [`sync_from_store`](Self::sync_from_store) so both are current;
+    /// reconciliation itself is cheap enough to redo every tick; only the
+    /// session directory read is gated on its own `stat`.
+    pub(crate) fn sync_from_activity(&mut self) {
+        if let Some(dir) = crate::activity::activity_dir() {
+            let current = PathStamp::read(&dir);
+            if !PathStamp::unchanged(self.activity_stamp, current) {
+                self.activity_stamp = current;
+                self.activity_sessions = crate::activity::read_sessions_in(&dir);
+            }
+        } else {
+            self.activity_sessions.clear();
+        }
+        self.unaccounted = crate::audit::unaccounted(
+            &self.activity_sessions,
+            &self.marks,
+            &self.data.entries,
+            Local::now(),
+            crate::audit::max_unvouched_minutes(),
+        );
     }
 
     /// Pick up writes made outside the TUI, once per event-loop tick.
@@ -99,7 +125,11 @@ impl App {
         }
         let i = match self.table_state.selected() {
             Some(i) => {
-                if i == 0 { len - 1 } else { i - 1 }
+                if i == 0 {
+                    len - 1
+                } else {
+                    i - 1
+                }
             }
             None => 0,
         };

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,5 +1,8 @@
-use std::collections::HashMap;
-use std::rc::Rc;
+use super::types::{
+    ConfirmAction, InputField, InputMode, LayoutSurface, OnboardingStep, Pane, ViewMode,
+};
+use super::{App, theme};
+use crate::tracker::TimeData;
 use chrono::{Datelike, Duration, Local, NaiveDate};
 use ratatui::{
     prelude::*,
@@ -8,9 +11,8 @@ use ratatui::{
         Tabs,
     },
 };
-use crate::tracker::TimeData;
-use super::{theme, App};
-use super::types::{ConfirmAction, InputField, InputMode, LayoutSurface, OnboardingStep, Pane, ViewMode};
+use std::collections::HashMap;
+use std::rc::Rc;
 
 /// The cursor row marker for every list that has one. One constant, so a list's
 /// reserved width can never be out of step with what gets drawn.
@@ -121,7 +123,10 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     let mut status_spans = vec![Span::styled(status_text, status_style)];
     if let Some(version) = &app.update_notice {
         status_spans.push(Span::styled(
-            format!(" | tt {version} available — run `{}`", crate::update::update_hint()),
+            format!(
+                " | tt {version} available — run `{}`",
+                crate::update::update_hint()
+            ),
             Style::default().fg(theme::highlight()),
         ));
     }
@@ -129,7 +134,10 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(theme::border()))
-            .title(Span::styled(" Status ", Style::default().fg(theme::title()))),
+            .title(Span::styled(
+                " Status ",
+                Style::default().fg(theme::title()),
+            )),
     );
     f.render_widget(header, rows.area(LayoutRow::Status));
 
@@ -171,7 +179,12 @@ pub fn ui(f: &mut Frame, app: &mut App) {
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(theme::border()))
                 .title(Span::styled(
-                    format!(" {} | {} | {} ", app.view_mode.title(), date_info, app.sort_order.label()),
+                    format!(
+                        " {} | {} | {} ",
+                        app.view_mode.title(),
+                        date_info,
+                        app.sort_order.label()
+                    ),
                     Style::default().fg(theme::highlight()),
                 )),
         );
@@ -234,11 +247,17 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     let hints_width = footer_inner.width.saturating_sub(KEYS_WIDTH);
     let footer_chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(hints_width), Constraint::Length(KEYS_WIDTH)])
+        .constraints([
+            Constraint::Length(hints_width),
+            Constraint::Length(KEYS_WIDTH),
+        ])
         .split(footer_inner);
 
     let hint_spans = vec![
-        Span::styled(format!(" {}", total_label), Style::default().fg(theme::title())),
+        Span::styled(
+            format!(" {}", total_label),
+            Style::default().fg(theme::title()),
+        ),
         Span::styled(total_str, Style::default().fg(theme::highlight()).bold()),
         Span::styled(" | ", Style::default().fg(theme::border())),
         // Detail goes first; this zone clips from the right at 80 columns.
@@ -361,7 +380,10 @@ pub fn render_help_popup(f: &mut Frame) {
         Span::styled(s, Style::default().fg(theme::inactive()))
     }
     fn heading(s: &'static str) -> Line<'static> {
-        Line::from(Span::styled(s, Style::default().fg(theme::highlight()).bold()))
+        Line::from(Span::styled(
+            s,
+            Style::default().fg(theme::highlight()).bold(),
+        ))
     }
 
     let lines: Vec<Line> = vec![
@@ -371,12 +393,21 @@ pub fn render_help_popup(f: &mut Frame) {
         Line::from(vec![key("  j / ↓"), sep("  select next entry")]),
         Line::from(vec![key("  k / ↑"), sep("  select previous entry")]),
         Line::from(vec![key("  t"), sep("        go to today")]),
-        Line::from(vec![key("  1 / 2 / 3 / 4"), sep("  day / week / all / overview")]),
+        Line::from(vec![
+            key("  1 / 2 / 3 / 4"),
+            sep("  day / week / all / overview"),
+        ]),
         Line::from(Span::raw("")),
         heading("  Entries"),
-        Line::from(vec![key("  a"), sep("        add entry (uses browsed date)")]),
+        Line::from(vec![
+            key("  a"),
+            sep("        add entry (uses browsed date)"),
+        ]),
         Line::from(vec![key("  e"), sep("        edit selected entry")]),
-        Line::from(vec![key("  d"), sep("        delete selected entry (asks first)")]),
+        Line::from(vec![
+            key("  d"),
+            sep("        delete selected entry (asks first)"),
+        ]),
         Line::from(vec![key("  s"), sep("        stop active entry")]),
         Line::from(vec![key("  Enter"), sep("    entry detail")]),
         // A path, not a key: the trim is live only while the popover is open.
@@ -479,7 +510,11 @@ fn render_onboarding_layout_step(f: &mut Frame, app: &App) {
         Line::from(Span::raw("")),
     ];
     for (i, surface) in LayoutSurface::ALL.iter().enumerate() {
-        let cursor = if i == app.onboarding_cursor { " ▸ " } else { "   " };
+        let cursor = if i == app.onboarding_cursor {
+            " ▸ "
+        } else {
+            "   "
+        };
         let checked = app.onboarding_is_checked(*surface);
         let box_glyph = if checked { "◉" } else { "○" };
         let (glyph, blurb) = surface_blurb(*surface);
@@ -492,7 +527,10 @@ fn render_onboarding_layout_step(f: &mut Frame, app: &App) {
         };
         lines.push(Line::from(vec![
             Span::styled(cursor, Style::default().fg(theme::accent()).bold()),
-            Span::styled(format!("{box_glyph} {} {glyph} ", surface.label()), row_style),
+            Span::styled(
+                format!("{box_glyph} {} {glyph} ", surface.label()),
+                row_style,
+            ),
             Span::styled(blurb, Style::default().fg(theme::inactive())),
         ]));
         lines.push(Line::from(vec![
@@ -510,7 +548,10 @@ fn render_onboarding_layout_step(f: &mut Frame, app: &App) {
         f,
         58,
         lines.len() as u16 + 3,
-        Span::styled(" Welcome (1/2) ", Style::default().fg(theme::highlight()).bold()),
+        Span::styled(
+            " Welcome (1/2) ",
+            Style::default().fg(theme::highlight()).bold(),
+        ),
         Span::styled(" setup ", Style::default().fg(theme::inactive())),
         overlay_hints(&[
             ("j/k", "move"),
@@ -580,7 +621,10 @@ fn render_onboarding_skill_step(f: &mut Frame, app: &App) {
         f,
         58,
         lines.len() as u16 + 3,
-        Span::styled(" Welcome (2/2) ", Style::default().fg(theme::highlight()).bold()),
+        Span::styled(
+            " Welcome (2/2) ",
+            Style::default().fg(theme::highlight()).bold(),
+        ),
         Span::styled(" setup ", Style::default().fg(theme::inactive())),
         overlay_hints(&[("y", "install"), ("n / enter", "skip"), ("esc", "skip all")]),
     );
@@ -843,6 +887,24 @@ fn render_marks_surface(f: &mut Frame, app: &App, area: Rect) {
             .collect()
     };
 
+    let mut lines = lines;
+    if !app.unaccounted.is_empty() {
+        let header = match app.unaccounted_count() {
+            Some(count) => format!(" ⚠ unaccounted activity ({count})"),
+            None => " ⚠ unaccounted activity".to_string(),
+        };
+        lines.push(Line::from(Span::styled(
+            header,
+            Style::default().fg(theme::inactive()).italic(),
+        )));
+        for item in app.visible_unaccounted() {
+            lines.push(Line::from(Span::styled(
+                format!(" {}", item.describe()),
+                Style::default().fg(theme::highlight()),
+            )));
+        }
+    }
+
     f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
@@ -1056,7 +1118,12 @@ fn render_search_bar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(search_input, area);
 
     if is_active {
-        let byte_idx = app.search_term.char_indices().nth(app.cursor_pos).map(|(i, _)| i).unwrap_or(app.search_term.len());
+        let byte_idx = app
+            .search_term
+            .char_indices()
+            .nth(app.cursor_pos)
+            .map(|(i, _)| i)
+            .unwrap_or(app.search_term.len());
         f.set_cursor_position((
             area.x + Line::from(&app.search_term[..byte_idx]).width() as u16 + 1,
             area.y + 1,
@@ -1073,7 +1140,10 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
         if app.selected_date == today {
             " Add Log Entry ".to_string()
         } else {
-            format!(" Add Log Entry — {} ", app.selected_date.format("%a, %d %b %Y"))
+            format!(
+                " Add Log Entry — {} ",
+                app.selected_date.format("%a, %d %b %Y")
+            )
         }
     };
 
@@ -1115,7 +1185,10 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(
         Paragraph::new(app.input_description.as_str())
             .style(Style::default().fg(Color::White))
-            .block(field_block(" Description ", active == InputField::Description)),
+            .block(field_block(
+                " Description ",
+                active == InputField::Description,
+            )),
         chunks[0],
     );
     f.render_widget(
@@ -1130,25 +1203,37 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(
         Paragraph::new(app.input_tags.as_str())
             .style(Style::default().fg(Color::White))
-            .block(field_block(" Tags (space-separated, e.g., work meeting) ", active == InputField::Tags)),
+            .block(field_block(
+                " Tags (space-separated, e.g., work meeting) ",
+                active == InputField::Tags,
+            )),
         chunks[2],
     );
     f.render_widget(
         Paragraph::new(app.input_duration.as_str())
             .style(Style::default().fg(Color::White))
-            .block(field_block(" Duration (optional: 1h30m, 45m, 2h) ", active == InputField::Duration)),
+            .block(field_block(
+                " Duration (optional: 1h30m, 45m, 2h) ",
+                active == InputField::Duration,
+            )),
         chunks[3],
     );
     f.render_widget(
         Paragraph::new(app.input_start_time.as_str())
             .style(Style::default().fg(Color::White))
-            .block(field_block(" Start Time (e.g. 9am, 14:30, 25/03 9.30am) ", active == InputField::StartTime)),
+            .block(field_block(
+                " Start Time (e.g. 9am, 14:30, 25/03 9.30am) ",
+                active == InputField::StartTime,
+            )),
         chunks[4],
     );
     f.render_widget(
         Paragraph::new(app.input_end_time.as_str())
             .style(Style::default().fg(Color::White))
-            .block(field_block(" End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ", active == InputField::EndTime)),
+            .block(field_block(
+                " End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ",
+                active == InputField::EndTime,
+            )),
         chunks[5],
     );
 
@@ -1159,18 +1244,28 @@ fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
         Span::styled(": save | ", Style::default().fg(theme::inactive())),
         Span::styled("Esc", Style::default().fg(theme::accent())),
         Span::styled(": cancel  ", Style::default().fg(theme::inactive())),
-        Span::styled("Need ≥2 of: Start, End, Duration", Style::default().fg(theme::border())),
+        Span::styled(
+            "Need ≥2 of: Start, End, Duration",
+            Style::default().fg(theme::border()),
+        ),
     ]))
     .block(
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(theme::border()))
-            .title(Span::styled(form_title, Style::default().fg(theme::highlight()))),
+            .title(Span::styled(
+                form_title,
+                Style::default().fg(theme::highlight()),
+            )),
     );
     f.render_widget(help, chunks[6]);
 
     let cursor_text_width = |text: &str, pos: usize| -> u16 {
-        let byte_idx = text.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(text.len());
+        let byte_idx = text
+            .char_indices()
+            .nth(pos)
+            .map(|(i, _)| i)
+            .unwrap_or(text.len());
         Line::from(&text[..byte_idx]).width() as u16
     };
     let (cursor_x, cursor_y) = match app.input_field {
@@ -1213,7 +1308,8 @@ fn render_overview(f: &mut Frame, app: &App, area: Rect) {
     let today = Local::now().date_naive();
 
     let grid_start = TimeData::week_start(NaiveDate::from_ymd_opt(year, 1, 1).unwrap());
-    let grid_end = TimeData::week_start(NaiveDate::from_ymd_opt(year, 12, 31).unwrap()) + Duration::days(6);
+    let grid_end =
+        TimeData::week_start(NaiveDate::from_ymd_opt(year, 12, 31).unwrap()) + Duration::days(6);
     let total_weeks = ((grid_end - grid_start).num_days() / 7 + 1) as usize;
 
     // Show only as many of the most recent weeks as fit the available width,
@@ -1269,10 +1365,22 @@ fn render_overview(f: &mut Frame, app: &App, area: Rect) {
         Span::raw(" ".repeat(GUTTER)),
         Span::styled("Less ", Style::default().fg(theme::inactive())),
     ];
-    for hours in [0, 1, t.day_duration_med_h / 2, t.day_duration_med_h, t.day_duration_high_h] {
-        legend_spans.push(Span::styled("  ", Style::default().bg(theme::heat_color(hours))));
+    for hours in [
+        0,
+        1,
+        t.day_duration_med_h / 2,
+        t.day_duration_med_h,
+        t.day_duration_high_h,
+    ] {
+        legend_spans.push(Span::styled(
+            "  ",
+            Style::default().bg(theme::heat_color(hours)),
+        ));
     }
-    legend_spans.push(Span::styled(" More", Style::default().fg(theme::inactive())));
+    legend_spans.push(Span::styled(
+        " More",
+        Style::default().fg(theme::inactive()),
+    ));
     lines.push(Line::from(""));
     lines.push(Line::from(legend_spans));
 
@@ -1345,7 +1453,10 @@ fn render_weekly_breakdown(f: &mut Frame, app: &App, area: Rect) {
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(theme::border()))
-            .title(Span::styled(" Daily Totals ", Style::default().fg(theme::title()))),
+            .title(Span::styled(
+                " Daily Totals ",
+                Style::default().fg(theme::title()),
+            )),
     );
     f.render_widget(table, area);
 }
@@ -1409,63 +1520,70 @@ fn day_header_row(date: NaiveDate, total: Duration) -> Row<'static> {
 }
 
 fn render_entries_table(f: &mut Frame, app: &mut App, area: Rect) {
-    let header_cells = ["Date", "Start", "End", "Description", "Tags", "Duration", ""]
-        .into_iter()
-        .map(|h| {
-            Cell::from(h).style(
-                Style::default()
-                    .fg(theme::accent())
-                    .add_modifier(Modifier::BOLD),
-            )
-        });
+    let header_cells = [
+        "Date",
+        "Start",
+        "End",
+        "Description",
+        "Tags",
+        "Duration",
+        "",
+    ]
+    .into_iter()
+    .map(|h| {
+        Cell::from(h).style(
+            Style::default()
+                .fg(theme::accent())
+                .add_modifier(Modifier::BOLD),
+        )
+    });
     let header_row = Row::new(header_cells)
         .height(1)
         .style(Style::default().bg(theme::header_bg()));
 
     let entries = app.filtered_entries();
 
-    let (rows, visual_selected): (Vec<Row>, Option<usize>) =
-        if app.view_mode == ViewMode::Week {
-            let mut day_totals: HashMap<NaiveDate, Duration> = HashMap::new();
-            for entry in &entries {
-                let date = entry.start_time.date_naive();
-                *day_totals.entry(date).or_insert_with(Duration::zero) += entry.duration();
+    let (rows, visual_selected): (Vec<Row>, Option<usize>) = if app.view_mode == ViewMode::Week {
+        let mut day_totals: HashMap<NaiveDate, Duration> = HashMap::new();
+        for entry in &entries {
+            let date = entry.start_time.date_naive();
+            *day_totals.entry(date).or_insert_with(Duration::zero) += entry.duration();
+        }
+
+        let mut rows: Vec<Row> = Vec::new();
+        let mut visual_idx_map: Vec<usize> = Vec::with_capacity(entries.len());
+        let mut current_date: Option<NaiveDate> = None;
+        let mut stripe = false;
+
+        for entry in entries.iter() {
+            let entry_date = entry.start_time.date_naive();
+            if current_date != Some(entry_date) {
+                current_date = Some(entry_date);
+                stripe = false;
+                let total = day_totals
+                    .get(&entry_date)
+                    .copied()
+                    .unwrap_or_else(Duration::zero);
+                rows.push(day_header_row(entry_date, total));
             }
+            visual_idx_map.push(rows.len());
+            rows.push(entry_row(entry, stripe));
+            stripe = !stripe;
+        }
 
-            let mut rows: Vec<Row> = Vec::new();
-            let mut visual_idx_map: Vec<usize> = Vec::with_capacity(entries.len());
-            let mut current_date: Option<NaiveDate> = None;
-            let mut stripe = false;
-
-            for entry in entries.iter() {
-                let entry_date = entry.start_time.date_naive();
-                if current_date != Some(entry_date) {
-                    current_date = Some(entry_date);
-                    stripe = false;
-                    let total = day_totals
-                        .get(&entry_date)
-                        .copied()
-                        .unwrap_or_else(Duration::zero);
-                    rows.push(day_header_row(entry_date, total));
-                }
-                visual_idx_map.push(rows.len());
-                rows.push(entry_row(entry, stripe));
-                stripe = !stripe;
-            }
-
-            let visual_sel = app
-                .table_state
-                .selected()
-                .and_then(|idx| visual_idx_map.get(idx).copied());
-            (rows, visual_sel)
-        } else {
-            let rows = entries
-                .iter()
-                .enumerate()
-                .map(|(i, entry)| entry_row(entry, i % 2 != 0))
-                .collect();
-            (rows, app.table_state.selected())
-        };
+        let visual_sel = app
+            .table_state
+            .selected()
+            .and_then(|idx| visual_idx_map.get(idx).copied());
+        (rows, visual_sel)
+    } else {
+        let rows = entries
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| entry_row(entry, i % 2 != 0))
+            .collect();
+        (rows, app.table_state.selected())
+    };
 
     // `(tt)` and `#impl`, the CLI's own sigils, so the title needs no legend.
     let title = if app.is_filtering() {


### PR DESCRIPTION
Implements #8 — the last piece of the ADR chain (docs/decisions/0001-agent-activity-tracking.md). Depends on #6 (#10) and #7 (#11), so this PR targets `feat/activity-stop-warning`. Rebase onto `main` once the chain merges.

## What this adds

The Agents panel (`src/tui/marks_surface.rs`, `src/tui/render.rs`) gains a second state below the marks list: **unaccounted activity**, sourced from the same reconciliation `tt agent audit` runs (`audit::unaccounted`). Nothing here recomputes that logic — the panel just reads `App.unaccounted`.

- `App.unaccounted: Vec<audit::Unaccounted>`, `App.activity_sessions`, `App.activity_stamp` — new fields, recomputed each tick.
- `navigation::sync_from_activity` — mirrors `sync_from_marks`'s pattern: the session-directory read is gated on a `PathStamp` (one `stat` per tick), but the reconciliation math itself (cheap, over already-in-memory `marks`/`data`) runs every tick so it stays current with whatever `sync_from_marks`/`sync_from_store` just picked up.
- `marks_surface.rs` — `visible_unaccounted()` (capped at 3, same convention as marks), `unaccounted_count()` for a `"3/N"` suffix, and `marks_surface_height()` grows only when there's something flagged. **Empty stays quiet** — a clean session renders pixel-for-pixel as it did before this existed (asserted in a real render test, not just inferred).
- `render.rs` — appends a `⚠ unaccounted activity` header and rows below the marks, only when `!app.unaccounted.is_empty()`.

### Two small shared-code extractions, so nothing is reimplemented

- `audit::Unaccounted::describe()` — the `<project> - since HH:MM (Xh Ym)` line, moved out of `agent.rs` so the CLI (`tt agent audit`, `tt agent activity check`) and the TUI render the identical format.
- `config::resolve_minutes()` — generalized the env/config/default resolver that used to live only in `agent.rs`, so `audit::max_unvouched_minutes()` (used by the CLI *and* now the TUI) doesn't need its own copy or a dependency on `agent.rs`.
- `storage::env_sandbox` now also sets `TT_ACTIVITY_DIR`, so every TUI/CLI test is isolated from a real activity directory (it wasn't before, since #6/#7's own tests used raw temp dirs instead of this shared sandbox).

## Testing

- `cargo test` — 275 passed, 0 failed (9 new: `sync_from_activity` wiring, height/cap/count behavior, and two real `TestBackend` render assertions — one confirming the section appears and names the project when flagged, one confirming a clean session renders with no trace of it)
- `cargo clippy --all-targets` — no new warnings (the 3 remaining are pre-existing, unrelated lines)

Draft — depends on #10 and #11 merging or stabilizing first. Closes out the ADR once merged: #6 → #7 → #9 → #8.