### PR TITLE
feat(completions): dynamic nushell completions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,8 +147,8 @@ If you installed the Flatpak build, update with `flatpak update` instead —
 
 ### `tt completions [shell]`
 
-Print the shell completion hook for `bash`, `zsh`, `fish`, `powershell` or
-`elvish`. With no argument the shell is detected from `$SHELL`; pass one to
+Print the shell completion hook for `bash`, `zsh`, `fish`, `powershell`,
+`elvish` or `nu`. With no argument the shell is detected from `$SHELL`; pass one to
 override. The installers print this suggestion for your shell after
 installing. Evaluate it at shell startup:
 
@@ -166,8 +166,18 @@ Evaluate the hook at startup rather than saving its output: it embeds the
 absolute path of the `tt` binary that produced it, so a saved copy breaks the
 moment the binary moves or is upgraded in place.
 
-The hook is verified to load and register in bash 3.2 and zsh 5.9. For fish,
-powershell and elvish only the generator's output is checked: no shell has
+Nushell is the exception: it has no `eval`, so save the script once into the
+autoload directory. It calls `tt` by PATH name, so the saved copy stays valid
+across upgrades. Requires nushell 0.108 or newer (the `@complete` attribute).
+
+```nu
+mkdir $nu.user-autoload-dirs.0
+tt completions nu | save -f ($nu.user-autoload-dirs.0 | path join tt-completer.nu)
+```
+
+The hook is verified to load and register in bash 3.2 and zsh 5.9, and in
+nushell 0.115.1 (the `@complete` wrapper form, which passes `tt tui` and
+`tt report` through unchanged). For fish, powershell and elvish only the generator's output is checked: no shell has
 parsed those scripts here, so treat them as untested.
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,7 @@ if "$INSTALL_DIR/tt" completions --help >/dev/null 2>&1; then
     bash)   echo "  echo 'eval \"\$(tt completions bash)\"' >> ~/.bashrc" ;;
     fish)   echo "  echo 'tt completions fish | source' >> ~/.config/fish/config.fish" ;;
     elvish) echo "  echo 'eval (tt completions elvish | slurp)' >> ~/.config/elvish/rc.elv" ;;
+    nu)     echo "  tt completions nu | save -f (\$nu.user-autoload-dirs.0 | path join tt-completer.nu)" ;;
     *)      echo "  tt completions --help   (see docs/usage.md#tt-completions-shell)" ;;
   esac
 fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -148,6 +148,7 @@ pub fn completions(shell: Option<&str>) -> Result<()> {
     let completer = shell
         .map(str::to_string)
         .or(from_env)
+        .or_else(|| cfg!(windows).then(|| "powershell".to_string()))
         .and_then(|n| completions::SHELLS.completer(&n))
         .ok_or_else(|| {
             anyhow::anyhow!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use clap_complete::ArgValueCandidates;
-use clap_complete::aot::Shell;
-use clap_complete::env::Shells;
+use clap::builder::PossibleValuesParser;
 
 use crate::completions;
 
@@ -114,8 +113,9 @@ pub enum Commands {
     },
     /// Print the shell completion hook, for `eval "$(tt completions zsh)"`
     Completions {
-        /// One of bash, elvish, fish, powershell, zsh; detected from $SHELL when omitted
-        shell: Option<Shell>,
+        /// Detected from $SHELL when omitted
+        #[arg(value_parser = PossibleValuesParser::new(completions::SHELLS.names()))]
+        shell: Option<String>,
     },
 }
 
@@ -137,20 +137,24 @@ impl Commands {
 }
 
 /// Print the completion hook for `eval` at shell startup. The hook embeds this
-/// binary's absolute path, so it is regenerated on every startup, never saved.
-pub fn completions(shell: Option<Shell>) -> Result<()> {
-    let shells = Shells::builtins();
-    let shell = shell.or_else(Shell::from_env).ok_or_else(|| {
-        anyhow::anyhow!(
-            "could not detect the shell from $SHELL; pass one of: {}",
-            shells.names().collect::<Vec<_>>().join(", ")
-        )
-    })?;
-    let name = shell.to_possible_value().map(|v| v.get_name().to_string());
-    let completer = name
-        .as_deref()
-        .and_then(|n| shells.completer(n))
-        .ok_or_else(|| anyhow::anyhow!("no dynamic completer for {shell}"))?;
+/// binary's absolute path, so it is regenerated on every startup, never saved;
+/// nu is the exception (see `completions::Nu`).
+pub fn completions(shell: Option<&str>) -> Result<()> {
+    let from_env = std::env::var_os("SHELL").and_then(|s| {
+        std::path::Path::new(&s)
+            .file_stem()
+            .map(|n| n.to_string_lossy().into_owned())
+    });
+    let completer = shell
+        .map(str::to_string)
+        .or(from_env)
+        .and_then(|n| completions::SHELLS.completer(&n))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not detect the shell from $SHELL; pass one of: {}",
+                completions::SHELLS.names().collect::<Vec<_>>().join(", ")
+            )
+        })?;
     let exe = std::env::current_exe()?;
     completer.write_registration(
         "COMPLETE",
@@ -168,9 +172,10 @@ pub fn completions(shell: Option<Shell>) -> Result<()> {
                 "tt completions powershell | Out-String | Invoke-Expression   # $PROFILE".to_string()
             }
             "elvish" => "eval (tt completions elvish | slurp)   # ~/.config/elvish/rc.elv".to_string(),
+            "nu" => "tt completions nu | save -f ($nu.user-autoload-dirs.0 | path join tt-completer.nu)   # run once".to_string(),
             _ => format!("eval \"$(tt completions {name})\"   # ~/.{name}rc"),
         };
-        eprintln!("\nTo enable completion, add this line to your shell startup file:\n  {line}");
+        eprintln!("\nTo enable completion, run this once or add it to your shell startup file:\n  {line}");
     }
     Ok(())
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -3,9 +3,11 @@
 //! and on any failure return nothing rather than an error.
 
 use std::collections::BTreeSet;
+use std::ffi::OsString;
 
 use clap::CommandFactory;
 use clap_complete::CompletionCandidate;
+use clap_complete::env::{Bash, Elvish, EnvCompleter, Fish, Powershell, Shells, Zsh};
 
 use crate::agent::PHASES;
 use crate::cli::Cli;
@@ -13,6 +15,72 @@ use crate::marks::{Mark, open_marks};
 use crate::report::classify;
 use crate::storage::load_data;
 use crate::tracker::{self, TimeData};
+
+/// Every supported shell; the single definition behind `CompleteEnv`, the
+/// `completions` argument and its error message.
+pub const SHELLS: Shells<'static> = Shells(&[&Bash, &Elvish, &Fish, &Nu, &Powershell, &Zsh]);
+
+/// Nushell. The registration script is saved to disk, not evaluated, so it
+/// invokes `tt` by PATH name rather than by absolute path.
+pub struct Nu;
+
+impl EnvCompleter for Nu {
+    fn name(&self) -> &'static str {
+        "nu"
+    }
+
+    fn is(&self, name: &str) -> bool {
+        name == "nu" || name == "nushell"
+    }
+
+    fn write_registration(
+        &self,
+        var: &str,
+        name: &str,
+        bin: &str,
+        _completer: &str,
+        buf: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        writeln!(
+            buf,
+            r##"def {name}-completer [spans: list<string>]: nothing -> list {{
+    with-env {{{var}: "nu"}} {{ ^r#'{bin}'# -- ...$spans }} | from json
+}}
+
+@complete {name}-completer
+def --wrapped {bin} [...args] {{ ^r#'{bin}'# ...$args }}"##
+        )
+    }
+
+    fn write_complete(
+        &self,
+        cmd: &mut clap::Command,
+        mut args: Vec<OsString>,
+        current_dir: Option<&std::path::Path>,
+        buf: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        // nu hands over `" "` for an empty word after a space.
+        if let Some(last) = args.last_mut()
+            && last.to_string_lossy().trim().is_empty()
+        {
+            *last = OsString::new();
+        }
+        let index = args.len().saturating_sub(1);
+        let candidates = clap_complete::engine::complete(cmd, args, index, current_dir)?;
+        let json: Vec<serde_json::Value> = candidates.iter().map(candidate_json).collect();
+        writeln!(buf, "{}", serde_json::Value::Array(json))
+    }
+}
+
+fn candidate_json(c: &CompletionCandidate) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("value".into(), c.get_value().to_string_lossy().into());
+    if let Some(help) = c.get_help() {
+        let first = help.to_string().lines().next().unwrap_or_default().to_string();
+        obj.insert("description".into(), first.into());
+    }
+    serde_json::Value::Object(obj)
+}
 
 /// Every project named by a store entry or an open mark.
 pub fn projects() -> Vec<CompletionCandidate> {
@@ -123,6 +191,41 @@ mod tests {
             .map(|w| w.to_string())
             .collect::<Vec<_>>()
             .into_iter()
+    }
+
+    fn nu_complete(words: &[&str]) -> Vec<serde_json::Value> {
+        let args = words.iter().map(OsString::from).collect();
+        let mut buf = Vec::new();
+        Nu.write_complete(&mut Cli::command(), args, None, &mut buf).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    #[test]
+    fn nu_registration_calls_tt_by_name_and_attaches_the_completer() {
+        let mut buf = Vec::new();
+        Nu.write_registration("COMPLETE", "tt", "tt", "/abs/path/tt", &mut buf).unwrap();
+        let script = String::from_utf8(buf).unwrap();
+        assert!(script.contains("@complete tt-completer"));
+        assert!(script.contains("def tt-completer [spans: list<string>]"));
+        assert!(script.contains("with-env {COMPLETE: \"nu\"}"));
+        assert!(script.contains("def --wrapped tt [...args]"));
+        assert!(!script.contains("/abs/path"), "{script}");
+    }
+
+    #[test]
+    fn nu_candidates_are_json_records_with_optional_descriptions() {
+        let got = nu_complete(&["tt", "agent", "begin", "proj", "-", "im"]);
+        assert_eq!(got, [serde_json::json!({"value": "impl"})]);
+        let subs = nu_complete(&["tt", "compl"]);
+        assert_eq!(subs[0]["value"], "completions");
+        assert!(subs[0]["description"].as_str().unwrap().starts_with("Print the shell completion hook"));
+    }
+
+    #[test]
+    fn nu_whitespace_span_completes_like_an_empty_one() {
+        assert_eq!(nu_complete(&["tt", "agent", "begin", "p", "-", " "]), nu_complete(&["tt", "agent", "begin", "p", "-", ""]));
+        let values: Vec<_> = nu_complete(&["tt", "agent", "begin", "p", "-", ""]).into_iter().filter(|v| !v["value"].as_str().unwrap().starts_with("--")).collect();
+        assert_eq!(values.len(), PHASES.len());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ use clap::{CommandFactory, Parser};
 fn main() -> Result<()> {
     // Exits the process on a completion request, so nothing below — including
     // the store-lock migration — runs on a Tab press.
-    clap_complete::CompleteEnv::with_factory(Cli::command).complete();
+    clap_complete::CompleteEnv::with_factory(Cli::command)
+        .shells(completions::SHELLS)
+        .complete();
     let cli = Cli::parse();
 
     // At most once per day, bounded to a couple of seconds — see
@@ -55,7 +57,7 @@ fn main() -> Result<()> {
             return cli::update(*check, *yes);
         }
         Commands::Completions { shell } => {
-            return cli::completions(*shell);
+            return cli::completions(shell.as_deref());
         }
         _ => {}
     }
@@ -108,6 +110,6 @@ fn main() -> Result<()> {
         // Dispatched ahead of the preamble above; unreachable in practice,
         // kept for exhaustiveness (same shape as `Report` just above it).
         Commands::Update { check, yes } => cli::update(check, yes),
-        Commands::Completions { shell } => cli::completions(shell),
+        Commands::Completions { shell } => cli::completions(shell.as_deref()),
     }
 }

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -5,7 +5,7 @@ mod common;
 use common::{Case, StoreRow, now};
 use std::fs;
 
-const SHELLS: [&str; 5] = ["bash", "elvish", "fish", "powershell", "zsh"];
+const SHELLS: [&str; 6] = ["bash", "elvish", "fish", "nu", "powershell", "zsh"];
 
 fn row(project: &'static str, tags: &'static [&'static str]) -> StoreRow {
     let start = now() - 3600;
@@ -50,6 +50,40 @@ fn complete(case: &Case, index: usize, words: &[&str]) -> Vec<String> {
         .filter(|l| !l.is_empty() && !l.starts_with("--"))
         .map(str::to_string)
         .collect()
+}
+
+/// Drive the completer as the generated nu `tt-completer` does: `COMPLETE=nu
+/// tt -- tt <spans…>`, the cursor implied by the last span, JSON records back.
+fn complete_nu(case: &Case, words: &[&str]) -> Vec<String> {
+    let mut args = vec!["--", "tt"];
+    args.extend_from_slice(words);
+    let run = case.run_bare_with_env(&args, &[("COMPLETE", "nu")]);
+    run.assert_status(0);
+    let records: Vec<serde_json::Value> = serde_json::from_str(&run.stdout).unwrap();
+    records
+        .iter()
+        .map(|r| r["value"].as_str().unwrap().to_string())
+        .filter(|v| !v.starts_with("--"))
+        .collect()
+}
+
+#[test]
+fn nu_returns_the_same_candidates_as_bash() {
+    let case = seeded("completions-nu-parity");
+    let sub = complete_nu(&case, &[""]);
+    for name in ["start", "stop", "log", "report", "agent", "completions"] {
+        assert!(sub.contains(&name.to_string()), "missing {name} in {sub:?}");
+    }
+    assert_eq!(complete_nu(&case, &["start", "--project", ""]), complete(&case, 3, &["start", "--project", ""]));
+    assert_eq!(complete_nu(&case, &["agent", "begin", "alpha", ""]), complete(&case, 4, &["agent", "begin", "alpha", ""]));
+    assert_eq!(complete_nu(&case, &["agent", "begin", ""]), complete(&case, 3, &["agent", "begin", ""]));
+    assert_eq!(complete_nu(&case, &["agent", "begin", "alpha", "-", ""]), complete(&case, 5, &["agent", "begin", "alpha", "-", ""]));
+}
+
+#[test]
+fn nu_whitespace_span_completes_like_an_empty_span() {
+    let case = seeded("completions-nu-space");
+    assert_eq!(complete_nu(&case, &["start", "--project", " "]), ["alpha", "beta", "gamma"]);
 }
 
 #[test]
@@ -103,6 +137,7 @@ fn a_completion_run_leaves_the_store_and_its_lock_untouched() {
 
     complete(&case, 3, &["start", "--project", ""]);
     complete(&case, 4, &["agent", "begin", "alpha", ""]);
+    complete_nu(&case, &["agent", "begin", "alpha", ""]);
 
     assert_eq!(fs::metadata(&store).unwrap().modified().unwrap(), before);
     assert_eq!(fs::read_to_string(&store).unwrap(), body_before);
@@ -125,9 +160,9 @@ fn the_completions_subcommand_prints_the_same_hook_as_the_env_protocol() {
 #[test]
 fn an_unknown_shell_is_an_error_naming_the_choices() {
     let case = Case::new("completions-unknown-shell");
-    let run = case.run_bare_with_env(&["completions"], &[("SHELL", "/bin/nu")]);
+    let run = case.run_bare_with_env(&["completions"], &[("SHELL", "/bin/tcsh")]);
     assert_ne!(run.status, Some(0));
-    assert!(run.stderr.contains("bash, elvish, fish, powershell, zsh"), "{}", run.stderr);
+    assert!(run.stderr.contains("bash, elvish, fish, nu, powershell, zsh"), "{}", run.stderr);
 }
 
 #[test]


### PR DESCRIPTION
Adds dynamic nushell completions and retypes `tt completions` off a shared shell table.

- Adds a local `Nu` `EnvCompleter` emitting JSON candidates for nu >= 0.108 `@complete` (no new dependencies).
- Retypes the `tt completions` shell argument off a shared `SHELLS` table, with `$SHELL`-based detection (powershell stays the default on Windows).
- Adds nu install hints to the CLI, `install.sh` and the docs.
- Covers the nu completion protocol end-to-end in tests.

The generated nu script is saved once into `$nu.user-autoload-dirs` and invokes `tt` by PATH name.

Verified interactively in nushell 0.115.1: completions resolve for subcommands, `--project` and agent positionals; `tt tui` and `tt report` pass through the wrapper.

Stacked on #126 (`111-completions-wiring`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

