### PR TITLE
fix(agent): beat open marks when a subagent stops

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -88,7 +88,14 @@ fn activity_command(command: &ActivityCommands) -> Result<()> {
             project,
         } => activity::begin_in(&dir, session_id, project.as_deref())?,
         ActivityCommands::End { session_id } => activity::end_in(&dir, session_id)?,
-        ActivityCommands::Subagent { session_id } => activity::subagent_in(&dir, session_id)?,
+        ActivityCommands::Subagent { session_id } => {
+            activity::subagent_in(&dir, session_id)?;
+            // The hook is the one witness to when a subagent's work stopped;
+            // without this beat `end` sees the wait for the report as silence.
+            if let Some(marks) = marks::mark_dir() {
+                marks::touch_all_in(&marks);
+            }
+        }
         ActivityCommands::Check {
             session_id,
             auto_log,

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -310,6 +310,15 @@ pub fn touch_in(dir: &Path, project: &str, issue: &str, phase: &str) -> io::Resu
     Ok(Touch::Recorded)
 }
 
+/// Append one heartbeat to **every** open mark in `dir`. A mark whose beats
+/// cannot be written is skipped; the rest are still beaten.
+pub fn touch_all_in(dir: &Path) {
+    for mark in open_marks_in(dir) {
+        let issue = mark.issue.as_deref().unwrap_or("-");
+        let _ = touch_in(dir, &mark.project, issue, &mark.phase);
+    }
+}
+
 /// Record that a close for one phase is under way, holding the mark's start
 /// timestamp so the file names its own phase's span. An existing sentinel is
 /// overwritten; [`is_closing_in`] is what refuses.
@@ -471,6 +480,19 @@ mod tests {
 
     fn write(dir: &Path, name: &str, contents: &str) {
         fs::write(dir.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn touch_all_beats_every_open_mark_and_nothing_else() {
+        let dir = sandbox("touch-all");
+        write(&dir, "proj.7.impl", "1000100\n");
+        write(&dir, "proj.-.plan", "1000200\n");
+        touch_all_in(&dir);
+        for key in ["proj.7.impl", "proj.-.plan"] {
+            let body = fs::read_to_string(beats_path(&dir, key)).unwrap();
+            assert_eq!(body.lines().count(), 1, "{key}");
+        }
+        assert_eq!(fs::read_dir(dir.join("beats")).unwrap().count(), 2);
     }
 
     fn at(seconds: i64) -> DateTime<Local> {


### PR DESCRIPTION
Makes the SubagentStop hook append a beat to every open mark, so `tt agent end` measures to the moment the subagent actually stopped.

- `tt agent activity subagent` now also beats all open marks, not just the session activity ledger
- Adds `marks::touch_all_in`
- Adds a unit test covering the new behaviour

## Why the durations were wrong

`tt agent end` measures start -> last heartbeat and judges gaps over start, beats and end. In the orchestrator model the only heartbeat is the orchestrator's late `touch`, so the wait for the subagent's report reads as a single gap and `--trim` yields 0m. The real stop instant was already recorded by the hook, but only into the session activity ledger, which `end` never reads.

Verified: `cargo test` 234 pass; checked live with begin -> activity subagent -> beats file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
