### PR TITLE
Document #auto entries in the skill contract (#20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ tt agent item  <project> <issue|-> <phase> "<summary>" <minutes>
 
 tt agent list                                  # what is still open
 tt agent cancel <project> <issue|-> <phase>    # drop without logging
+tt agent audit [--auto-log]                    # unaccounted activity; see below
 
 tt report [--week|--all|--since DATE [--until DATE]] [--project NAME] [--json]
 ```
@@ -208,6 +209,24 @@ the plain begin → touch → end flow is enough.
   mark cleanup failed, an unwritable mark directory being the usual cause. **Do not
   retry the close**: a retry is exactly what would log the span twice. Say what
   happened, and `tt agent cancel` the phase once the directory is writable again.
+
+## Auto-logged entries
+
+`tt agent audit --auto-log` can write a fallback entry for a window that has
+sat unaccounted for well past the normal warning threshold — see
+`docs/decisions/0002-auto-logging-unaccounted-activity.md`. It is opt-in
+(`agent.auto_log_after_minutes`, unset by default — most operators will
+never see one of these) and, when it does run, it never guesses:
+
+- **Phase is always the literal `auto`**, summary always the literal
+  `"unattended activity"` — never generated, never inferred from anything.
+- **Tagged `#auto`, never `#agent`.** This was not an agent's self-report,
+  so it does not carry that tag's meaning.
+
+**If you find a `#auto` entry, do not reclassify it.** Guessing a real phase
+for it after the fact is exactly what this mechanism exists to avoid —
+leave it as `auto`, and if it matters, say so and let the operator decide
+whether to split or re-tag it by hand.
 
 ## Reading back
 

--- a/skills/tt-time-logging/SKILL.md
+++ b/skills/tt-time-logging/SKILL.md
@@ -123,6 +123,7 @@ tt agent item  <project> <issue|-> <phase> "<summary>" <minutes>
 
 tt agent list                                  # what is still open
 tt agent cancel <project> <issue|-> <phase>    # drop without logging
+tt agent audit [--auto-log]                    # unaccounted activity; see below
 
 tt report [--week|--all|--since DATE [--until DATE]] [--project NAME] [--json]
 ```
@@ -232,6 +233,25 @@ the plain begin → touch → end flow is enough.
   mark cleanup failed, an unwritable mark directory being the usual cause. **Do not
   retry the close**: a retry is exactly what would log the span twice. Say what
   happened, and `tt agent cancel` the phase once the directory is writable again.
+
+## Auto-logged entries
+
+`tt agent audit --auto-log` can write a fallback entry for a window that has
+sat unaccounted for well past the normal warning threshold — see
+`docs/decisions/0002-auto-logging-unaccounted-activity.md` in the
+timetracker-rs source repo for the full reasoning. It is opt-in
+(`agent.auto_log_after_minutes`, unset by default — most operators will
+never see one of these) and, when it does run, it never guesses:
+
+- **Phase is always the literal `auto`**, summary always the literal
+  `"unattended activity"` — never generated, never inferred from anything.
+- **Tagged `#auto`, never `#agent`.** This was not an agent's self-report,
+  so it does not carry that tag's meaning.
+
+**If you find a `#auto` entry, do not reclassify it.** Guessing a real phase
+for it after the fact is exactly what this mechanism exists to avoid —
+leave it as `auto`, and if it matters, say so and let the operator decide
+whether to split or re-tag it by hand.
 
 ## Reading back
 


### PR DESCRIPTION
Implements #20 — depends on #19 (#23), so this PR targets `feat/auto-log-write-path`. Rebase onto `main` once #22 and #23 merge.

## What this adds

- One line in the `## Commands` block: `tt agent audit [--auto-log]`.
- A new `## Auto-logged entries` section (placed before `## Reading back`, matching where the other "how to interpret what you find" sections live) covering:
  - what `#auto` means and that it's opt-in / off by default
  - phase and summary are always the same fixed literal text, never generated or inferred
  - tagged `#auto`, explicitly never `#agent`
  - **the important part for an agent reading one back: don't reclassify it.** Guessing a real phase after the fact is exactly what #0002 was built to avoid.

`SKILL.md` and `AGENTS.md` stay in sync per their existing convention — verified with a line-by-line diff of the shared body; the one intentional difference is `SKILL.md` naming the timetracker-rs source repo in the ADR reference (it's the distributed copy), which `AGENTS.md` doesn't need since it already lives there.

## Testing

Docs-only change; ran `cargo build`/`cargo test` anyway as a sanity check — 287 passed, 0 failed, unaffected.

This closes out #0002's core chain: #18 → #19 → #20. #21 (wiring `--auto-log` into the `Stop` hook) stays deliberately deferred per the ADR.