### PR TITLE
feat(completions): dynamic nushell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -243,6 +243,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -975,6 +987,15 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1784,6 +1805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2074,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "directories",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = { version = "4", features = ["unstable-dynamic"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,6 +168,14 @@ Evaluate the hook at startup rather than saving its output: the generated
 script embeds the absolute path of the `tt` binary that produced it, so a
 saved copy breaks the moment the binary moves or is upgraded in place.
 
+Set `COMPLETE` only on that one line, never `export` it: any `tt` invocation
+that sees `COMPLETE` in its environment prints the registration script and
+exits instead of running the command.
+
+Both surfaces are verified to load and register in bash 3.2 and zsh 5.9. For
+fish, powershell and elvish only the generator's output is checked: no shell
+has parsed those scripts here, so treat them as untested.
+
 ---
 
 ## Duration Format

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,6 +145,29 @@ setting `TT_SKIP_UPDATE_CHECK=1`. It's also skipped automatically whenever a
 If you installed the Flatpak build, update with `flatpak update` instead —
 `tt update` won't try to replace a binary it can't write to.
 
+### `tt completions [shell]`
+
+Print a completion script for `bash`, `zsh`, `fish`, `powershell` or `elvish`
+to stdout. With no argument the shell is detected from the environment.
+
+```sh
+tt completions zsh > ~/.zfunc/_tt
+```
+
+A second, richer surface completes live values — projects, issues and phases
+from your own store — and is enabled by evaluating a one-line hook at shell
+startup, naming your shell in `COMPLETE`:
+
+```sh
+eval "$(COMPLETE=bash tt)"        # ~/.bashrc
+eval "$(COMPLETE=zsh tt)"         # ~/.zshrc
+COMPLETE=fish tt | source         # ~/.config/fish/config.fish
+```
+
+Evaluate the hook at startup rather than saving its output: the generated
+script embeds the absolute path of the `tt` binary that produced it, so a
+saved copy breaks the moment the binary moves or is upgraded in place.
+
 ---
 
 ## Duration Format

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,8 +147,8 @@ If you installed the Flatpak build, update with `flatpak update` instead —
 
 ### `tt completions [shell]`
 
-Print the shell completion hook for `bash`, `zsh`, `fish`, `powershell` or
-`elvish`. With no argument the shell is detected from `$SHELL`; pass one to
+Print the shell completion hook for `bash`, `zsh`, `fish`, `powershell`,
+`elvish` or `nu`. With no argument the shell is detected from `$SHELL`; pass one to
 override. The installers print this suggestion for your shell after
 installing. Evaluate it at shell startup:
 
@@ -166,8 +166,18 @@ Evaluate the hook at startup rather than saving its output: it embeds the
 absolute path of the `tt` binary that produced it, so a saved copy breaks the
 moment the binary moves or is upgraded in place.
 
-The hook is verified to load and register in bash 3.2 and zsh 5.9. For fish,
-powershell and elvish only the generator's output is checked: no shell has
+Nushell is the exception: it has no `eval`, so save the script once into the
+autoload directory. It calls `tt` by PATH name, so the saved copy stays valid
+across upgrades. Requires nushell 0.108 or newer (the `@complete` attribute).
+
+```nu
+mkdir $nu.user-autoload-dirs.0
+tt completions nu | save -f ($nu.user-autoload-dirs.0 | path join tt-completer.nu)
+```
+
+The hook is verified to load and register in bash 3.2 and zsh 5.9, and in
+nushell 0.115.1 (the `@complete` wrapper form, which passes `tt tui` and
+`tt report` through unchanged). For fish, powershell and elvish only the generator's output is checked: no shell has
 parsed those scripts here, so treat them as untested.
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,7 +149,8 @@ If you installed the Flatpak build, update with `flatpak update` instead —
 
 Print the shell completion hook for `bash`, `zsh`, `fish`, `powershell` or
 `elvish`. With no argument the shell is detected from `$SHELL`; pass one to
-override. Evaluate it at shell startup:
+override. The installers print this suggestion for your shell after
+installing. Evaluate it at shell startup:
 
 ```sh
 eval "$(tt completions zsh)"      # ~/.zshrc

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,34 +147,27 @@ If you installed the Flatpak build, update with `flatpak update` instead —
 
 ### `tt completions [shell]`
 
-Print a completion script for `bash`, `zsh`, `fish`, `powershell` or `elvish`
-to stdout. With no argument the shell is detected from the environment.
+Print the shell completion hook for `bash`, `zsh`, `fish`, `powershell` or
+`elvish`. With no argument the shell is detected from `$SHELL`; pass one to
+override. Evaluate it at shell startup:
 
 ```sh
-tt completions zsh > ~/.zfunc/_tt
+eval "$(tt completions zsh)"      # ~/.zshrc
+eval "$(tt completions bash)"     # ~/.bashrc
+tt completions fish | source      # ~/.config/fish/config.fish
 ```
 
-A second, richer surface completes live values — projects, issues and phases
-from your own store — and is enabled by evaluating a one-line hook at shell
-startup, naming your shell in `COMPLETE`:
+Completion then covers subcommands and flags, and completes live values from
+your own store: `--project`, and the project, issue and phase positionals of
+`tt agent`. Issues are scoped to the project already typed on the line.
 
-```sh
-eval "$(COMPLETE=bash tt)"        # ~/.bashrc
-eval "$(COMPLETE=zsh tt)"         # ~/.zshrc
-COMPLETE=fish tt | source         # ~/.config/fish/config.fish
-```
+Evaluate the hook at startup rather than saving its output: it embeds the
+absolute path of the `tt` binary that produced it, so a saved copy breaks the
+moment the binary moves or is upgraded in place.
 
-Evaluate the hook at startup rather than saving its output: the generated
-script embeds the absolute path of the `tt` binary that produced it, so a
-saved copy breaks the moment the binary moves or is upgraded in place.
-
-Set `COMPLETE` only on that one line, never `export` it: any `tt` invocation
-that sees `COMPLETE` in its environment prints the registration script and
-exits instead of running the command.
-
-Both surfaces are verified to load and register in bash 3.2 and zsh 5.9. For
-fish, powershell and elvish only the generator's output is checked: no shell
-has parsed those scripts here, so treat them as untested.
+The hook is verified to load and register in bash 3.2 and zsh 5.9. For fish,
+powershell and elvish only the generator's output is checked: no shell has
+parsed those scripts here, so treat them as untested.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -38,4 +38,16 @@ if ($pathEntries -notcontains $InstallDir) {
     Write-Host "$InstallDir is already on your PATH."
 }
 
+# Mirrors the per-shell hint table in src/cli.rs (`completions`).
+$previousErrorAction = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
+& $dest completions --help *> $null
+$ErrorActionPreference = $previousErrorAction
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Host "Shell completion is available. To enable it, run:"
+    Write-Host "  Add-Content -Path `$PROFILE -Value 'tt completions powershell | Out-String | Invoke-Expression'"
+    Write-Host "(`$PROFILE may not exist yet; Add-Content creates it.)"
+}
+
 & $dest --version

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,7 @@ if "$INSTALL_DIR/tt" completions --help >/dev/null 2>&1; then
     bash)   echo "  echo 'eval \"\$(tt completions bash)\"' >> ~/.bashrc" ;;
     fish)   echo "  echo 'tt completions fish | source' >> ~/.config/fish/config.fish" ;;
     elvish) echo "  echo 'eval (tt completions elvish | slurp)' >> ~/.config/elvish/rc.elv" ;;
+    nu)     echo "  tt completions nu | save -f (\$nu.user-autoload-dirs.0 | path join tt-completer.nu)" ;;
     *)      echo "  tt completions --help   (see docs/usage.md#tt-completions-shell)" ;;
   esac
 fi

--- a/install.sh
+++ b/install.sh
@@ -72,4 +72,17 @@ case ":$PATH:" in
     ;;
 esac
 
+# Mirrors the per-shell hint table in src/cli.rs (`completions`).
+if "$INSTALL_DIR/tt" completions --help >/dev/null 2>&1; then
+  echo
+  echo "Shell completion is available. To enable it, run:"
+  case "$(basename "${SHELL:-}")" in
+    zsh)    echo "  echo 'eval \"\$(tt completions zsh)\"' >> ~/.zshrc" ;;
+    bash)   echo "  echo 'eval \"\$(tt completions bash)\"' >> ~/.bashrc" ;;
+    fish)   echo "  echo 'tt completions fish | source' >> ~/.config/fish/config.fish" ;;
+    elvish) echo "  echo 'eval (tt completions elvish | slurp)' >> ~/.config/elvish/rc.elv" ;;
+    *)      echo "  tt completions --help   (see docs/usage.md#tt-completions-shell)" ;;
+  esac
+fi
+
 "$INSTALL_DIR/tt" --version || true

--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,7 @@ cargo install --git https://github.com/linus-skold/timetracker-rs
 
 ## Quick start
 
-Shell completion: `eval "$(COMPLETE=zsh tt)"` (or `bash`, `fish`) in your
-shell's rc file — see [docs/usage.md](docs/usage.md#tt-completions-shell).
+Shell completion: `eval "$(tt completions)"` in your shell's rc file — see [docs/usage.md](docs/usage.md#tt-completions-shell).
 
 
 ```sh

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,10 @@ cargo install --git https://github.com/linus-skold/timetracker-rs
 
 ## Quick start
 
+Shell completion: `eval "$(COMPLETE=zsh tt)"` (or `bash`, `fish`) in your
+shell's rc file — see [docs/usage.md](docs/usage.md#tt-completions-shell).
+
+
 ```sh
 tt start Working on login page
 tt stop

--- a/skills/tt-time-logging/README.md
+++ b/skills/tt-time-logging/README.md
@@ -13,6 +13,9 @@ source:
 cargo install --git https://github.com/linus-skold/timetracker-rs
 ```
 
+Shell completion for `tt` is one line in your shell startup file,
+`eval "$(tt completions <shell>)"` — see the readme's Quick start.
+
 ## Enforcing this in Claude Code
 
 `npx skills add` is tool-agnostic — it only copies this directory into place; it

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -148,6 +148,7 @@ pub fn completions(shell: Option<&str>) -> Result<()> {
     let completer = shell
         .map(str::to_string)
         .or(from_env)
+        .or_else(|| cfg!(windows).then(|| "powershell".to_string()))
         .and_then(|n| completions::SHELLS.completer(&n))
         .ok_or_else(|| {
             anyhow::anyhow!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use clap_complete::ArgValueCandidates;
-use clap_complete::aot::Shell;
-use clap_complete::env::Shells;
+use clap::builder::PossibleValuesParser;
 
 use crate::completions;
 
@@ -114,8 +113,9 @@ pub enum Commands {
     },
     /// Print the shell completion hook, for `eval "$(tt completions zsh)"`
     Completions {
-        /// One of bash, elvish, fish, powershell, zsh; detected from $SHELL when omitted
-        shell: Option<Shell>,
+        /// Detected from $SHELL when omitted
+        #[arg(value_parser = PossibleValuesParser::new(completions::SHELLS.names()))]
+        shell: Option<String>,
     },
 }
 
@@ -137,20 +137,24 @@ impl Commands {
 }
 
 /// Print the completion hook for `eval` at shell startup. The hook embeds this
-/// binary's absolute path, so it is regenerated on every startup, never saved.
-pub fn completions(shell: Option<Shell>) -> Result<()> {
-    let shells = Shells::builtins();
-    let shell = shell.or_else(Shell::from_env).ok_or_else(|| {
-        anyhow::anyhow!(
-            "could not detect the shell from $SHELL; pass one of: {}",
-            shells.names().collect::<Vec<_>>().join(", ")
-        )
-    })?;
-    let name = shell.to_possible_value().map(|v| v.get_name().to_string());
-    let completer = name
-        .as_deref()
-        .and_then(|n| shells.completer(n))
-        .ok_or_else(|| anyhow::anyhow!("no dynamic completer for {shell}"))?;
+/// binary's absolute path, so it is regenerated on every startup, never saved;
+/// nu is the exception (see `completions::Nu`).
+pub fn completions(shell: Option<&str>) -> Result<()> {
+    let from_env = std::env::var_os("SHELL").and_then(|s| {
+        std::path::Path::new(&s)
+            .file_stem()
+            .map(|n| n.to_string_lossy().into_owned())
+    });
+    let completer = shell
+        .map(str::to_string)
+        .or(from_env)
+        .and_then(|n| completions::SHELLS.completer(&n))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not detect the shell from $SHELL; pass one of: {}",
+                completions::SHELLS.names().collect::<Vec<_>>().join(", ")
+            )
+        })?;
     let exe = std::env::current_exe()?;
     completer.write_registration(
         "COMPLETE",
@@ -168,9 +172,10 @@ pub fn completions(shell: Option<Shell>) -> Result<()> {
                 "tt completions powershell | Out-String | Invoke-Expression   # $PROFILE".to_string()
             }
             "elvish" => "eval (tt completions elvish | slurp)   # ~/.config/elvish/rc.elv".to_string(),
+            "nu" => "tt completions nu | save -f ($nu.user-autoload-dirs.0 | path join tt-completer.nu)   # run once".to_string(),
             _ => format!("eval \"$(tt completions {name})\"   # ~/.{name}rc"),
         };
-        eprintln!("\nTo enable completion, add this line to your shell startup file:\n  {line}");
+        eprintln!("\nTo enable completion, run this once or add it to your shell startup file:\n  {line}");
     }
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::aot::{self, Shell};
 
 use crate::config;
 use crate::duration;
@@ -107,6 +108,11 @@ pub enum Commands {
         #[arg(short = 'y', long)]
         yes: bool,
     },
+    /// Print a shell completion script to stdout
+    Completions {
+        /// Shell to generate for; detected from the environment when omitted
+        shell: Option<Shell>,
+    },
 }
 
 impl Commands {
@@ -118,9 +124,18 @@ impl Commands {
     pub fn wants_update_check(&self) -> bool {
         !matches!(
             self,
-            Commands::Update { .. } | Commands::Active | Commands::Agent { .. }
+            Commands::Update { .. }
+                | Commands::Active
+                | Commands::Agent { .. }
+                | Commands::Completions { .. }
         )
     }
+}
+
+pub fn completions(shell: Option<Shell>) -> Result<()> {
+    let shell = shell.or_else(Shell::from_env).unwrap_or(Shell::Bash);
+    aot::generate(shell, &mut Cli::command(), "tt", &mut std::io::stdout());
+    Ok(())
 }
 
 /// The agent layer's commands. Most touch mark files only; the ones that log an

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
 use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::ArgValueCandidates;
 use clap_complete::aot::{self, Shell};
+
+use crate::completions;
 
 use crate::config;
 use crate::duration;
@@ -25,7 +28,7 @@ pub enum Commands {
         #[arg(required = true)]
         description: Vec<String>,
         /// Project this entry belongs to
-        #[arg(long)]
+        #[arg(long, add = ArgValueCandidates::new(completions::projects))]
         project: Option<String>,
     },
     /// Stop the current active task
@@ -42,7 +45,7 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
         /// Project this entry belongs to
-        #[arg(long)]
+        #[arg(long, add = ArgValueCandidates::new(completions::projects))]
         project: Option<String>,
         /// A silent stretch inside the logged span, as epoch seconds
         /// `<start>-<end>`. Repeatable; records the interval without changing the
@@ -88,7 +91,7 @@ pub enum Commands {
         #[arg(long, requires = "scope")]
         until: Option<NaiveDate>,
         /// Only entries whose project field is this
-        #[arg(long)]
+        #[arg(long, add = ArgValueCandidates::new(completions::projects))]
         project: Option<String>,
         /// Machine-readable output
         #[arg(long)]
@@ -144,23 +147,32 @@ pub fn completions(shell: Option<Shell>) -> Result<()> {
 pub enum AgentCommands {
     /// Open a mark for a phase, keeping the start of one already open
     Begin {
+        #[arg(add = ArgValueCandidates::new(completions::projects))]
         project: String,
         /// Issue number, or `-` for a phase with no issue
+        #[arg(add = ArgValueCandidates::new(completions::issues))]
         issue: String,
+        #[arg(add = ArgValueCandidates::new(completions::phases))]
         phase: String,
     },
     /// Record one heartbeat for an open phase
     Touch {
+        #[arg(add = ArgValueCandidates::new(completions::projects))]
         project: String,
         /// Issue number, or `-` for a phase with no issue
+        #[arg(add = ArgValueCandidates::new(completions::issues))]
         issue: String,
+        #[arg(add = ArgValueCandidates::new(completions::phases))]
         phase: String,
     },
     /// Drop a phase's mark and heartbeats without logging anything
     Cancel {
+        #[arg(add = ArgValueCandidates::new(completions::projects))]
         project: String,
         /// Issue number, or `-` for a phase with no issue
+        #[arg(add = ArgValueCandidates::new(completions::issues))]
         issue: String,
+        #[arg(add = ArgValueCandidates::new(completions::phases))]
         phase: String,
     },
     /// List every open mark
@@ -171,9 +183,12 @@ pub enum AgentCommands {
     /// `begin`/`touch`/`end` whenever the work can be marked as it happens,
     /// so the logged span is measured, not guessed.
     Item {
+        #[arg(add = ArgValueCandidates::new(completions::projects))]
         project: String,
         /// Issue number, or `-` for a phase with no issue
+        #[arg(add = ArgValueCandidates::new(completions::issues))]
         issue: String,
+        #[arg(add = ArgValueCandidates::new(completions::phases))]
         phase: String,
         /// 3-6 words of plain prose, with no issue number in them
         summary: Option<String>,
@@ -182,9 +197,12 @@ pub enum AgentCommands {
     },
     /// Close a marked phase, measuring it to its last heartbeat
     End {
+        #[arg(add = ArgValueCandidates::new(completions::projects))]
         project: String,
         /// Issue number, or `-` for a phase with no issue
+        #[arg(add = ArgValueCandidates::new(completions::issues))]
         issue: String,
+        #[arg(add = ArgValueCandidates::new(completions::phases))]
         phase: String,
         /// 3-6 words of plain prose, with no issue number in them
         summary: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,6 +161,7 @@ pub fn completions(shell: Option<Shell>) -> Result<()> {
     )?;
     if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
         let name = completer.name();
+        // install.sh and install.ps1 print copies of this table.
         let line = match name {
             "fish" => "tt completions fish | source   # ~/.config/fish/config.fish".to_string(),
             "powershell" => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,18 @@ pub fn completions(shell: Option<Shell>) -> Result<()> {
         &exe.to_string_lossy(),
         &mut std::io::stdout(),
     )?;
+    if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+        let name = completer.name();
+        let line = match name {
+            "fish" => "tt completions fish | source   # ~/.config/fish/config.fish".to_string(),
+            "powershell" => {
+                "tt completions powershell | Out-String | Invoke-Expression   # $PROFILE".to_string()
+            }
+            "elvish" => "eval (tt completions elvish | slurp)   # ~/.config/elvish/rc.elv".to_string(),
+            _ => format!("eval \"$(tt completions {name})\"   # ~/.{name}rc"),
+        };
+        eprintln!("\nTo enable completion, add this line to your shell startup file:\n  {line}");
+    }
     Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
-use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::ArgValueCandidates;
-use clap_complete::aot::{self, Shell};
+use clap_complete::aot::Shell;
+use clap_complete::env::Shells;
 
 use crate::completions;
 
@@ -111,9 +112,9 @@ pub enum Commands {
         #[arg(short = 'y', long)]
         yes: bool,
     },
-    /// Print a shell completion script to stdout
+    /// Print the shell completion hook, for `eval "$(tt completions zsh)"`
     Completions {
-        /// Shell to generate for; detected from the environment when omitted
+        /// One of bash, elvish, fish, powershell, zsh; detected from $SHELL when omitted
         shell: Option<Shell>,
     },
 }
@@ -135,18 +136,29 @@ impl Commands {
     }
 }
 
+/// Print the completion hook for `eval` at shell startup. The hook embeds this
+/// binary's absolute path, so it is regenerated on every startup, never saved.
 pub fn completions(shell: Option<Shell>) -> Result<()> {
+    let shells = Shells::builtins();
     let shell = shell.or_else(Shell::from_env).ok_or_else(|| {
-        let names: Vec<String> = Shell::value_variants()
-            .iter()
-            .filter_map(|s| Some(s.to_possible_value()?.get_name().to_string()))
-            .collect();
         anyhow::anyhow!(
             "could not detect the shell from $SHELL; pass one of: {}",
-            names.join(", ")
+            shells.names().collect::<Vec<_>>().join(", ")
         )
     })?;
-    aot::generate(shell, &mut Cli::command(), "tt", &mut std::io::stdout());
+    let name = shell.to_possible_value().map(|v| v.get_name().to_string());
+    let completer = name
+        .as_deref()
+        .and_then(|n| shells.completer(n))
+        .ok_or_else(|| anyhow::anyhow!("no dynamic completer for {shell}"))?;
+    let exe = std::env::current_exe()?;
+    completer.write_registration(
+        "COMPLETE",
+        "tt",
+        "tt",
+        &exe.to_string_lossy(),
+        &mut std::io::stdout(),
+    )?;
     Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::ArgValueCandidates;
 use clap_complete::aot::{self, Shell};
 
@@ -136,7 +136,16 @@ impl Commands {
 }
 
 pub fn completions(shell: Option<Shell>) -> Result<()> {
-    let shell = shell.or_else(Shell::from_env).unwrap_or(Shell::Bash);
+    let shell = shell.or_else(Shell::from_env).ok_or_else(|| {
+        let names: Vec<String> = Shell::value_variants()
+            .iter()
+            .filter_map(|s| Some(s.to_possible_value()?.get_name().to_string()))
+            .collect();
+        anyhow::anyhow!(
+            "could not detect the shell from $SHELL; pass one of: {}",
+            names.join(", ")
+        )
+    })?;
     aot::generate(shell, &mut Cli::command(), "tt", &mut std::io::stdout());
     Ok(())
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -4,26 +4,34 @@
 
 use std::collections::BTreeSet;
 
+use clap::CommandFactory;
 use clap_complete::CompletionCandidate;
 
 use crate::agent::PHASES;
+use crate::cli::Cli;
 use crate::marks::{Mark, open_marks};
 use crate::report::classify;
 use crate::storage::load_data;
-use crate::tracker::TimeData;
+use crate::tracker::{self, TimeData};
 
 /// Every project named by a store entry or an open mark.
 pub fn projects() -> Vec<CompletionCandidate> {
-    let data = load_data().unwrap_or_default();
-    to_candidates(project_names(&data, &open_marks()))
+    to_candidates(project_names(&store(), &open_marks()))
 }
 
 /// Issues known for the project typed earlier on the line, or every issue when
 /// no project can be read off it. Always includes the no-issue sentinel `-`.
 pub fn issues() -> Vec<CompletionCandidate> {
-    let data = load_data().unwrap_or_default();
-    let project = typed_project(std::env::args());
-    to_candidates(issue_names(&data, &open_marks(), project.as_deref()))
+    let args = std::env::args_os().map(|a| a.to_string_lossy().into_owned());
+    let project = typed_project(args);
+    to_candidates(issue_names(&store(), &open_marks(), project.as_deref()))
+}
+
+/// The store as `tt report` sees it: migrated in memory, never written back.
+fn store() -> TimeData {
+    let mut data = load_data().unwrap_or_default();
+    tracker::migrate(&mut data);
+    data
 }
 
 pub fn phases() -> Vec<CompletionCandidate> {
@@ -61,12 +69,16 @@ fn issue_names(data: &TimeData, marks: &[Mark], project: Option<&str>) -> BTreeS
 }
 
 /// The project positional already typed on an `agent` command line, read from
-/// the completer's own argv: `<bin> -- tt agent <sub> <project> ...`. `None`
-/// whenever that shape is not found, so the caller falls back to every issue.
+/// the completer's own argv: `<bin> -- tt agent <sub> [flags] <project> ...`.
+/// `None` whenever that shape is not found, so the caller falls back to every issue.
 fn typed_project<I: Iterator<Item = String>>(args: I) -> Option<String> {
     let words: Vec<String> = args.skip_while(|a| a != "--").skip(1).collect();
-    let agent = words.iter().position(|w| w == "agent")?;
-    let project = words.get(agent + 2)?;
+    let matches = Cli::command()
+        .ignore_errors(true)
+        .try_get_matches_from(words)
+        .ok()?;
+    let (_, sub) = matches.subcommand()?.1.subcommand()?;
+    let project = sub.get_one::<String>("project")?;
     (!project.is_empty()).then(|| project.clone())
 }
 
@@ -153,6 +165,12 @@ mod tests {
     #[test]
     fn typed_project_reads_the_agent_positional() {
         let a = argv(&["/bin/tt", "--", "tt", "agent", "begin", "proj", ""]);
+        assert_eq!(typed_project(a), Some("proj".to_string()));
+    }
+
+    #[test]
+    fn typed_project_skips_flags_before_the_positionals() {
+        let a = argv(&["/bin/tt", "--", "tt", "agent", "end", "--full", "proj", ""]);
         assert_eq!(typed_project(a), Some("proj".to_string()));
     }
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -3,9 +3,11 @@
 //! and on any failure return nothing rather than an error.
 
 use std::collections::BTreeSet;
+use std::ffi::OsString;
 
 use clap::CommandFactory;
 use clap_complete::CompletionCandidate;
+use clap_complete::env::{Bash, Elvish, EnvCompleter, Fish, Powershell, Shells, Zsh};
 
 use crate::agent::PHASES;
 use crate::cli::Cli;
@@ -13,6 +15,72 @@ use crate::marks::{Mark, open_marks};
 use crate::report::classify;
 use crate::storage::load_data;
 use crate::tracker::{self, TimeData};
+
+/// Every supported shell; the single definition behind `CompleteEnv`, the
+/// `completions` argument and its error message.
+pub const SHELLS: Shells<'static> = Shells(&[&Bash, &Elvish, &Fish, &Nu, &Powershell, &Zsh]);
+
+/// Nushell. The registration script is saved to disk, not evaluated, so it
+/// invokes `tt` by PATH name rather than by absolute path.
+pub struct Nu;
+
+impl EnvCompleter for Nu {
+    fn name(&self) -> &'static str {
+        "nu"
+    }
+
+    fn is(&self, name: &str) -> bool {
+        name == "nu" || name == "nushell"
+    }
+
+    fn write_registration(
+        &self,
+        var: &str,
+        name: &str,
+        bin: &str,
+        _completer: &str,
+        buf: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        writeln!(
+            buf,
+            r##"def {name}-completer [spans: list<string>]: nothing -> list {{
+    with-env {{{var}: "nu"}} {{ ^r#'{bin}'# -- ...$spans }} | from json
+}}
+
+@complete {name}-completer
+def --wrapped {bin} [...args] {{ ^r#'{bin}'# ...$args }}"##
+        )
+    }
+
+    fn write_complete(
+        &self,
+        cmd: &mut clap::Command,
+        mut args: Vec<OsString>,
+        current_dir: Option<&std::path::Path>,
+        buf: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        // nu hands over `" "` for an empty word after a space.
+        if let Some(last) = args.last_mut()
+            && last.to_string_lossy().trim().is_empty()
+        {
+            *last = OsString::new();
+        }
+        let index = args.len().saturating_sub(1);
+        let candidates = clap_complete::engine::complete(cmd, args, index, current_dir)?;
+        let json: Vec<serde_json::Value> = candidates.iter().map(candidate_json).collect();
+        writeln!(buf, "{}", serde_json::Value::Array(json))
+    }
+}
+
+fn candidate_json(c: &CompletionCandidate) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("value".into(), c.get_value().to_string_lossy().into());
+    if let Some(help) = c.get_help() {
+        let first = help.to_string().lines().next().unwrap_or_default().to_string();
+        obj.insert("description".into(), first.into());
+    }
+    serde_json::Value::Object(obj)
+}
 
 /// Every project named by a store entry or an open mark.
 pub fn projects() -> Vec<CompletionCandidate> {
@@ -123,6 +191,41 @@ mod tests {
             .map(|w| w.to_string())
             .collect::<Vec<_>>()
             .into_iter()
+    }
+
+    fn nu_complete(words: &[&str]) -> Vec<serde_json::Value> {
+        let args = words.iter().map(OsString::from).collect();
+        let mut buf = Vec::new();
+        Nu.write_complete(&mut Cli::command(), args, None, &mut buf).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    #[test]
+    fn nu_registration_calls_tt_by_name_and_attaches_the_completer() {
+        let mut buf = Vec::new();
+        Nu.write_registration("COMPLETE", "tt", "tt", "/abs/path/tt", &mut buf).unwrap();
+        let script = String::from_utf8(buf).unwrap();
+        assert!(script.contains("@complete tt-completer"));
+        assert!(script.contains("def tt-completer [spans: list<string>]"));
+        assert!(script.contains("with-env {COMPLETE: \"nu\"}"));
+        assert!(script.contains("def --wrapped tt [...args]"));
+        assert!(!script.contains("/abs/path"), "{script}");
+    }
+
+    #[test]
+    fn nu_candidates_are_json_records_with_optional_descriptions() {
+        let got = nu_complete(&["tt", "agent", "begin", "proj", "-", "im"]);
+        assert_eq!(got, [serde_json::json!({"value": "impl"})]);
+        let subs = nu_complete(&["tt", "compl"]);
+        assert_eq!(subs[0]["value"], "completions");
+        assert!(subs[0]["description"].as_str().unwrap().starts_with("Print the shell completion hook"));
+    }
+
+    #[test]
+    fn nu_whitespace_span_completes_like_an_empty_one() {
+        assert_eq!(nu_complete(&["tt", "agent", "begin", "p", "-", " "]), nu_complete(&["tt", "agent", "begin", "p", "-", ""]));
+        let values: Vec<_> = nu_complete(&["tt", "agent", "begin", "p", "-", ""]).into_iter().filter(|v| !v["value"].as_str().unwrap().starts_with("--")).collect();
+        assert_eq!(values.len(), PHASES.len());
     }
 
     #[test]

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,167 @@
+//! Candidate providers for dynamic shell completion. Every provider runs on each
+//! Tab press: read through the lock-free `storage::load_data`, never `with_data`,
+//! and on any failure return nothing rather than an error.
+
+use std::collections::BTreeSet;
+
+use clap_complete::CompletionCandidate;
+
+use crate::agent::PHASES;
+use crate::marks::{Mark, open_marks};
+use crate::report::classify;
+use crate::storage::load_data;
+use crate::tracker::TimeData;
+
+/// Every project named by a store entry or an open mark.
+pub fn projects() -> Vec<CompletionCandidate> {
+    let data = load_data().unwrap_or_default();
+    to_candidates(project_names(&data, &open_marks()))
+}
+
+/// Issues known for the project typed earlier on the line, or every issue when
+/// no project can be read off it. Always includes the no-issue sentinel `-`.
+pub fn issues() -> Vec<CompletionCandidate> {
+    let data = load_data().unwrap_or_default();
+    let project = typed_project(std::env::args());
+    to_candidates(issue_names(&data, &open_marks(), project.as_deref()))
+}
+
+pub fn phases() -> Vec<CompletionCandidate> {
+    PHASES.iter().map(CompletionCandidate::new).collect()
+}
+
+fn to_candidates(names: BTreeSet<String>) -> Vec<CompletionCandidate> {
+    names.into_iter().map(CompletionCandidate::new).collect()
+}
+
+fn project_names(data: &TimeData, marks: &[Mark]) -> BTreeSet<String> {
+    data.entries
+        .iter()
+        .filter_map(|e| e.project.clone())
+        .chain(marks.iter().map(|m| m.project.clone()))
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+fn issue_names(data: &TimeData, marks: &[Mark], project: Option<&str>) -> BTreeSet<String> {
+    let wanted = |p: &str| project.is_none_or(|w| w == p);
+    let from_entries = data.entries.iter().filter_map(|e| {
+        let (item, _) = classify(&e.tags);
+        let (p, issue) = item?.split_once('/')?;
+        (wanted(p) && !issue.is_empty()).then(|| issue.to_string())
+    });
+    let from_marks = marks
+        .iter()
+        .filter(|m| wanted(&m.project))
+        .filter_map(|m| m.issue.clone());
+    from_entries
+        .chain(from_marks)
+        .chain(std::iter::once("-".to_string()))
+        .collect()
+}
+
+/// The project positional already typed on an `agent` command line, read from
+/// the completer's own argv: `<bin> -- tt agent <sub> <project> ...`. `None`
+/// whenever that shape is not found, so the caller falls back to every issue.
+fn typed_project<I: Iterator<Item = String>>(args: I) -> Option<String> {
+    let words: Vec<String> = args.skip_while(|a| a != "--").skip(1).collect();
+    let agent = words.iter().position(|w| w == "agent")?;
+    let project = words.get(agent + 2)?;
+    (!project.is_empty()).then(|| project.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracker::TimeEntry;
+    use chrono::Local;
+
+    fn entry(project: Option<&str>, tags: &[&str]) -> TimeEntry {
+        TimeEntry {
+            id: 0,
+            description: String::new(),
+            project: project.map(String::from),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            start_time: Local::now(),
+            end_time: None,
+            idle: Vec::new(),
+        }
+    }
+
+    fn mark(project: &str, issue: Option<&str>) -> Mark {
+        Mark {
+            project: project.to_string(),
+            issue: issue.map(String::from),
+            phase: "impl".to_string(),
+            start: Local::now(),
+        }
+    }
+
+    fn data(entries: Vec<TimeEntry>) -> TimeData {
+        TimeData {
+            entries,
+            next_id: 1,
+            schema_version: 1,
+        }
+    }
+
+    fn argv(words: &[&str]) -> impl Iterator<Item = String> {
+        words
+            .iter()
+            .map(|w| w.to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    #[test]
+    fn projects_union_store_and_marks_deduplicated_and_sorted() {
+        let d = data(vec![
+            entry(Some("zeta"), &[]),
+            entry(Some("alpha"), &[]),
+            entry(None, &[]),
+            entry(Some(""), &[]),
+        ]);
+        let names = project_names(&d, &[mark("alpha", None), mark("mid", None)]);
+        assert_eq!(names.into_iter().collect::<Vec<_>>(), ["alpha", "mid", "zeta"]);
+    }
+
+    #[test]
+    fn issues_scoped_to_project_with_sentinel() {
+        let d = data(vec![
+            entry(Some("a"), &["a/10", "impl"]),
+            entry(Some("b"), &["b/20"]),
+            entry(Some("a"), &["a/"]),
+        ]);
+        let marks = [mark("a", Some("11")), mark("b", Some("21")), mark("a", None)];
+        let scoped = issue_names(&d, &marks, Some("a"));
+        assert_eq!(scoped.into_iter().collect::<Vec<_>>(), ["-", "10", "11"]);
+    }
+
+    #[test]
+    fn issues_unfiltered_without_project() {
+        let d = data(vec![entry(Some("a"), &["a/10"]), entry(Some("b"), &["b/20"])]);
+        let all = issue_names(&d, &[mark("b", Some("21"))], None);
+        assert_eq!(all.into_iter().collect::<Vec<_>>(), ["-", "10", "20", "21"]);
+    }
+
+    #[test]
+    fn phases_are_the_canonical_list() {
+        let got: Vec<String> = phases().iter().map(|c| c.get_value().to_string_lossy().into_owned()).collect();
+        assert_eq!(got, PHASES);
+    }
+
+    #[test]
+    fn typed_project_reads_the_agent_positional() {
+        let a = argv(&["/bin/tt", "--", "tt", "agent", "begin", "proj", ""]);
+        assert_eq!(typed_project(a), Some("proj".to_string()));
+    }
+
+    #[test]
+    fn typed_project_is_none_on_odd_shapes() {
+        assert_eq!(typed_project(argv(&["/bin/tt"])), None);
+        assert_eq!(typed_project(argv(&["/bin/tt", "tt", "agent", "begin", "proj"])), None);
+        assert_eq!(typed_project(argv(&["/bin/tt", "--", "tt", "agent", "begin"])), None);
+        assert_eq!(typed_project(argv(&["/bin/tt", "--", "tt", "agent", "begin", ""])), None);
+        assert_eq!(typed_project(argv(&["/bin/tt", "--", "tt", "start", "--project", ""])), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod activity;
 mod agent;
 mod audit;
 mod cli;
+mod completions;
 mod config;
 mod duration;
 mod icons;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ use clap::{CommandFactory, Parser};
 fn main() -> Result<()> {
     // Exits the process on a completion request, so nothing below — including
     // the store-lock migration — runs on a Tab press.
-    clap_complete::CompleteEnv::with_factory(Cli::command).complete();
+    clap_complete::CompleteEnv::with_factory(Cli::command)
+        .shells(completions::SHELLS)
+        .complete();
     let cli = Cli::parse();
 
     // At most once per day, bounded to a couple of seconds — see
@@ -55,7 +57,7 @@ fn main() -> Result<()> {
             return cli::update(*check, *yes);
         }
         Commands::Completions { shell } => {
-            return cli::completions(*shell);
+            return cli::completions(shell.as_deref());
         }
         _ => {}
     }
@@ -108,6 +110,6 @@ fn main() -> Result<()> {
         // Dispatched ahead of the preamble above; unreachable in practice,
         // kept for exhaustiveness (same shape as `Report` just above it).
         Commands::Update { check, yes } => cli::update(check, yes),
-        Commands::Completions { shell } => cli::completions(shell),
+        Commands::Completions { shell } => cli::completions(shell.as_deref()),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,12 @@ mod tui;
 mod update;
 
 use cli::{Cli, Commands};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 fn main() -> Result<()> {
+    // Exits the process on a completion request, so nothing below — including
+    // the store-lock migration — runs on a Tab press.
+    clap_complete::CompleteEnv::with_factory(Cli::command).complete();
     let cli = Cli::parse();
 
     // At most once per day, bounded to a couple of seconds — see
@@ -49,6 +52,9 @@ fn main() -> Result<()> {
         }
         Commands::Update { check, yes } => {
             return cli::update(*check, *yes);
+        }
+        Commands::Completions { shell } => {
+            return cli::completions(*shell);
         }
         _ => {}
     }
@@ -101,5 +107,6 @@ fn main() -> Result<()> {
         // Dispatched ahead of the preamble above; unreachable in practice,
         // kept for exhaustiveness (same shape as `Report` just above it).
         Commands::Update { check, yes } => cli::update(check, yes),
+        Commands::Completions { shell } => cli::completions(shell),
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -168,6 +168,11 @@ impl Case {
         self.run_with(args, true)
     }
 
+    /// [`Case::run_bare`] with extra `KEY=value` pairs that `env_clear` would strip.
+    pub fn run_bare_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Run {
+        self.run_full(args, true, env)
+    }
+
     /// Lay a `data.json` into the sandbox from fabricated rows, at `schema_version:
     /// 1` so the migrate preamble early-returns and the `project` fields survive.
     pub fn write_store(&self, rows: &[StoreRow]) {

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -5,7 +5,7 @@ mod common;
 use common::{Case, StoreRow, now};
 use std::fs;
 
-const SHELLS: [&str; 5] = ["bash", "elvish", "fish", "powershell", "zsh"];
+const SHELLS: [&str; 6] = ["bash", "elvish", "fish", "nu", "powershell", "zsh"];
 
 fn row(project: &'static str, tags: &'static [&'static str]) -> StoreRow {
     let start = now() - 3600;
@@ -50,6 +50,40 @@ fn complete(case: &Case, index: usize, words: &[&str]) -> Vec<String> {
         .filter(|l| !l.is_empty() && !l.starts_with("--"))
         .map(str::to_string)
         .collect()
+}
+
+/// Drive the completer as the generated nu `tt-completer` does: `COMPLETE=nu
+/// tt -- tt <spans…>`, the cursor implied by the last span, JSON records back.
+fn complete_nu(case: &Case, words: &[&str]) -> Vec<String> {
+    let mut args = vec!["--", "tt"];
+    args.extend_from_slice(words);
+    let run = case.run_bare_with_env(&args, &[("COMPLETE", "nu")]);
+    run.assert_status(0);
+    let records: Vec<serde_json::Value> = serde_json::from_str(&run.stdout).unwrap();
+    records
+        .iter()
+        .map(|r| r["value"].as_str().unwrap().to_string())
+        .filter(|v| !v.starts_with("--"))
+        .collect()
+}
+
+#[test]
+fn nu_returns_the_same_candidates_as_bash() {
+    let case = seeded("completions-nu-parity");
+    let sub = complete_nu(&case, &[""]);
+    for name in ["start", "stop", "log", "report", "agent", "completions"] {
+        assert!(sub.contains(&name.to_string()), "missing {name} in {sub:?}");
+    }
+    assert_eq!(complete_nu(&case, &["start", "--project", ""]), complete(&case, 3, &["start", "--project", ""]));
+    assert_eq!(complete_nu(&case, &["agent", "begin", "alpha", ""]), complete(&case, 4, &["agent", "begin", "alpha", ""]));
+    assert_eq!(complete_nu(&case, &["agent", "begin", ""]), complete(&case, 3, &["agent", "begin", ""]));
+    assert_eq!(complete_nu(&case, &["agent", "begin", "alpha", "-", ""]), complete(&case, 5, &["agent", "begin", "alpha", "-", ""]));
+}
+
+#[test]
+fn nu_whitespace_span_completes_like_an_empty_span() {
+    let case = seeded("completions-nu-space");
+    assert_eq!(complete_nu(&case, &["start", "--project", " "]), ["alpha", "beta", "gamma"]);
 }
 
 #[test]
@@ -103,6 +137,7 @@ fn a_completion_run_leaves_the_store_and_its_lock_untouched() {
 
     complete(&case, 3, &["start", "--project", ""]);
     complete(&case, 4, &["agent", "begin", "alpha", ""]);
+    complete_nu(&case, &["agent", "begin", "alpha", ""]);
 
     assert_eq!(fs::metadata(&store).unwrap().modified().unwrap(), before);
     assert_eq!(fs::read_to_string(&store).unwrap(), body_before);
@@ -125,9 +160,9 @@ fn the_completions_subcommand_prints_the_same_hook_as_the_env_protocol() {
 #[test]
 fn an_unknown_shell_is_an_error_naming_the_choices() {
     let case = Case::new("completions-unknown-shell");
-    let run = case.run_bare_with_env(&["completions"], &[("SHELL", "/bin/nu")]);
+    let run = case.run_bare_with_env(&["completions"], &[("SHELL", "/bin/tcsh")]);
     assert_ne!(run.status, Some(0));
-    assert!(run.stderr.contains("bash, elvish, fish, powershell, zsh"), "{}", run.stderr);
+    assert!(run.stderr.contains("bash, elvish, fish, nu, powershell, zsh"), "{}", run.stderr);
 }
 
 #[test]

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -110,17 +110,24 @@ fn a_completion_run_leaves_the_store_and_its_lock_untouched() {
 }
 
 #[test]
-fn static_scripts_are_generated_for_every_shell() {
-    let case = Case::new("completions-static");
+fn the_completions_subcommand_prints_the_same_hook_as_the_env_protocol() {
+    let case = Case::new("completions-subcommand-hook");
     for shell in SHELLS {
-        let run = case.run_bare(&["completions", shell]);
-        run.assert_status(0);
-        assert!(
-            run.stdout.contains("tt") && run.stdout.len() > 500,
-            "{shell} script looks wrong: {} bytes",
-            run.stdout.len()
-        );
+        let sub = case.run_bare(&["completions", shell]);
+        sub.assert_status(0);
+        let env = case.run_bare_with_env(&[], &[("COMPLETE", shell)]);
+        env.assert_status(0);
+        assert!(sub.stdout.contains("COMPLETE"), "{shell}: no COMPLETE in hook");
+        assert_eq!(sub.stdout, env.stdout, "{shell}: the two surfaces diverge");
     }
+}
+
+#[test]
+fn an_unknown_shell_is_an_error_naming_the_choices() {
+    let case = Case::new("completions-unknown-shell");
+    let run = case.run_bare_with_env(&["completions"], &[("SHELL", "/bin/nu")]);
+    assert_ne!(run.status, Some(0));
+    assert!(run.stderr.contains("bash, elvish, fish, powershell, zsh"), "{}", run.stderr);
 }
 
 #[test]

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -1,0 +1,134 @@
+//! Shell completion through the real binary: the dynamic candidate protocol and
+//! the static `tt completions <shell>` scripts, against a sandboxed store.
+
+mod common;
+use common::{Case, StoreRow, now};
+use std::fs;
+
+const SHELLS: [&str; 5] = ["bash", "elvish", "fish", "powershell", "zsh"];
+
+fn row(project: &'static str, tags: &'static [&'static str]) -> StoreRow {
+    let start = now() - 3600;
+    StoreRow {
+        description: "work",
+        project: Some(project),
+        tags,
+        start,
+        end: Some(start + 600),
+    }
+}
+
+fn seeded(name: &str) -> Case {
+    let case = Case::new(name);
+    case.write_store(&[
+        row("alpha", &["alpha/10", "impl", "agent"]),
+        row("beta", &["beta/20", "impl", "agent"]),
+        row("alpha", &["alpha/11", "qa", "agent"]),
+    ]);
+    case.write_mark("gamma.30.impl", now() - 60);
+    case
+}
+
+/// Drive the completer as the shell hook does: `tt -- tt <words…>` with the
+/// cursor at `index`, returning one candidate per line.
+fn complete(case: &Case, index: usize, words: &[&str]) -> Vec<String> {
+    let mut args = vec!["--", "tt"];
+    args.extend_from_slice(words);
+    let index = index.to_string();
+    let run = case.run_bare_with_env(
+        &args,
+        &[
+            ("COMPLETE", "bash"),
+            ("_CLAP_COMPLETE_INDEX", &index),
+            ("_CLAP_COMPLETE_COMP_TYPE", "9"),
+            ("_CLAP_IFS", "\n"),
+        ],
+    );
+    run.assert_status(0);
+    run.stdout
+        .lines()
+        .filter(|l| !l.is_empty() && !l.starts_with("--"))
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn subcommand_names_complete_at_the_first_word() {
+    let case = Case::new("completions-subcommands");
+    let got = complete(&case, 1, &[""]);
+    for name in ["start", "stop", "log", "report", "agent", "completions"] {
+        assert!(got.contains(&name.to_string()), "missing {name} in {got:?}");
+    }
+}
+
+#[test]
+fn project_flag_completes_from_store_and_open_marks() {
+    let case = seeded("completions-projects");
+    assert_eq!(
+        complete(&case, 3, &["start", "--project", ""]),
+        ["alpha", "beta", "gamma"]
+    );
+}
+
+#[test]
+fn issue_positional_is_scoped_to_the_typed_project() {
+    let case = seeded("completions-issues-scoped");
+    assert_eq!(complete(&case, 4, &["agent", "begin", "alpha", ""]), ["-", "10", "11"]);
+    assert_eq!(complete(&case, 4, &["agent", "begin", "gamma", ""]), ["-", "30"]);
+}
+
+#[test]
+fn issue_positional_falls_back_to_every_issue_without_a_project() {
+    let case = seeded("completions-issues-unscoped");
+    let got = complete(&case, 4, &["agent", "begin", "", ""]);
+    assert_eq!(got, ["-", "10", "11", "20", "30"]);
+}
+
+#[test]
+fn phase_positional_completes_the_fixed_vocabulary() {
+    let case = seeded("completions-phases");
+    assert_eq!(
+        complete(&case, 5, &["agent", "begin", "alpha", "10", ""]),
+        ["plan", "impl", "qa", "review", "docs", "spike", "explore", "ops"]
+    );
+}
+
+#[test]
+fn a_completion_run_leaves_the_store_and_its_lock_untouched() {
+    let case = seeded("completions-no-store-write");
+    let store = case.data_dir().join("data.json");
+    let lock = case.data_dir().join("data.lock");
+    let before = fs::metadata(&store).unwrap().modified().unwrap();
+    let body_before = fs::read_to_string(&store).unwrap();
+
+    complete(&case, 3, &["start", "--project", ""]);
+    complete(&case, 4, &["agent", "begin", "alpha", ""]);
+
+    assert_eq!(fs::metadata(&store).unwrap().modified().unwrap(), before);
+    assert_eq!(fs::read_to_string(&store).unwrap(), body_before);
+    assert!(!lock.exists(), "a completion run must not create the store lock");
+}
+
+#[test]
+fn static_scripts_are_generated_for_every_shell() {
+    let case = Case::new("completions-static");
+    for shell in SHELLS {
+        let run = case.run_bare(&["completions", shell]);
+        run.assert_status(0);
+        assert!(
+            run.stdout.contains("tt") && run.stdout.len() > 500,
+            "{shell} script looks wrong: {} bytes",
+            run.stdout.len()
+        );
+    }
+}
+
+#[test]
+fn the_dynamic_hook_registers_for_every_shell() {
+    let case = Case::new("completions-hook");
+    for shell in SHELLS {
+        let run = case.run_bare_with_env(&[], &[("COMPLETE", shell)]);
+        run.assert_status(0);
+        assert!(run.stdout.contains("tt"), "{shell} hook does not name tt");
+    }
+}


### PR DESCRIPTION
> Stacked on #47 (completions); the diff includes those commits until #47 merges.

Adds dynamic nushell completions and retypes `tt completions` off a shared shell table.

- Adds a local `Nu` `EnvCompleter` emitting JSON candidates for nu >= 0.108 `@complete` (no new dependencies).
- Retypes the `tt completions` shell argument off a shared `SHELLS` table, with `$SHELL`-based detection (powershell stays the default on Windows).
- Adds nu install hints to the CLI, `install.sh` and the docs.
- Covers the nu completion protocol end-to-end in tests.

The generated nu script is saved once into `$nu.user-autoload-dirs` and invokes `tt` by PATH name.

Verified interactively in nushell 0.115.1: completions resolve for subcommands, `--project` and agent positionals; `tt tui` and `tt report` pass through the wrapper.

Stacked on #126 (`111-completions-wiring`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

