### PR TITLE
feat(agent): add an explore phase to the phase vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ issue number, or `-`. `<phase>` is one of:
 | verifying behaviour, running or fixing tests | `qa` |
 | reading code to judge it, whether or not it changes | `review` |
 | documentation | `docs` |
-| investigation that produces no artifact | `spike` |
+| investigation that produces no artifact, answering a specific question | `spike` |
+| open-ended exploration with no specific question | `explore` |
 | tooling, config, environment, release | `ops` |
 
 Everything below is detail on those three commands.
@@ -63,7 +64,7 @@ Everything below is detail on those three commands.
   environment manager such as `mise` or `direnv`, `$TT_PROJECT` is a natural thing
   for them to declare there, so the value travels with the repo.)
 - **issue** — the tracked issue number, or `-` if untracked
-- **phase** — one of `plan` `impl` `qa` `review` `docs` `spike` `ops`; see the
+- **phase** — one of `plan` `impl` `qa` `review` `docs` `spike` `explore` `ops`; see the
   phase table at the top of this file
 
 **project is a real field** on the entry, not a tag: the agent commands pass it as

--- a/skills/tt-time-logging/SKILL.md
+++ b/skills/tt-time-logging/SKILL.md
@@ -24,7 +24,8 @@ issue number, or `-`. `<phase>` is one of:
 | verifying behaviour, running or fixing tests | `qa` |
 | reading code to judge it, whether or not it changes | `review` |
 | documentation | `docs` |
-| investigation that produces no artifact | `spike` |
+| investigation that produces no artifact, answering a specific question | `spike` |
+| open-ended exploration with no specific question | `explore` |
 | tooling, config, environment, release | `ops` |
 
 <!-- card:end — everything above is the per-prompt card; see scripts/tt-contract-hook.mjs -->

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -577,7 +577,7 @@ fn strip_stray_tags(summary: &str) -> String {
 /// The phase vocabulary, in the order the docs list it. `src/report.rs` reads it
 /// back off the stored tags, so it must stay the one list. Not used to validate
 /// the `phase` argument: any word is accepted.
-pub const PHASES: [&str; 7] = ["plan", "impl", "qa", "review", "docs", "spike", "ops"];
+pub const PHASES: [&str; 8] = ["plan", "impl", "qa", "review", "docs", "spike", "explore", "ops"];
 
 /// The description `cli::log` is given: the summary, then one tag per axis the
 /// `project` field cannot express — the item (omitted for the `-` sentinel), the


### PR DESCRIPTION
Adds `explore` to the agent phase vocabulary for open-ended exploration with no specific question, distinguishing it from `spike` (investigation that answers a specific question).

- Adds `explore` to the `PHASES` const.
- Adds `explore` to the phase table in `AGENTS.md`.
- Adds `explore` to the mirrored phase table in `SKILL.md`.

Both doc tables and the code const are updated together, per the maintainer sync note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
