### PR TITLE
tt agent audit --auto-log: write #auto entries (#19)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,9 +2,10 @@
 //!
 //! Presentation only; [`crate::marks`] owns every fact about the mark files.
 //!
-//! **`begin`, `touch`, `cancel` and `list` must touch no store** — `main.rs`
-//! dispatches them ahead of its migrate preamble. `item` and `end` log an entry
-//! through [`crate::cli::log`] and dispatch after it.
+//! **`begin`, `touch`, `cancel`, `list` and a plain `audit` must touch no
+//! store** — `main.rs` dispatches them ahead of its migrate preamble. `item`,
+//! `end` and `audit --auto-log` log an entry through [`crate::cli::log`] and
+//! dispatch after it.
 //!
 //! The messages are a contract: their caller is an agent following prose.
 
@@ -72,7 +73,7 @@ pub fn run(command: &AgentCommands) -> Result<()> {
             *trim,
         ),
         AgentCommands::Activity(command) => activity_command(command),
-        AgentCommands::Audit => run_audit(),
+        AgentCommands::Audit { auto_log } => run_audit(*auto_log),
     }
 }
 
@@ -215,32 +216,71 @@ fn list() -> Result<()> {
 /// entries, reporting activity with no evidence it was ever tracked. Missing
 /// or unreadable activity/mark directories read as empty rather than erroring
 /// — an audit must never fail over there being nothing to audit yet.
-fn run_audit() -> Result<()> {
+fn run_audit(auto_log: bool) -> Result<()> {
     let sessions = activity::activity_dir()
         .map(|dir| activity::read_sessions_in(&dir))
         .unwrap_or_default();
     let marks = marks::open_marks();
-    let mut data = storage::load_data()?;
-    tracker::migrate(&mut data);
+    let floor = audit::max_unvouched_minutes();
+    let now = chrono::Local::now();
 
-    let flagged = audit::unaccounted(
-        &sessions,
-        &marks,
-        &data.entries,
-        chrono::Local::now(),
-        audit::max_unvouched_minutes(),
-    );
+    let flagged = {
+        let mut data = storage::load_data()?;
+        tracker::migrate(&mut data);
+        audit::unaccounted(&sessions, &marks, &data.entries, now, floor)
+    };
 
-    if flagged.is_empty() {
+    // `auto_log_after_minutes` unset: `--auto-log` is accepted but logs
+    // nothing, exactly like a plain audit — see AgentConfig::auto_log_after_minutes.
+    let mut wrote_any = false;
+    if auto_log && let Some(threshold) = audit::auto_log_after_minutes() {
+        for item in &flagged {
+            let minutes = item.end.signed_duration_since(item.start).num_minutes();
+            if minutes > threshold {
+                write_auto_log(item)?;
+                wrote_any = true;
+            }
+        }
+    }
+
+    // Re-read: the entries just written now cover their own windows, so the
+    // report below must not still call them unaccounted.
+    let remaining = if wrote_any {
+        let mut data = storage::load_data()?;
+        tracker::migrate(&mut data);
+        audit::unaccounted(&sessions, &marks, &data.entries, now, floor)
+    } else {
+        flagged
+    };
+
+    if remaining.is_empty() {
         println!("No unaccounted agent activity.");
         return Ok(());
     }
 
     println!("{} Unaccounted agent activity:\n", icons::warning());
-    for item in &flagged {
+    for item in &remaining {
         println!("  {}", item.describe());
     }
     Ok(())
+}
+
+/// `--auto-log`: write one fixed-phase `#auto` entry for an unaccounted
+/// window, the way `tt agent item` would — except **never** tagged `#agent`,
+/// since this was not an agent's own self-report. Phase and summary are
+/// always the same literal text; nothing here guesses either. See
+/// docs/decisions/0002-auto-logging-unaccounted-activity.md.
+fn write_auto_log(item: &audit::Unaccounted) -> Result<()> {
+    let minutes = item.end.signed_duration_since(item.start).num_minutes();
+    cli::log(
+        "unattended activity #auto".to_string(),
+        format!("{}m", round_quarter(minutes)),
+        Vec::new(),
+        Some(item.project.clone()),
+        Vec::new(),
+        false,
+        Some(item.end),
+    )
 }
 
 /// `tt agent item <project> <issue|-> <phase> <summary> <minutes>`: log one

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -67,9 +67,6 @@ pub fn max_unvouched_minutes() -> i64 {
 /// [`max_unvouched_minutes`]. The latter is a misconfiguration, and it must
 /// fail toward "off" rather than toward auto-logging a window the audit
 /// surfaces never had a chance to warn about first.
-///
-/// Unused outside tests until `--auto-log` (issue #19) reads it.
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn auto_log_after_minutes() -> Option<i64> {
     let configured = std::env::var("TT_AUTO_LOG_AFTER_MINUTES")
         .ok()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,7 +187,14 @@ pub enum AgentCommands {
     Activity(ActivityCommands),
     /// Reconcile the activity ledger against marks and logged entries,
     /// reporting activity with no evidence it was ever tracked.
-    Audit,
+    Audit {
+        /// Write a fixed-phase `#auto` entry for every window that has also
+        /// passed `agent.auto_log_after_minutes`. A no-op unless that setting
+        /// is configured — see
+        /// docs/decisions/0002-auto-logging-unaccounted-activity.md.
+        #[arg(long)]
+        auto_log: bool,
+    },
 }
 
 /// See [`AgentCommands::Activity`]. Keyed by Claude Code's own session id.
@@ -219,8 +226,10 @@ impl AgentCommands {
             | AgentCommands::Touch { .. }
             | AgentCommands::Cancel { .. }
             | AgentCommands::List
-            | AgentCommands::Activity(_)
-            | AgentCommands::Audit => false,
+            | AgentCommands::Activity(_) => false,
+            // Only `--auto-log` actually writes; a plain audit stays on the
+            // fast, no-preamble path like `list` and `report`.
+            AgentCommands::Audit { auto_log } => *auto_log,
             AgentCommands::Item { .. } | AgentCommands::End { .. } => true,
         }
     }

--- a/tests/agent_audit.rs
+++ b/tests/agent_audit.rs
@@ -1,0 +1,135 @@
+//! `tt agent audit` and `tt agent audit --auto-log`, end to end through the
+//! real binary and a sandboxed store/marks/activity directory. See
+//! docs/decisions/0001-agent-activity-tracking.md and
+//! docs/decisions/0002-auto-logging-unaccounted-activity.md.
+
+mod common;
+use common::{Case, now};
+
+const HOUR: i64 = 3600;
+
+#[test]
+fn a_clean_sandbox_reports_nothing_unaccounted() {
+    let case = Case::new("audit-clean");
+    let run = case.run(&["audit"]);
+    run.assert_status(0);
+    run.assert_stdout_has("No unaccounted agent activity.");
+}
+
+#[test]
+fn a_session_past_the_floor_with_no_coverage_is_reported() {
+    let case = Case::new("audit-flagged");
+    let start = now() - 3 * HOUR;
+    case.write_session("sess-1", "smoke", start, None);
+
+    let run = case.run(&["audit"]);
+    run.assert_status(0);
+    run.assert_stdout_has("Unaccounted agent activity");
+    run.assert_stdout_has("smoke");
+}
+
+#[test]
+fn a_covering_mark_removes_it_from_the_report() {
+    let case = Case::new("audit-covered-by-mark");
+    let start = now() - 3 * HOUR;
+    case.write_session("sess-1", "smoke", start, None);
+    case.write_mark("smoke.-.impl", start - 60);
+
+    let run = case.run(&["audit"]);
+    run.assert_status(0);
+    run.assert_stdout_has("No unaccounted agent activity.");
+}
+
+#[test]
+fn auto_log_is_a_no_op_when_the_setting_is_unset() {
+    let case = Case::new("audit-auto-log-unset");
+    let start = now() - 3 * HOUR;
+    case.write_session("sess-1", "smoke", start, None);
+
+    let run = case.run(&["audit", "--auto-log"]);
+    run.assert_status(0);
+    // Same report as a plain audit: nothing got logged.
+    run.assert_stdout_has("Unaccounted agent activity");
+    run.assert_stdout_has("smoke");
+    assert!(
+        case.store().entries.is_empty(),
+        "no entry should have been written"
+    );
+}
+
+#[test]
+fn auto_log_writes_a_fixed_phase_auto_entry_over_the_threshold() {
+    let case = Case::new("audit-auto-log-writes");
+    case.write_config("[agent]\nauto_log_after_minutes = 180\n"); // 3h, floor stays 120
+    let start = now() - 4 * HOUR; // 240m, over both the 120m floor and the 180m auto-log threshold
+    case.write_session("sess-1", "smoke", start, None);
+
+    let run = case.run(&["audit", "--auto-log"]);
+    run.assert_status(0);
+    run.assert_stdout_has("No unaccounted agent activity.");
+
+    let store = case.store();
+    assert_eq!(store.entries.len(), 1);
+    let entry = &store.entries[0];
+    assert_eq!(entry.description, "unattended activity");
+    assert_eq!(entry.project.as_deref(), Some("smoke"));
+    assert_eq!(entry.tags, vec!["auto".to_string()]);
+    assert!(
+        !entry.tags.contains(&"agent".to_string()),
+        "an auto-logged entry must never carry #agent"
+    );
+}
+
+#[test]
+fn a_window_under_the_auto_log_threshold_is_reported_but_not_logged() {
+    let case = Case::new("audit-auto-log-under-threshold");
+    case.write_config("[agent]\nauto_log_after_minutes = 300\n"); // 5h
+    let start = now() - 3 * HOUR; // over the 120m floor, under the 300m auto-log threshold
+    case.write_session("sess-1", "smoke", start, None);
+
+    let run = case.run(&["audit", "--auto-log"]);
+    run.assert_status(0);
+    run.assert_stdout_has("Unaccounted agent activity");
+    run.assert_stdout_has("smoke");
+    assert!(
+        case.store().entries.is_empty(),
+        "under the auto-log threshold: reported, never logged"
+    );
+}
+
+#[test]
+fn a_misconfigured_threshold_at_or_under_the_floor_disables_auto_log() {
+    let case = Case::new("audit-auto-log-misconfigured");
+    // Not strictly greater than the (default 120m) floor: must disable, not clamp.
+    case.write_config("[agent]\nauto_log_after_minutes = 120\n");
+    let start = now() - 4 * HOUR;
+    case.write_session("sess-1", "smoke", start, None);
+
+    let run = case.run(&["audit", "--auto-log"]);
+    run.assert_status(0);
+    run.assert_stdout_has("smoke");
+    assert!(
+        case.store().entries.is_empty(),
+        "a misconfigured threshold must fail toward off, not auto-log anyway"
+    );
+}
+
+#[test]
+fn running_auto_log_twice_logs_the_window_once() {
+    let case = Case::new("audit-auto-log-idempotent");
+    case.write_config("[agent]\nauto_log_after_minutes = 180\n");
+    let start = now() - 4 * HOUR;
+    case.write_session("sess-1", "smoke", start, None);
+
+    case.run(&["audit", "--auto-log"]).assert_status(0);
+    assert_eq!(case.store().entries.len(), 1, "first run logs one entry");
+
+    let second = case.run(&["audit", "--auto-log"]);
+    second.assert_status(0);
+    second.assert_stdout_has("No unaccounted agent activity.");
+    assert_eq!(
+        case.store().entries.len(),
+        1,
+        "the second run must not log a duplicate"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,7 @@ pub struct Case {
     pub marks: PathBuf,
     pub data: PathBuf,
     pub config: PathBuf,
+    pub activity: PathBuf,
 }
 
 pub struct Run {
@@ -40,14 +41,17 @@ impl Case {
         let marks = root.join("marks");
         let data = root.join("store");
         let config = root.join("config.toml");
+        let activity = root.join("activity");
         fs::create_dir_all(&home).unwrap();
         fs::create_dir_all(&marks).unwrap();
         fs::create_dir_all(&data).unwrap();
+        fs::create_dir_all(&activity).unwrap();
         Self {
             home,
             marks,
             data,
             config,
+            activity,
         }
     }
 
@@ -83,7 +87,8 @@ impl Case {
             self.home.starts_with(std::env::temp_dir())
                 && self.marks.starts_with(root)
                 && self.data.starts_with(root)
-                && self.config.starts_with(root),
+                && self.config.starts_with(root)
+                && self.activity.starts_with(root),
             "sandbox paths escaped the scratch directory: {:?}",
             self.home
         );
@@ -93,6 +98,7 @@ impl Case {
         command.env("HOME", &self.home);
         command.env("TT_DATA_DIR", &self.data);
         command.env("TT_CONFIG_FILE", &self.config);
+        command.env("TT_ACTIVITY_DIR", &self.activity);
         // `env_clear()` strips this too, so it has to be set explicitly on every
         // run — otherwise every one of these subprocess invocations would attempt
         // a real network call to GitHub's release API during `cargo test`.
@@ -145,6 +151,16 @@ impl Case {
     /// Fabricate an open mark started at an absolute epoch.
     pub fn write_mark(&self, key: &str, start: i64) {
         fs::write(self.mark_file(key), format!("{start}\n")).unwrap();
+    }
+
+    /// Fabricate an activity-ledger session file the way a hook would, at
+    /// absolute epochs. `end` is `None` for a still-open session.
+    pub fn write_session(&self, session_id: &str, project: &str, start: i64, end: Option<i64>) {
+        let mut body = format!("start={start}\nproject={project}\n");
+        if let Some(end) = end {
+            body.push_str(&format!("end={end}\n"));
+        }
+        fs::write(self.activity.join(session_id), body).unwrap();
     }
 
     /// Run `tt <args>` with **no** `agent` prefix, for the store-reading commands.


### PR DESCRIPTION
Implements #19 — depends on #18 (#22), so this PR targets `feat/auto-log-config-and-coverage`. Rebase onto `main` once #22 merges.

## What this adds

- `tt agent audit --auto-log` — for every window `audit::unaccounted()` returns that also exceeds `audit::auto_log_after_minutes()`, logs it the way `tt agent item` would (rounded to the nearest quarter hour), but:
  - **phase and summary are always the same literal text** (`unattended activity #auto`) — never generated, never guessed
  - **explicitly no `#agent` tag** — this wasn't an agent's self-report, so it doesn't borrow that tag's meaning
  - re-reads the store afterward so the printed report reflects what just got covered, instead of re-listing entries `--auto-log` itself just resolved
- `cli::AgentCommands::touches_store` now returns `true` only when `--auto-log` is actually passed, so a plain `tt agent audit` stays on the fast no-preamble path (same as `list`/`report`) and only a real write goes through the normal dispatch + migrate preamble.
- Test harness: `tests/common/mod.rs`'s `Case` now sandboxes `TT_ACTIVITY_DIR` (previously unset — meaning any test touching activity/audit commands would silently fall through to the real machine's activity ledger; this closes that gap) and gains `write_session` for fabricating ledger fixtures.
- `tests/agent_audit.rs` — new end-to-end coverage through the real binary.

## Testing

- `cargo test` — 287 passed, 0 failed (8 new integration tests: clean sandbox, flagged, covered-by-mark, unset/under-threshold/misconfigured no-ops, the actual write, and idempotency across two `--auto-log` runs)
- `cargo clippy --all-targets` — no new warnings
- Manual end-to-end smoke test (real binary, real config file): flagged → `--auto-log` → `📝 Logged: "unattended activity" (smoke-project) [#auto]` → `tt report --all` shows it correctly under the project → second `--auto-log` run reports `No unaccounted agent activity.`

Next: #20 (documenting `#auto` in the skill contract/AGENTS.md), depends on this.