### PR TITLE
feat(tui): add exclude filtering to the project and tag panes

### DIFF
--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -51,7 +51,7 @@ impl IdleInterval {
 pub fn parse_tags(text: &str) -> (String, Vec<String>) {
     let mut tags = Vec::new();
     let mut clean_parts = Vec::new();
-    
+
     for word in text.split_whitespace() {
         if word.starts_with('#') && word.len() > 1 {
             // Remove the # prefix and add to tags
@@ -60,7 +60,7 @@ pub fn parse_tags(text: &str) -> (String, Vec<String>) {
             clean_parts.push(word);
         }
     }
-    
+
     (clean_parts.join(" "), tags)
 }
 
@@ -95,7 +95,10 @@ pub fn migrate(data: &mut TimeData) {
 
 /// Format tags for display (with # prefix), e.g. "#backend #bug"
 pub fn format_tags(tags: &[String]) -> String {
-    tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(" ")
+    tags.iter()
+        .map(|t| format!("#{}", t))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 impl TimeEntry {
@@ -148,24 +151,14 @@ impl TimeEntry {
         self.tags.iter().any(|t| t.to_lowercase() == tag_lower)
     }
 
-    /// Check if entry matches any of the given tags (case-insensitive)
-    pub fn has_any_tag(&self, tags: &[String]) -> bool {
-        tags.iter().any(|t| self.has_tag(t))
-    }
-
-    /// Whether the entry's project is one of `projects` (case-insensitive). An
-    /// entry with no project matches nothing.
-    pub fn has_any_project(&self, projects: &[String]) -> bool {
-        let Some(project) = self
-            .project
+    /// Whether the entry's project is `name` (trim, case-insensitive). An entry
+    /// with no project matches nothing.
+    pub fn is_project(&self, name: &str) -> bool {
+        self.project
             .as_deref()
             .map(str::trim)
             .filter(|p| !p.is_empty())
-        else {
-            return false;
-        };
-        let project = project.to_lowercase();
-        projects.iter().any(|p| p.trim().to_lowercase() == project)
+            .is_some_and(|p| p.to_lowercase() == name.trim().to_lowercase())
     }
 
     /// The haystack `/` searches: everything a row or the popover can show, built

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -46,9 +46,9 @@ pub(crate) struct App {
     pub(crate) input_end_time: String,
     pub(crate) input_duration: String,
     pub(crate) search_term: String,
-    /// The values picked in each pane. OR within a set, AND across the two.
-    pub(crate) selected_projects: Vec<String>,
-    pub(crate) selected_tags: Vec<String>,
+    /// Each pane's tri-state filter. OR within a pane's includes, AND across the two.
+    pub(crate) project_filter: panes::PaneFilter,
+    pub(crate) tag_filter: panes::PaneFilter,
     pub(crate) editing_entry_id: Option<u64>,
     /// What `InputMode::Confirm` is asking about: the action, entry and origin mode.
     pub(crate) pending_confirm: Option<PendingConfirm>,
@@ -144,8 +144,8 @@ impl App {
             input_end_time: String::new(),
             input_duration: String::new(),
             search_term: String::new(),
-            selected_projects: Vec::new(),
-            selected_tags: Vec::new(),
+            project_filter: panes::PaneFilter::default(),
+            tag_filter: panes::PaneFilter::default(),
             editing_entry_id: None,
             pending_confirm: None,
             sort_order: SortOrder::NewestFirst,
@@ -330,12 +330,16 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
                                     app.previous();
                                 }
                             }
-                            // One key, disambiguated by focus: `toggle_pane_value`
+                            // One key, disambiguated by focus: `cycle_pane_value`
                             // reporting false *is* the focus check.
                             KeyCode::Enter => {
-                                if !app.toggle_pane_value() {
+                                if !app.cycle_pane_value(true) {
                                     app.open_detail();
                                 }
+                            }
+                            // Reverse cycle; without pane focus it does nothing.
+                            KeyCode::Char('-') => {
+                                app.cycle_pane_value(false);
                             }
                             KeyCode::Char('P') => app.toggle_pane(Pane::Projects),
                             KeyCode::Char('T') => app.toggle_pane(Pane::Tags),
@@ -527,6 +531,7 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::panes::Polarity;
     use super::*;
     use crate::storage;
     /// Serialises the tests that repoint `HOME` and `TT_MARK_DIR`; env is
@@ -1051,7 +1056,7 @@ mod tests {
         app.view_mode = ViewMode::Day;
         let before = app.pane_values(Pane::Tags);
 
-        app.selected_tags = vec!["plan".to_string()];
+        app.tag_filter.cycle("plan", true);
         app.search_term = "nothing matches this".to_string();
         assert!(app.filtered_entries().is_empty(), "filter did not bite");
         assert_eq!(app.pane_values(Pane::Tags), before);
@@ -1559,7 +1564,7 @@ mod tests {
         }
     }
 
-    /// `Enter` in a pane filters on the value under its cursor; on the table it does not.
+    /// `Enter` in a pane cycles the value under its cursor; on the table it does not.
     #[test]
     fn enter_toggles_the_value_under_the_pane_cursor() {
         let _guard = env_guard();
@@ -1568,22 +1573,121 @@ mod tests {
         app.view_mode = ViewMode::Day;
         assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
 
+        // Three Enters walk off → include → exclude → off.
         point_at(&mut app, Pane::Projects, "tt");
-        assert!(app.toggle_pane_value(), "Enter was not handled by the pane");
-        assert_eq!(app.selected_projects, vec!["tt".to_string()]);
+        assert!(
+            app.cycle_pane_value(true),
+            "Enter was not handled by the pane"
+        );
+        assert_eq!(
+            app.pane_value_state(Pane::Projects, "tt"),
+            Some(Polarity::Include)
+        );
         assert_eq!(in_view(&app), vec!["a", "b"]);
         assert!(app.is_filtering());
-        assert!(app.pane_value_is_selected(Pane::Projects, "tt"));
 
-        assert!(app.toggle_pane_value());
-        assert!(app.selected_projects.is_empty());
+        assert!(app.cycle_pane_value(true));
+        assert_eq!(
+            app.pane_value_state(Pane::Projects, "tt"),
+            Some(Polarity::Exclude)
+        );
+        // Pure negation: `f`, with no project, survives the exclusion.
+        assert_eq!(in_view(&app), vec!["c", "f"]);
+        assert!(app.is_filtering());
+
+        assert!(app.cycle_pane_value(true));
+        assert_eq!(app.pane_value_state(Pane::Projects, "tt"), None);
         assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
         assert!(!app.is_filtering());
 
         app.focus = Focus::Table;
-        assert!(!app.toggle_pane_value());
-        assert!(app.selected_projects.is_empty() && app.selected_tags.is_empty());
+        assert!(!app.cycle_pane_value(true));
+        assert!(!app.is_filtering());
         assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+    }
+
+    /// `-` walks the cycle the other way: off → exclude → include → off.
+    #[test]
+    fn minus_cycles_the_pane_value_backwards() {
+        let _guard = env_guard();
+        sandbox("pane-cycle-back");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+
+        point_at(&mut app, Pane::Projects, "tt");
+        assert!(app.cycle_pane_value(false), "- was not handled by the pane");
+        assert_eq!(
+            app.pane_value_state(Pane::Projects, "tt"),
+            Some(Polarity::Exclude)
+        );
+        assert_eq!(in_view(&app), vec!["c", "f"]);
+
+        assert!(app.cycle_pane_value(false));
+        assert_eq!(
+            app.pane_value_state(Pane::Projects, "tt"),
+            Some(Polarity::Include)
+        );
+        assert_eq!(in_view(&app), vec!["a", "b"]);
+
+        assert!(app.cycle_pane_value(false));
+        assert_eq!(app.pane_value_state(Pane::Projects, "tt"), None);
+        assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+
+        app.focus = Focus::Table;
+        assert!(!app.cycle_pane_value(false));
+        assert!(!app.is_filtering());
+        assert_eq!(in_view(&app), vec!["a", "b", "c", "f"]);
+    }
+
+    /// Excluding a tag hides its entries and keeps the untagged ones.
+    #[test]
+    fn excluding_a_tag_admits_untagged_entries() {
+        let _guard = env_guard();
+        sandbox("pane-exclude-tag");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+
+        app.tag_filter.cycle("impl", false);
+        assert_eq!(in_view(&app), vec!["b", "f"]);
+
+        // An include plus an exclude in the same pane narrows correctly.
+        app.tag_filter.cycle("ops", true);
+        assert_eq!(in_view(&app), Vec::<String>::new());
+        app.tag_filter.cycle("plan", true);
+        assert_eq!(in_view(&app), vec!["b"]);
+    }
+
+    /// An excluded value renders as `-value` in its pane and `-` in the title.
+    #[test]
+    fn the_excluded_state_is_rendered_in_the_pane_and_the_title() {
+        let _guard = env_guard();
+        sandbox("pane-exclude-render");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        app.toggle_pane(Pane::Projects);
+        app.toggle_pane(Pane::Tags);
+        app.project_filter.cycle("tt", false);
+        app.tag_filter.cycle("impl", true);
+
+        let screen = frame_lines(&mut app, 100, 30).join("\n");
+        assert!(screen.contains("-tt"), "no `-tt` pane row:\n{screen}");
+        assert!(screen.contains("•impl"), "no `•impl` pane row:\n{screen}");
+        assert!(
+            screen.contains("Entries [filtered: -(tt) #impl]"),
+            "the title does not show the exclusion:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn the_help_popup_teaches_both_cycle_keys() {
+        let _guard = env_guard();
+        sandbox("help-cycle-keys");
+        let mut app = seed_panes();
+        app.input_mode = InputMode::Help;
+
+        let screen = frame_lines(&mut app, 100, 45).join("\n");
+        assert!(screen.contains("pane value: include / exclude / off"));
+        assert!(screen.contains("cycle the pane value back"));
     }
 
     #[test]
@@ -1596,7 +1700,7 @@ mod tests {
 
         // This is exactly what the Normal-mode Enter arm does.
         let enter = |app: &mut App| {
-            if !app.toggle_pane_value() {
+            if !app.cycle_pane_value(true) {
                 app.open_detail();
             }
         };
@@ -1607,7 +1711,10 @@ mod tests {
             app.input_mode == InputMode::Normal,
             "Enter in a pane opened the popover instead of filtering"
         );
-        assert_eq!(app.selected_projects, vec!["tt".to_string()]);
+        assert_eq!(
+            app.pane_value_state(Pane::Projects, "tt"),
+            Some(Polarity::Include)
+        );
 
         app.focus = Focus::Table;
         enter(&mut app);
@@ -1616,7 +1723,10 @@ mod tests {
             "Enter on the table did not open the popover"
         );
         assert_eq!(app.table_state.selected(), Some(0));
-        assert_eq!(app.selected_projects, vec!["tt".to_string()]);
+        assert_eq!(
+            app.pane_value_state(Pane::Projects, "tt"),
+            Some(Polarity::Include)
+        );
         assert_eq!(app.selected_entry().map(|e| e.id), Some(0));
     }
 
@@ -2419,21 +2529,21 @@ mod tests {
         app.view_mode = ViewMode::Day;
 
         point_at(&mut app, Pane::Projects, "tt");
-        app.toggle_pane_value();
+        app.cycle_pane_value(true);
         assert_eq!(in_view(&app), vec!["a", "b"]);
 
         // A second project widens the set — the two are OR'd.
         point_at(&mut app, Pane::Projects, "loremind");
-        app.toggle_pane_value();
+        app.cycle_pane_value(true);
         assert_eq!(in_view(&app), vec!["a", "b", "c"]);
 
         // A tag narrows within them — the panes are AND'd.
         point_at(&mut app, Pane::Tags, "impl");
-        app.toggle_pane_value();
+        app.cycle_pane_value(true);
         assert_eq!(in_view(&app), vec!["a", "c"]);
 
         point_at(&mut app, Pane::Tags, "plan");
-        app.toggle_pane_value();
+        app.cycle_pane_value(true);
         assert_eq!(in_view(&app), vec!["a", "b", "c"]);
 
         app.clear_filters();
@@ -2452,7 +2562,7 @@ mod tests {
         assert_eq!(app.filtered_total().num_hours(), 4);
 
         point_at(&mut app, Pane::Projects, "tt");
-        app.toggle_pane_value();
+        app.cycle_pane_value(true);
         assert_eq!(app.filtered_total().num_hours(), 2);
         assert!(app.is_filtering());
     }
@@ -2584,15 +2694,15 @@ mod tests {
         let before = app.project_summary();
         let in_scope = app.scope_entries().len();
 
-        app.selected_projects = vec!["tt".to_string()];
+        app.project_filter.cycle("tt", true);
         assert!(
             app.filtered_entries().len() < in_scope,
             "filter did not bite"
         );
         assert_eq!(app.project_summary(), before);
 
-        app.selected_projects.clear();
-        app.selected_tags = vec!["ops".to_string()];
+        app.project_filter.clear();
+        app.tag_filter.cycle("ops", true);
         assert!(
             app.filtered_entries().len() < in_scope,
             "filter did not bite"
@@ -2702,7 +2812,7 @@ mod tests {
         app.set_view_mode(ViewMode::Day);
         assert!(!app.total_is_filtered());
         let unfiltered = app.summary_marker(6);
-        app.selected_projects = vec!["tt".to_string()];
+        app.project_filter.cycle("tt", true);
         assert!(app.total_is_filtered(), "the footer total is now narrowed");
         assert_eq!(app.summary_marker(6), unfiltered);
     }
@@ -2752,7 +2862,7 @@ mod tests {
         assert!(!app.total_is_filtered());
         assert_eq!(summed, app.data.total_for_week(week_start));
 
-        app.selected_projects = vec!["tt".to_string()];
+        app.project_filter.cycle("tt", true);
         assert!(app.total_is_filtered(), "the marker is now emphasised");
         assert!(
             app.filtered_total() < summed,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1641,7 +1641,7 @@ mod tests {
 
     /// Excluding a tag hides its entries and keeps the untagged ones.
     #[test]
-    fn excluding_a_tag_admits_untagged_entries() {
+    fn excluding_a_tag_allows_untagged_entries() {
         let _guard = env_guard();
         sandbox("pane-exclude-tag");
         let mut app = seed_panes();

--- a/src/tui/panes.rs
+++ b/src/tui/panes.rs
@@ -10,6 +10,75 @@ use crate::tracker::TimeEntry;
 /// Most value rows a pane shows before it starts scrolling.
 const MAX_VISIBLE_VALUES: usize = 6;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Polarity {
+    Include,
+    Exclude,
+}
+
+/// A pane's filter. One vec, so a value is include or exclude, never both.
+#[derive(Debug, Default)]
+pub(crate) struct PaneFilter(Vec<(String, Polarity)>);
+
+impl PaneFilter {
+    /// Walk a value one step: forward is off → include → exclude → off,
+    /// backward the reverse.
+    pub(crate) fn cycle(&mut self, value: &str, forward: bool) {
+        let next = match (self.state(value), forward) {
+            (None, true) | (Some(Polarity::Exclude), false) => Some(Polarity::Include),
+            (None, false) | (Some(Polarity::Include), true) => Some(Polarity::Exclude),
+            (Some(Polarity::Exclude), true) | (Some(Polarity::Include), false) => None,
+        };
+        self.0.retain(|(v, _)| v != value);
+        if let Some(polarity) = next {
+            self.0.push((value.to_string(), polarity));
+        }
+    }
+
+    pub(crate) fn state(&self, value: &str) -> Option<Polarity> {
+        self.0
+            .iter()
+            .find(|(v, _)| v == value)
+            .map(|(_, polarity)| *polarity)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// The precedence rule, stated once: admitted when the entry matches no
+    /// excluded value and (there are no included values or it matches one).
+    /// Pure negation follows — an entry with no value matches nothing, so an
+    /// exclusion-only filter admits it.
+    pub(crate) fn admits(&self, matches: impl Fn(&str) -> bool) -> bool {
+        let mut any_include = false;
+        let mut include_hit = false;
+        for (value, polarity) in &self.0 {
+            match polarity {
+                Polarity::Exclude => {
+                    if matches(value) {
+                        return false;
+                    }
+                }
+                Polarity::Include => {
+                    any_include = true;
+                    include_hit = include_hit || matches(value);
+                }
+            }
+        }
+        !any_include || include_hit
+    }
+
+    /// The values in cycle order, for the Entries title.
+    pub(crate) fn values(&self) -> impl Iterator<Item = (&str, Polarity)> {
+        self.0.iter().map(|(v, p)| (v.as_str(), *p))
+    }
+}
+
 /// The number a collapsible surface puts on its top border, or `None` when it has
 /// nothing to say. With a cursor (`position` is `Some`) it is about *place*: hidden
 /// while every row fits, `position/total` once the list scrolls. Without one it is
@@ -31,9 +100,9 @@ pub(crate) fn surface_count(
 impl App {
     /// The current view scope, before any filter. `filtered_entries` starts here.
     pub(crate) fn scope_entries(&self) -> Vec<&TimeEntry> {
-        use chrono::Datelike;
         use super::types::ViewMode;
         use crate::tracker::TimeData;
+        use chrono::Datelike;
         match self.view_mode {
             ViewMode::All => self.data.entries.iter().collect(),
             ViewMode::Day => self.data.entries_for_date(self.selected_date),
@@ -178,22 +247,18 @@ impl App {
         self.focus = order[(current + delta).rem_euclid(len) as usize];
     }
 
-    pub(crate) fn pane_selection(&self, pane: Pane) -> &[String] {
+    /// Exact match: both sides come from [`pane_values`](Self::pane_values), though
+    /// the filter predicates themselves stay case-insensitive.
+    pub(crate) fn pane_value_state(&self, pane: Pane, value: &str) -> Option<Polarity> {
         match pane {
-            Pane::Projects => &self.selected_projects,
-            Pane::Tags => &self.selected_tags,
+            Pane::Projects => self.project_filter.state(value),
+            Pane::Tags => self.tag_filter.state(value),
         }
     }
 
-    /// Exact match: both sides come from [`pane_values`](Self::pane_values), though
-    /// the filter predicates themselves stay case-insensitive.
-    pub(crate) fn pane_value_is_selected(&self, pane: Pane, value: &str) -> bool {
-        self.pane_selection(pane).iter().any(|v| v == value)
-    }
-
-    /// `Enter` in the focused pane: toggle the value under its cursor. Returns false
-    /// when no pane has focus, so `Enter` falls through to the detail popover.
-    pub(crate) fn toggle_pane_value(&mut self) -> bool {
+    /// Cycle the value under the focused pane's cursor. Returns false when no
+    /// pane has focus, so `Enter` falls through to the detail popover.
+    pub(crate) fn cycle_pane_value(&mut self, forward: bool) -> bool {
         let Some(pane) = self.focused_pane() else {
             return false;
         };
@@ -201,15 +266,9 @@ impl App {
         let Some((value, _)) = self.pane_values(pane).into_iter().nth(cursor) else {
             return true;
         };
-        let selection = match pane {
-            Pane::Projects => &mut self.selected_projects,
-            Pane::Tags => &mut self.selected_tags,
-        };
-        match selection.iter().position(|v| v == &value) {
-            Some(pos) => {
-                selection.remove(pos);
-            }
-            None => selection.push(value),
+        match pane {
+            Pane::Projects => self.project_filter.cycle(&value, forward),
+            Pane::Tags => self.tag_filter.cycle(&value, forward),
         }
         // The row that was selected is very unlikely to still be the same row.
         self.table_state.select(Some(0));

--- a/src/tui/panes.rs
+++ b/src/tui/panes.rs
@@ -53,8 +53,8 @@ impl PaneFilter {
     /// The precedence rule, stated once: admitted when the entry matches no
     /// excluded value and (there are no included values or it matches one).
     /// Pure negation follows — an entry with no value matches nothing, so an
-    /// exclusion-only filter admits it.
-    pub(crate) fn admits(&self, matches: impl Fn(&str) -> bool) -> bool {
+    /// exclusion-only filter allows it.
+    pub(crate) fn allows(&self, matches: impl Fn(&str) -> bool) -> bool {
         let mut any_include = false;
         let mut include_hit = false;
         for (value, polarity) in &self.0 {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,3 +1,4 @@
+use super::panes::Polarity;
 use super::types::{
     ConfirmAction, InputField, InputMode, LayoutSurface, OnboardingStep, Pane, ViewMode,
 };
@@ -423,7 +424,11 @@ pub fn render_help_popup(f: &mut Frame) {
         Line::from(vec![key("  Shift-T"), sep("    Tags pane on / off")]),
         Line::from(vec![key("  Tab"), sep("        focus table / panes")]),
         Line::from(vec![key("  Shift-Tab"), sep("  focus panes in reverse")]),
-        Line::from(vec![key("  Enter"), sep("      filter on the pane value")]),
+        Line::from(vec![
+            key("  Enter"),
+            sep("      pane value: include / exclude / off"),
+        ]),
+        Line::from(vec![key("  -"), sep("          cycle the pane value back")]),
         Line::from(Span::raw("")),
         heading("  Other"),
         Line::from(vec![key("  Shift-A"), sep("  agent phases on / off")]),
@@ -1043,17 +1048,17 @@ fn render_pane(f: &mut Frame, app: &App, pane: Pane, area: Rect) {
         values
             .iter()
             .map(|(value, count)| {
-                // The lead column carries the selection mark, so it costs no width.
-                let selected = app.pane_value_is_selected(pane, value);
-                let mark = if selected { "•" } else { " " };
+                // The lead column carries the filter mark, so it costs no width.
+                // Both marks are one ASCII column: `used` below counts on it.
+                let state = app.pane_value_state(pane, value);
+                let (mark, value_style) = match state {
+                    Some(Polarity::Include) => ("•", Style::default().fg(theme::accent()).bold()),
+                    Some(Polarity::Exclude) => ("-", Style::default().fg(theme::inactive()).bold()),
+                    None => (" ", Style::default().fg(Color::White)),
+                };
                 let count = count.to_string();
                 let used = 1 + value.chars().count() + count.chars().count() + 1;
                 let gap = width.saturating_sub(used).max(1);
-                let value_style = if selected {
-                    Style::default().fg(theme::accent()).bold()
-                } else {
-                    Style::default().fg(Color::White)
-                };
                 ListItem::new(Line::from(vec![
                     Span::styled(format!("{}{}", mark, value), value_style),
                     Span::raw(" ".repeat(gap)),
@@ -1585,13 +1590,19 @@ fn render_entries_table(f: &mut Frame, app: &mut App, area: Rect) {
         (rows, app.table_state.selected())
     };
 
-    // `(tt)` and `#impl`, the CLI's own sigils, so the title needs no legend.
+    // `(tt)` and `#impl`, the CLI's own sigils, so the title needs no legend;
+    // an excluded value carries a `-` prefix.
     let title = if app.is_filtering() {
+        let negate = |p: Polarity| if p == Polarity::Exclude { "-" } else { "" };
         let values: Vec<String> = app
-            .selected_projects
-            .iter()
-            .map(|p| format!("({})", p))
-            .chain(app.selected_tags.iter().map(|t| format!("#{}", t)))
+            .project_filter
+            .values()
+            .map(|(v, p)| format!("{}({})", negate(p), v))
+            .chain(
+                app.tag_filter
+                    .values()
+                    .map(|(v, p)| format!("{}#{}", negate(p), v)),
+            )
             .collect();
         format!(" Entries [filtered: {}] ", values.join(" "))
     } else {

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -1,6 +1,6 @@
-use chrono::Duration;
 use super::App;
 use super::types::{InputMode, SortOrder};
+use chrono::Duration;
 
 impl App {
     pub(crate) fn filtered_entries(&self) -> Vec<&crate::tracker::TimeEntry> {
@@ -11,13 +11,11 @@ impl App {
             SortOrder::OldestFirst => entries.sort_by(|a, b| a.start_time.cmp(&b.start_time)),
         }
 
-        // OR within a pane, AND across the two; an empty set is not a filter.
+        // OR within a pane's includes, AND across the two; exclusions veto first.
         let entries: Vec<_> = entries
             .into_iter()
-            .filter(|e| {
-                self.selected_projects.is_empty() || e.has_any_project(&self.selected_projects)
-            })
-            .filter(|e| self.selected_tags.is_empty() || e.has_any_tag(&self.selected_tags))
+            .filter(|e| self.project_filter.admits(|v| e.is_project(v)))
+            .filter(|e| self.tag_filter.admits(|v| e.has_tag(v)))
             .collect();
 
         if self.search_term.is_empty() {
@@ -43,7 +41,7 @@ impl App {
 
     /// Whether a pane selection is narrowing the view.
     pub(crate) fn is_filtering(&self) -> bool {
-        !self.selected_projects.is_empty() || !self.selected_tags.is_empty()
+        !self.project_filter.is_empty() || !self.tag_filter.is_empty()
     }
 
     /// Whether the footer's figure is narrowed — pane selection or search term.
@@ -53,8 +51,8 @@ impl App {
     }
 
     pub(crate) fn clear_filters(&mut self) {
-        self.selected_projects.clear();
-        self.selected_tags.clear();
+        self.project_filter.clear();
+        self.tag_filter.clear();
         self.table_state.select(Some(0));
     }
 
@@ -72,7 +70,12 @@ impl App {
 
     pub(crate) fn handle_search_char(&mut self, c: char) {
         let pos = self.cursor_pos;
-        let byte_idx = self.search_term.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(self.search_term.len());
+        let byte_idx = self
+            .search_term
+            .char_indices()
+            .nth(pos)
+            .map(|(i, _)| i)
+            .unwrap_or(self.search_term.len());
         self.search_term.insert(byte_idx, c);
         self.cursor_pos += 1;
         self.table_state.select(Some(0));
@@ -81,9 +84,21 @@ impl App {
     pub(crate) fn handle_search_backspace(&mut self) {
         let pos = self.cursor_pos;
         let actual_pos = pos.min(self.search_term.chars().count());
-        if actual_pos == 0 { return; }
-        let byte_start = self.search_term.char_indices().nth(actual_pos - 1).map(|(i, _)| i).unwrap_or(self.search_term.len());
-        let byte_end = self.search_term.char_indices().nth(actual_pos).map(|(i, _)| i).unwrap_or(self.search_term.len());
+        if actual_pos == 0 {
+            return;
+        }
+        let byte_start = self
+            .search_term
+            .char_indices()
+            .nth(actual_pos - 1)
+            .map(|(i, _)| i)
+            .unwrap_or(self.search_term.len());
+        let byte_end = self
+            .search_term
+            .char_indices()
+            .nth(actual_pos)
+            .map(|(i, _)| i)
+            .unwrap_or(self.search_term.len());
         self.search_term.drain(byte_start..byte_end);
         self.cursor_pos = actual_pos - 1;
         self.table_state.select(Some(0));

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -14,8 +14,8 @@ impl App {
         // OR within a pane's includes, AND across the two; exclusions veto first.
         let entries: Vec<_> = entries
             .into_iter()
-            .filter(|e| self.project_filter.admits(|v| e.is_project(v)))
-            .filter(|e| self.tag_filter.admits(|v| e.has_tag(v)))
+            .filter(|e| self.project_filter.allows(|v| e.is_project(v)))
+            .filter(|e| self.tag_filter.allows(|v| e.has_tag(v)))
             .collect();
 
         if self.search_term.is_empty() {


### PR DESCRIPTION
Adds tri-state include/exclude filtering to the TUI project and tag panes.

- Filter model is tri-state per item: off, include, exclude.
- Enter cycles a selection forward; `-` cycles it back.
- Pure-negation semantics: excluding a project also shows entries with no project.
- Pane markers, entries-title sigil and the help popup reflect the new states.
- Tests cover the filter model, key wiring and rendered frames.

Reference: janlofberg-knowit/timetracker-rs#122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
