### PR TITLE
feat(tui): table-driven, scrollable keybindings help popup

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -38,6 +38,8 @@ pub(crate) struct App {
     pub(crate) view_mode: ViewMode,
     pub(crate) selected_date: NaiveDate,
     pub(crate) input_mode: InputMode,
+    /// Top row of the help popup; clamped by the renderer, so it may run ahead.
+    pub(crate) help_scroll: usize,
     pub(crate) input_field: InputField,
     pub(crate) input_description: String,
     pub(crate) input_project: String,
@@ -136,6 +138,7 @@ impl App {
             view_mode: ViewMode::Day,
             selected_date: Local::now().date_naive(),
             input_mode: InputMode::Normal,
+            help_scroll: 0,
             input_field: InputField::Description,
             input_description: String::new(),
             input_project: String::new(),
@@ -363,7 +366,10 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
                             KeyCode::Char('l') | KeyCode::Right => app.next_period(),
                             KeyCode::Char('t') => app.go_to_today(),
                             KeyCode::Char('o') => app.toggle_sort_order(),
-                            KeyCode::Char('?') => app.input_mode = InputMode::Help,
+                            KeyCode::Char('?') => {
+                                app.help_scroll = 0;
+                                app.input_mode = InputMode::Help;
+                            }
                             _ => {}
                         },
                         InputMode::Onboarding => match app.onboarding_step {
@@ -462,7 +468,12 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
                         },
                         InputMode::Help => match key.code {
                             KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+                                app.help_scroll = 0;
                                 app.input_mode = InputMode::Normal;
+                            }
+                            KeyCode::Char('j') | KeyCode::Down => app.help_scroll += 1,
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                app.help_scroll = app.help_scroll.saturating_sub(1)
                             }
                             _ => {}
                         },
@@ -1688,6 +1699,51 @@ mod tests {
         let screen = frame_lines(&mut app, 100, 45).join("\n");
         assert!(screen.contains("pane value: include / exclude / off"));
         assert!(screen.contains("cycle the pane value back"));
+    }
+
+    #[test]
+    fn the_help_popup_aligns_descriptions_across_sections() {
+        let _guard = env_guard();
+        sandbox("help-aligned");
+        let mut app = seed_panes();
+        app.input_mode = InputMode::Help;
+
+        let lines = frame_lines(&mut app, 100, 45);
+        let column = |needle: &str| {
+            lines
+                .iter()
+                .find_map(|l| l.find(needle).map(|byte| l[..byte].chars().count()))
+                .unwrap_or_else(|| panic!("{needle} missing:\n{}", lines.join("\n")))
+        };
+        let first = column("previous period");
+        for needle in ["stop active entry", "focus panes in reverse", "quit"] {
+            assert_eq!(column(needle), first, "{needle}");
+        }
+        let screen = lines.join("\n");
+        assert!(screen.contains("trim idle from the entry (asks first)"), "{screen}");
+    }
+
+    #[test]
+    fn a_short_help_popup_scrolls_and_clamps() {
+        let _guard = env_guard();
+        sandbox("help-scroll");
+        let mut app = seed_panes();
+        app.input_mode = InputMode::Help;
+
+        let top = frame_lines(&mut app, 100, 20).join("\n");
+        assert!(top.contains("▾ more"), "{top}");
+        assert!(top.contains("j/k scroll"), "{top}");
+        assert!(!top.contains("q / Esc"), "{top}");
+
+        app.help_scroll = 1000;
+        let bottom = frame_lines(&mut app, 100, 20).join("\n");
+        assert!(bottom.contains("q / Esc"), "{bottom}");
+        assert!(!bottom.contains("▾ more"), "{bottom}");
+        assert!(app.help_scroll < 1000, "render clamps the offset");
+
+        app.input_mode = InputMode::Help;
+        let tall = frame_lines(&mut app, 100, 45).join("\n");
+        assert!(!tall.contains("▾ more") && !tall.contains("j/k scroll"), "{tall}");
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -305,7 +305,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     f.render_widget(keys_hint, footer_chunks[1]);
 
     match app.input_mode {
-        InputMode::Help => render_help_popup(f),
+        InputMode::Help => render_help_popup(f, app),
         InputMode::Detail => render_detail_popup(f, app),
         InputMode::Confirm => render_confirm_popup(f, app),
         InputMode::Onboarding => render_onboarding_popup(f, app),
@@ -373,86 +373,124 @@ fn overlay_hints(pairs: &[(&'static str, &'static str)]) -> Line<'static> {
     Line::from(spans)
 }
 
-pub fn render_help_popup(f: &mut Frame) {
-    fn key(k: &'static str) -> Span<'static> {
-        Span::styled(k, Style::default().fg(theme::accent()).bold())
-    }
-    fn sep(s: &'static str) -> Span<'static> {
-        Span::styled(s, Style::default().fg(theme::inactive()))
-    }
-    fn heading(s: &'static str) -> Line<'static> {
-        Line::from(Span::styled(
-            s,
-            Style::default().fg(theme::highlight()).bold(),
-        ))
+/// Section title, then `(keys, description)` rows. The key column is one
+/// width across every section, measured in display cells.
+const HELP_SECTIONS: &[(&str, &[(&str, &str)])] = &[
+    (
+        "Navigation",
+        &[
+            ("h / ←", "previous period"),
+            ("l / →", "next period"),
+            ("j / ↓", "select next entry"),
+            ("k / ↑", "select previous entry"),
+            ("t", "go to today"),
+            ("1 / 2 / 3 / 4", "day / week / all / overview"),
+        ],
+    ),
+    (
+        "Entries",
+        &[
+            ("a", "add entry (uses browsed date)"),
+            ("e", "edit selected entry"),
+            ("d", "delete selected entry (asks first)"),
+            ("s", "stop active entry"),
+            ("Enter", "entry detail"),
+            // A path, not a key: the trim is live only while the popover is open.
+            ("Enter, t", "trim idle from the entry (asks first)"),
+        ],
+    ),
+    (
+        "Search & Filter",
+        &[
+            ("/", "search any field"),
+            ("Shift-P", "Projects pane on / off"),
+            ("Shift-T", "Tags pane on / off"),
+            ("Tab", "focus table / panes"),
+            ("Shift-Tab", "focus panes in reverse"),
+            ("Enter", "pane value: include / exclude / off"),
+            ("-", "cycle the pane value back"),
+        ],
+    ),
+    (
+        "Other",
+        &[
+            ("Shift-A", "agent phases on / off"),
+            ("Shift-S", "project summary on / off"),
+            ("o", "toggle sort order"),
+            ("r", "reload data from disk"),
+            ("?", "toggle this help"),
+            ("q / Esc", "quit"),
+        ],
+    ),
+];
+
+/// Width and height follow the table, and `app.help_scroll` is clamped here
+/// against the viewport `render_overlay` actually granted — never in the key
+/// handler — so a resize corrects itself on the next frame.
+pub fn render_help_popup(f: &mut Frame, app: &mut App) {
+    const INSET: &str = "  ";
+    const GAP: usize = 2;
+    let key_style = Style::default().fg(theme::accent()).bold();
+    let desc_style = Style::default().fg(theme::inactive());
+    let heading_style = Style::default().fg(theme::highlight()).bold();
+
+    let rows = HELP_SECTIONS.iter().flat_map(|(_, rows)| rows.iter());
+    let key_width = rows
+        .clone()
+        .map(|(k, _)| Span::raw(*k).width())
+        .max()
+        .unwrap_or(0);
+    let desc_width = rows.map(|(_, d)| Span::raw(*d).width()).max().unwrap_or(0);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, (title, rows)) in HELP_SECTIONS.iter().enumerate() {
+        if i > 0 {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from(Span::styled(format!("{INSET}{title}"), heading_style)));
+        for (k, d) in rows.iter() {
+            let pad = key_width - Span::raw(*k).width() + GAP;
+            lines.push(Line::from(vec![
+                Span::raw(INSET),
+                Span::styled(*k, key_style),
+                Span::raw(" ".repeat(pad)),
+                Span::styled(*d, desc_style),
+            ]));
+        }
     }
 
-    let lines: Vec<Line> = vec![
-        heading("  Navigation"),
-        Line::from(vec![key("  h / ←"), sep("  previous period")]),
-        Line::from(vec![key("  l / →"), sep("  next period")]),
-        Line::from(vec![key("  j / ↓"), sep("  select next entry")]),
-        Line::from(vec![key("  k / ↑"), sep("  select previous entry")]),
-        Line::from(vec![key("  t"), sep("        go to today")]),
-        Line::from(vec![
-            key("  1 / 2 / 3 / 4"),
-            sep("  day / week / all / overview"),
-        ]),
-        Line::from(Span::raw("")),
-        heading("  Entries"),
-        Line::from(vec![
-            key("  a"),
-            sep("        add entry (uses browsed date)"),
-        ]),
-        Line::from(vec![key("  e"), sep("        edit selected entry")]),
-        Line::from(vec![
-            key("  d"),
-            sep("        delete selected entry (asks first)"),
-        ]),
-        Line::from(vec![key("  s"), sep("        stop active entry")]),
-        Line::from(vec![key("  Enter"), sep("    entry detail")]),
-        // A path, not a key: the trim is live only while the popover is open.
-        Line::from(vec![
-            key("  Enter, t"),
-            sep(" trim idle from the entry (asks first)"),
-        ]),
-        Line::from(Span::raw("")),
-        heading("  Search & Filter"),
-        // This section's key column is two wider, for `Shift-Tab`.
-        Line::from(vec![key("  /"), sep("          search any field")]),
-        Line::from(vec![key("  Shift-P"), sep("    Projects pane on / off")]),
-        Line::from(vec![key("  Shift-T"), sep("    Tags pane on / off")]),
-        Line::from(vec![key("  Tab"), sep("        focus table / panes")]),
-        Line::from(vec![key("  Shift-Tab"), sep("  focus panes in reverse")]),
-        Line::from(vec![
-            key("  Enter"),
-            sep("      pane value: include / exclude / off"),
-        ]),
-        Line::from(vec![key("  -"), sep("          cycle the pane value back")]),
-        Line::from(Span::raw("")),
-        heading("  Other"),
-        Line::from(vec![key("  Shift-A"), sep("  agent phases on / off")]),
-        Line::from(vec![key("  Shift-S"), sep("  project summary on / off")]),
-        Line::from(vec![key("  o"), sep("        toggle sort order")]),
-        Line::from(vec![key("  r"), sep("        reload data from disk")]),
-        Line::from(vec![key("  ?"), sep("        toggle this help")]),
-        Line::from(vec![key("  q / Esc"), sep("  quit")]),
-    ];
-
-    // Sized from the content, so adding a binding cannot push the last one out.
+    let width = (INSET.len() + key_width + GAP + desc_width + 2).max(32) as u16;
+    let wanted = lines.len() as u16 + 3;
+    let fits = wanted <= f.area().height.saturating_sub(2);
+    let hints: &[(&str, &str)] = if fits {
+        &[("esc", "close")]
+    } else {
+        &[("esc", "close"), ("j/k", "scroll")]
+    };
     let content = render_overlay(
         f,
-        52,
-        lines.len() as u16 + 3,
-        Span::styled(
-            " Keybindings ",
-            Style::default().fg(theme::highlight()).bold(),
-        ),
-        Span::styled(" ? ", Style::default().fg(theme::inactive())),
-        overlay_hints(&[("esc", "close")]),
+        width,
+        wanted,
+        Span::styled(" Keybindings ", heading_style),
+        Span::styled(" ? ", desc_style),
+        overlay_hints(hints),
     );
+
+    let visible = content.height as usize;
+    let max_offset = lines.len().saturating_sub(visible);
+    app.help_scroll = app.help_scroll.min(max_offset);
+    let more_below = app.help_scroll < max_offset;
+    let shown = if more_below { visible.saturating_sub(1) } else { visible };
+    let mut page: Vec<Line> = lines
+        .into_iter()
+        .skip(app.help_scroll)
+        .take(shown)
+        .collect();
+    if more_below {
+        page.push(Line::from(Span::styled("▾ more", desc_style)).right_aligned());
+    }
     f.render_widget(
-        Paragraph::new(lines).style(Style::default().bg(theme::OVERLAY_BG)),
+        Paragraph::new(page).style(Style::default().bg(theme::OVERLAY_BG)),
         content,
     );
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -326,7 +326,7 @@ fn render_overlay(
 ) -> Rect {
     let area = f.area();
     let width = width.min(area.width.saturating_sub(4));
-    let height = height.min(area.height.saturating_sub(2));
+    let height = overlay_height(f, height);
     let popup_area = Rect {
         x: (area.width.saturating_sub(width)) / 2,
         y: (area.height.saturating_sub(height)) / 2,
@@ -352,6 +352,11 @@ fn render_overlay(
         .split(inner);
     f.render_widget(Paragraph::new(hints).style(overlay_style), rows[1]);
     rows[0]
+}
+
+/// The rows an overlay asking for `wanted` actually gets on this frame.
+fn overlay_height(f: &Frame, wanted: u16) -> u16 {
+    wanted.min(f.area().height.saturating_sub(2))
 }
 
 /// ` esc close `-style hints, spelled out rather than glyphed.
@@ -461,7 +466,7 @@ pub fn render_help_popup(f: &mut Frame, app: &mut App) {
 
     let width = (INSET.len() + key_width + GAP + desc_width + 2).max(32) as u16;
     let wanted = lines.len() as u16 + 3;
-    let fits = wanted <= f.area().height.saturating_sub(2);
+    let fits = overlay_height(f, wanted) == wanted;
     let hints: &[(&str, &str)] = if fits {
         &[("esc", "close")]
     } else {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -447,7 +447,8 @@ pub fn render_help_popup(f: &mut Frame, app: &mut App) {
         .unwrap_or(0);
     let desc_width = rows.map(|(_, d)| Span::raw(*d).width()).max().unwrap_or(0);
 
-    let mut lines: Vec<Line> = Vec::new();
+    // A blank row above and below the table keeps it off the title and hints.
+    let mut lines: Vec<Line> = vec![Line::from("")];
     for (i, (title, rows)) in HELP_SECTIONS.iter().enumerate() {
         if i > 0 {
             lines.push(Line::from(""));
@@ -463,6 +464,7 @@ pub fn render_help_popup(f: &mut Frame, app: &mut App) {
             ]));
         }
     }
+    lines.push(Line::from(""));
 
     let width = (INSET.len() + key_width + GAP + desc_width + 2).max(32) as u16;
     let wanted = lines.len() as u16 + 3;


### PR DESCRIPTION
Rebuilds the TUI keybindings help popup from a section table with content-derived sizing, and makes it scrollable when the terminal is too short.

- Drive the popup from a section table with one aligned key column
- Derive popup width and height from the content instead of fixed values
- Scroll with `j`/`k`, showing a `▾` marker when more rows remain below
- Pad the table with a blank row above and below
- Share one overlay height clamp definition across overlays

<img width="497" height="728" alt="Screenshot 2026-08-26 at 09 57 52" src="https://github.com/user-attachments/assets/e97c4426-47d6-42d0-9067-61095fd6220c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)