### PR TITLE
ci: gate pull requests on cargo test, fmt and clippy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,37 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Formatting, lints and the test suite. Ubuntu alone: `build` below already
+  # covers cross-platform compilation, and none of these three checks is
+  # platform-dependent. Runs on every PR and every push to main, including the
+  # pushes that skip `build` entirely, so nothing reaches main unchecked.
+  #
+  # `-D warnings` is deliberate: clippy findings accumulate precisely because
+  # nothing rejects them, and every later refactor then has to work around the
+  # noise. --all-targets so the lint covers tests/ too, not just the binary.
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Lint
+        run: cargo clippy --all-targets -- -D warnings
+
+      # The integration tests under tests/ shell out to the compiled `tt`
+      # binary, so they need it built first; `cargo test` does that itself.
+      - name: Test
+        run: cargo test
+
   # On a push to main (not a tag, not a PR), checks whether Cargo.toml's
   # version already has a matching tag. If not, this *is* the release: it
   # tags it here, in this same run, rather than pushing the tag and hoping a

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -584,7 +584,9 @@ fn strip_stray_tags(summary: &str) -> String {
 /// The phase vocabulary, in the order the docs list it. `src/report.rs` reads it
 /// back off the stored tags, so it must stay the one list. Not used to validate
 /// the `phase` argument: any word is accepted.
-pub const PHASES: [&str; 8] = ["plan", "impl", "qa", "review", "docs", "spike", "explore", "ops"];
+pub const PHASES: [&str; 8] = [
+    "plan", "impl", "qa", "review", "docs", "spike", "explore", "ops",
+];
 
 /// The description `cli::log` is given: the summary, then one tag per axis the
 /// `project` field cannot express — the item (omitted for the `-` sentinel), the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate, TimeZone};
+use clap::builder::PossibleValuesParser;
 use clap::{Parser, Subcommand};
 use clap_complete::ArgValueCandidates;
-use clap::builder::PossibleValuesParser;
 
 use crate::completions;
 
@@ -176,7 +176,9 @@ pub fn completions(shell: Option<&str>) -> Result<()> {
             "nu" => "tt completions nu | save -f ($nu.user-autoload-dirs.0 | path join tt-completer.nu)   # run once".to_string(),
             _ => format!("eval \"$(tt completions {name})\"   # ~/.{name}rc"),
         };
-        eprintln!("\nTo enable completion, run this once or add it to your shell startup file:\n  {line}");
+        eprintln!(
+            "\nTo enable completion, run this once or add it to your shell startup file:\n  {line}"
+        );
     }
     Ok(())
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -76,7 +76,12 @@ fn candidate_json(c: &CompletionCandidate) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
     obj.insert("value".into(), c.get_value().to_string_lossy().into());
     if let Some(help) = c.get_help() {
-        let first = help.to_string().lines().next().unwrap_or_default().to_string();
+        let first = help
+            .to_string()
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string();
         obj.insert("description".into(), first.into());
     }
     serde_json::Value::Object(obj)
@@ -196,14 +201,16 @@ mod tests {
     fn nu_complete(words: &[&str]) -> Vec<serde_json::Value> {
         let args = words.iter().map(OsString::from).collect();
         let mut buf = Vec::new();
-        Nu.write_complete(&mut Cli::command(), args, None, &mut buf).unwrap();
+        Nu.write_complete(&mut Cli::command(), args, None, &mut buf)
+            .unwrap();
         serde_json::from_slice(&buf).unwrap()
     }
 
     #[test]
     fn nu_registration_calls_tt_by_name_and_attaches_the_completer() {
         let mut buf = Vec::new();
-        Nu.write_registration("COMPLETE", "tt", "tt", "/abs/path/tt", &mut buf).unwrap();
+        Nu.write_registration("COMPLETE", "tt", "tt", "/abs/path/tt", &mut buf)
+            .unwrap();
         let script = String::from_utf8(buf).unwrap();
         assert!(script.contains("@complete tt-completer"));
         assert!(script.contains("def tt-completer [spans: list<string>]"));
@@ -218,13 +225,24 @@ mod tests {
         assert_eq!(got, [serde_json::json!({"value": "impl"})]);
         let subs = nu_complete(&["tt", "compl"]);
         assert_eq!(subs[0]["value"], "completions");
-        assert!(subs[0]["description"].as_str().unwrap().starts_with("Print the shell completion hook"));
+        assert!(
+            subs[0]["description"]
+                .as_str()
+                .unwrap()
+                .starts_with("Print the shell completion hook")
+        );
     }
 
     #[test]
     fn nu_whitespace_span_completes_like_an_empty_one() {
-        assert_eq!(nu_complete(&["tt", "agent", "begin", "p", "-", " "]), nu_complete(&["tt", "agent", "begin", "p", "-", ""]));
-        let values: Vec<_> = nu_complete(&["tt", "agent", "begin", "p", "-", ""]).into_iter().filter(|v| !v["value"].as_str().unwrap().starts_with("--")).collect();
+        assert_eq!(
+            nu_complete(&["tt", "agent", "begin", "p", "-", " "]),
+            nu_complete(&["tt", "agent", "begin", "p", "-", ""])
+        );
+        let values: Vec<_> = nu_complete(&["tt", "agent", "begin", "p", "-", ""])
+            .into_iter()
+            .filter(|v| !v["value"].as_str().unwrap().starts_with("--"))
+            .collect();
         assert_eq!(values.len(), PHASES.len());
     }
 
@@ -237,7 +255,10 @@ mod tests {
             entry(Some(""), &[]),
         ]);
         let names = project_names(&d, &[mark("alpha", None), mark("mid", None)]);
-        assert_eq!(names.into_iter().collect::<Vec<_>>(), ["alpha", "mid", "zeta"]);
+        assert_eq!(
+            names.into_iter().collect::<Vec<_>>(),
+            ["alpha", "mid", "zeta"]
+        );
     }
 
     #[test]
@@ -247,21 +268,31 @@ mod tests {
             entry(Some("b"), &["b/20"]),
             entry(Some("a"), &["a/"]),
         ]);
-        let marks = [mark("a", Some("11")), mark("b", Some("21")), mark("a", None)];
+        let marks = [
+            mark("a", Some("11")),
+            mark("b", Some("21")),
+            mark("a", None),
+        ];
         let scoped = issue_names(&d, &marks, Some("a"));
         assert_eq!(scoped.into_iter().collect::<Vec<_>>(), ["-", "10", "11"]);
     }
 
     #[test]
     fn issues_unfiltered_without_project() {
-        let d = data(vec![entry(Some("a"), &["a/10"]), entry(Some("b"), &["b/20"])]);
+        let d = data(vec![
+            entry(Some("a"), &["a/10"]),
+            entry(Some("b"), &["b/20"]),
+        ]);
         let all = issue_names(&d, &[mark("b", Some("21"))], None);
         assert_eq!(all.into_iter().collect::<Vec<_>>(), ["-", "10", "20", "21"]);
     }
 
     #[test]
     fn phases_are_the_canonical_list() {
-        let got: Vec<String> = phases().iter().map(|c| c.get_value().to_string_lossy().into_owned()).collect();
+        let got: Vec<String> = phases()
+            .iter()
+            .map(|c| c.get_value().to_string_lossy().into_owned())
+            .collect();
         assert_eq!(got, PHASES);
     }
 
@@ -280,9 +311,21 @@ mod tests {
     #[test]
     fn typed_project_is_none_on_odd_shapes() {
         assert_eq!(typed_project(argv(&["/bin/tt"])), None);
-        assert_eq!(typed_project(argv(&["/bin/tt", "tt", "agent", "begin", "proj"])), None);
-        assert_eq!(typed_project(argv(&["/bin/tt", "--", "tt", "agent", "begin"])), None);
-        assert_eq!(typed_project(argv(&["/bin/tt", "--", "tt", "agent", "begin", ""])), None);
-        assert_eq!(typed_project(argv(&["/bin/tt", "--", "tt", "start", "--project", ""])), None);
+        assert_eq!(
+            typed_project(argv(&["/bin/tt", "tt", "agent", "begin", "proj"])),
+            None
+        );
+        assert_eq!(
+            typed_project(argv(&["/bin/tt", "--", "tt", "agent", "begin"])),
+            None
+        );
+        assert_eq!(
+            typed_project(argv(&["/bin/tt", "--", "tt", "agent", "begin", ""])),
+            None
+        );
+        assert_eq!(
+            typed_project(argv(&["/bin/tt", "--", "tt", "start", "--project", ""])),
+            None
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,10 +237,10 @@ fn resolve_include_path(raw: &str, including_file: &Path) -> PathBuf {
 }
 
 fn expand_tilde(raw: &str) -> PathBuf {
-    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
-        if let Some(base) = directories::BaseDirs::new() {
-            return base.home_dir().join(rest);
-        }
+    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\"))
+        && let Some(base) = directories::BaseDirs::new()
+    {
+        return base.home_dir().join(rest);
     }
     PathBuf::from(raw)
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -16,7 +16,8 @@ struct Icons {
 
 impl Icons {
     fn from_config(cfg: &config::IconsConfig) -> Self {
-        let icon = |s: &Option<String>, default: &str| s.clone().unwrap_or_else(|| default.to_string());
+        let icon =
+            |s: &Option<String>, default: &str| s.clone().unwrap_or_else(|| default.to_string());
 
         Icons {
             active: icon(&cfg.active, "▶️"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ mod tracker;
 mod tui;
 mod update;
 
-use cli::{Cli, Commands};
 use clap::{CommandFactory, Parser};
+use cli::{Cli, Commands};
 
 fn main() -> Result<()> {
     // Exits the process on a completion request, so nothing below — including

--- a/src/tui/entry_form.rs
+++ b/src/tui/entry_form.rs
@@ -1,15 +1,24 @@
-use anyhow::Result;
-use chrono::{DateTime, Local, NaiveDate};
 use super::App;
 use super::types::{InputField, InputMode, ViewMode};
+use anyhow::Result;
+use chrono::{DateTime, Local, NaiveDate};
+
+/// A submittable form resolved into the fields `add_entry` takes: description,
+/// tags, start, and the end an open entry does not have.
+type EntryFields = (
+    String,
+    Vec<String>,
+    DateTime<Local>,
+    Option<DateTime<Local>>,
+);
 
 impl App {
     pub(crate) fn start_adding(&mut self) {
         // In week view, snap selected_date to the day under the cursor.
-        if self.view_mode == ViewMode::Week {
-            if let Some(date) = self.date_under_cursor() {
-                self.selected_date = date;
-            }
+        if self.view_mode == ViewMode::Week
+            && let Some(date) = self.date_under_cursor()
+        {
+            self.selected_date = date;
         }
         self.input_mode = InputMode::AddingEntry;
         self.input_field = InputField::Description;
@@ -45,7 +54,9 @@ impl App {
                         entry.project.clone().unwrap_or_default(),
                         entry.tags.join(" "),
                         entry.start_time.format("%Y-%m-%d %H:%M").to_string(),
-                        entry.end_time.map(|t| t.format("%Y-%m-%d %H:%M").to_string()),
+                        entry
+                            .end_time
+                            .map(|t| t.format("%Y-%m-%d %H:%M").to_string()),
                         entry.end_time.map(|_| entry.format_duration()),
                     )
                 })
@@ -69,12 +80,17 @@ impl App {
     /// Validates the current form input and resolves it into entry fields.
     /// Returns `None` if the form isn't currently submittable (empty
     /// description, unresolvable start/end times).
-    fn build_entry_fields(&self) -> Option<(String, Vec<String>, DateTime<Local>, Option<DateTime<Local>>)> {
+    fn build_entry_fields(&self) -> Option<EntryFields> {
         if self.input_description.is_empty() {
             return None;
         }
         let (start_time, end_time) = self.resolve_times()?;
-        Some((self.input_description.clone(), self.parse_tags(), start_time, end_time))
+        Some((
+            self.input_description.clone(),
+            self.parse_tags(),
+            start_time,
+            end_time,
+        ))
     }
 
     pub(crate) fn submit_entry(&mut self) -> Result<()> {
@@ -160,9 +176,19 @@ impl App {
             InputField::Duration => &mut self.input_duration,
         };
         let actual_pos = pos.min(s.chars().count());
-        if actual_pos == 0 { return; }
-        let byte_start = s.char_indices().nth(actual_pos - 1).map(|(i, _)| i).unwrap_or(s.len());
-        let byte_end = s.char_indices().nth(actual_pos).map(|(i, _)| i).unwrap_or(s.len());
+        if actual_pos == 0 {
+            return;
+        }
+        let byte_start = s
+            .char_indices()
+            .nth(actual_pos - 1)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len());
+        let byte_end = s
+            .char_indices()
+            .nth(actual_pos)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len());
         s.drain(byte_start..byte_end);
         self.cursor_pos = actual_pos - 1;
     }
@@ -258,7 +284,8 @@ impl App {
             (None, None, Some(d)) => {
                 // Anchored to selected_date, so a past day's entry lands on that day.
                 let now_time = Local::now().time();
-                let end = self.selected_date
+                let end = self
+                    .selected_date
                     .and_time(now_time)
                     .and_local_timezone(Local)
                     .single()
@@ -277,9 +304,17 @@ impl App {
         let end_str = self.input_end_time.clone();
         let dur_str = self.input_duration.clone();
 
-        let start = if !start_str.is_empty() { self.parse_time_str(&start_str) } else { None };
-        let end   = if !end_str.is_empty()   { self.parse_time_str(&end_str)   } else { None };
-        let dur   = if !dur_str.is_empty() {
+        let start = if !start_str.is_empty() {
+            self.parse_time_str(&start_str)
+        } else {
+            None
+        };
+        let end = if !end_str.is_empty() {
+            self.parse_time_str(&end_str)
+        } else {
+            None
+        };
+        let dur = if !dur_str.is_empty() {
             let d = crate::duration::parse(&dur_str);
             if d.num_seconds() > 0 { Some(d) } else { None }
         } else {
@@ -349,10 +384,10 @@ impl App {
         // DD/MM
         if s.contains('/') {
             let mut parts = s.splitn(2, '/');
-            if let (Some(d), Some(m)) = (parts.next(), parts.next()) {
-                if let (Ok(day), Ok(month)) = (d.parse::<u32>(), m.parse::<u32>()) {
-                    return NaiveDate::from_ymd_opt(current_year, month, day);
-                }
+            if let (Some(d), Some(m)) = (parts.next(), parts.next())
+                && let (Ok(day), Ok(month)) = (d.parse::<u32>(), m.parse::<u32>())
+            {
+                return NaiveDate::from_ymd_opt(current_year, month, day);
             }
         }
         // YYYY-MM-DD
@@ -383,7 +418,9 @@ impl App {
         let (hour, minute) = if let Some(colon_pos) = rest.find(':') {
             let h: u32 = rest[..colon_pos].trim().parse().ok()?;
             let m: u32 = rest[colon_pos + 1..].trim().parse().ok()?;
-            if m > 59 { return None; }
+            if m > 59 {
+                return None;
+            }
             (h, m)
         } else {
             let h: u32 = rest.trim().parse().ok()?;
@@ -391,7 +428,9 @@ impl App {
         };
 
         let hour_24 = if is_12h {
-            if hour == 0 || hour > 12 { return None; }
+            if hour == 0 || hour > 12 {
+                return None;
+            }
             match (is_pm, hour) {
                 (false, 12) => 0,
                 (true, 12) => 12,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -308,198 +308,197 @@ pub fn run_tui(update_notice: Option<String>) -> Result<()> {
     loop {
         terminal.draw(|f| render::ui(f, &mut app))?;
 
-        if event::poll(std::time::Duration::from_millis(250))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    match app.input_mode {
-                        InputMode::Normal => match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => {
-                                if app.is_searching() {
-                                    app.clear_search();
-                                } else if app.is_filtering() {
-                                    app.clear_filters();
-                                } else {
-                                    app.should_quit = true;
-                                }
-                            }
-                            // j/k move in the focused pane, else the table.
-                            KeyCode::Char('j') | KeyCode::Down => {
-                                if !app.pane_next() {
-                                    app.next();
-                                }
-                            }
-                            KeyCode::Char('k') | KeyCode::Up => {
-                                if !app.pane_previous() {
-                                    app.previous();
-                                }
-                            }
-                            // One key, disambiguated by focus: `cycle_pane_value`
-                            // reporting false *is* the focus check.
-                            KeyCode::Enter => {
-                                if !app.cycle_pane_value(true) {
-                                    app.open_detail();
-                                }
-                            }
-                            // Reverse cycle; without pane focus it does nothing.
-                            KeyCode::Char('-') => {
-                                app.cycle_pane_value(false);
-                            }
-                            KeyCode::Char('P') => app.toggle_pane(Pane::Projects),
-                            KeyCode::Char('T') => app.toggle_pane(Pane::Tags),
-                            KeyCode::Char('A') => app.toggle_marks(),
-                            // Capital `S` only; lowercase `s` stops the entry.
-                            KeyCode::Char('S') => app.toggle_summary(),
-                            KeyCode::Tab => app.cycle_focus(),
-                            // crossterm reports Shift-Tab as its own code.
-                            KeyCode::BackTab => app.cycle_focus_back(),
-                            KeyCode::Char('d') => app.request_confirm(ConfirmAction::Delete),
-                            KeyCode::Char('s') => app.stop_active()?,
-                            KeyCode::Char('r') => app.reload()?,
-                            KeyCode::Char('a') => app.start_adding(),
-                            KeyCode::Char('e') => app.start_editing(),
-                            KeyCode::Char('/') => app.start_search(),
-                            KeyCode::Char('1') => app.set_view_mode(ViewMode::Day),
-                            KeyCode::Char('2') => app.set_view_mode(ViewMode::Week),
-                            KeyCode::Char('3') => app.set_view_mode(ViewMode::All),
-                            KeyCode::Char('4') => app.set_view_mode(ViewMode::Overview),
-                            KeyCode::Char('h') | KeyCode::Left => app.previous_period(),
-                            KeyCode::Char('l') | KeyCode::Right => app.next_period(),
-                            KeyCode::Char('t') => app.go_to_today(),
-                            KeyCode::Char('o') => app.toggle_sort_order(),
-                            KeyCode::Char('?') => {
-                                app.help_scroll = 0;
-                                app.input_mode = InputMode::Help;
-                            }
-                            _ => {}
-                        },
-                        InputMode::Onboarding => match app.onboarding_step {
-                            OnboardingStep::Layout => match key.code {
-                                KeyCode::Char('j') | KeyCode::Down => app.onboarding_move(1),
-                                KeyCode::Char('k') | KeyCode::Up => app.onboarding_move(-1),
-                                KeyCode::Char(' ') | KeyCode::Enter => app.onboarding_toggle(),
-                                KeyCode::Char('s') => app.onboarding_apply_layout(),
-                                KeyCode::Esc => app.onboarding_skip()?,
-                                _ => {}
-                            },
-                            OnboardingStep::Skill => match key.code {
-                                KeyCode::Char('y') => {
-                                    if npx_available() {
-                                        app.onboarding_skill_error = None;
-                                        app.request_skill_install = true;
-                                    } else {
-                                        app.onboarding_skill_error = Some(
-                                            "npx not found on PATH — install Node.js, or run \
-                                             this later yourself; see AGENTS.md."
-                                                .to_string(),
-                                        );
-                                    }
-                                }
-                                KeyCode::Char('n') | KeyCode::Enter => app.onboarding_finish()?,
-                                KeyCode::Esc => app.onboarding_skip()?,
-                                _ => {}
-                            },
-                        },
-                        InputMode::AddingEntry => match key.code {
-                            KeyCode::Esc => app.cancel_adding(),
-                            KeyCode::Enter => app.submit_entry()?,
-                            KeyCode::Tab => app.next_input_field(),
-                            KeyCode::BackTab => app.prev_input_field(),
-                            KeyCode::Backspace => app.handle_input_backspace(),
-                            KeyCode::Left => {
-                                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                                    app.move_cursor_word_left();
-                                } else {
-                                    app.move_cursor_left();
-                                }
-                            }
-                            KeyCode::Right => {
-                                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                                    app.move_cursor_word_right();
-                                } else {
-                                    app.move_cursor_right();
-                                }
-                            }
-                            KeyCode::Char(c) => app.handle_input_char(c),
-                            _ => {}
-                        },
-                        InputMode::EditingEntry => match key.code {
-                            KeyCode::Esc => app.cancel_adding(),
-                            KeyCode::Enter => app.submit_edit()?,
-                            KeyCode::Tab => app.next_input_field(),
-                            KeyCode::BackTab => app.prev_input_field(),
-                            KeyCode::Backspace => app.handle_input_backspace(),
-                            KeyCode::Left => {
-                                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                                    app.move_cursor_word_left();
-                                } else {
-                                    app.move_cursor_left();
-                                }
-                            }
-                            KeyCode::Right => {
-                                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                                    app.move_cursor_word_right();
-                                } else {
-                                    app.move_cursor_right();
-                                }
-                            }
-                            KeyCode::Char(c) => app.handle_input_char(c),
-                            _ => {}
-                        },
-                        InputMode::Searching => match key.code {
-                            KeyCode::Esc => app.clear_search(),
-                            KeyCode::Enter => app.confirm_search(),
-                            KeyCode::Backspace => app.handle_search_backspace(),
-                            KeyCode::Left => {
-                                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                                    app.move_cursor_word_left();
-                                } else {
-                                    app.move_cursor_left();
-                                }
-                            }
-                            KeyCode::Right => {
-                                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                                    app.move_cursor_word_right();
-                                } else {
-                                    app.move_cursor_right();
-                                }
-                            }
-                            KeyCode::Char(c) => app.handle_search_char(c),
-                            _ => {}
-                        },
-                        InputMode::Help => match key.code {
-                            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
-                                app.help_scroll = 0;
-                                app.input_mode = InputMode::Normal;
-                            }
-                            KeyCode::Char('j') | KeyCode::Down => app.help_scroll += 1,
-                            KeyCode::Char('k') | KeyCode::Up => {
-                                app.help_scroll = app.help_scroll.saturating_sub(1)
-                            }
-                            _ => {}
-                        },
-                        // Modal, but not inert: the popover renders whatever
-                        // `selected_entry()` returns, so j/k alone make it follow.
-                        InputMode::Detail => match key.code {
-                            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => {
-                                app.input_mode = InputMode::Normal;
-                            }
-                            // The table's own, so a focused pane cannot capture j/k.
-                            KeyCode::Char('j') | KeyCode::Down => app.next(),
-                            KeyCode::Char('k') | KeyCode::Up => app.previous(),
-                            // The form is modal too, so it replaces the popover.
-                            KeyCode::Char('e') => app.start_editing(),
-                            // Confirmed here as on the table: one key, one meaning.
-                            KeyCode::Char('d') => app.request_confirm(ConfirmAction::Delete),
-                            // `t` rather than `s`, so a slip outside this modal hits
-                            // `go_to_today()`. Bound here only.
-                            KeyCode::Char('t') => app.request_confirm(ConfirmAction::Trim),
-                            _ => {}
-                        },
-                        // Which key is a yes depends on the pending action, so the
-                        // whole answer lives in `answer_confirm`.
-                        InputMode::Confirm => app.answer_confirm(key.code)?,
+        if event::poll(std::time::Duration::from_millis(250))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+        {
+            match app.input_mode {
+                InputMode::Normal => match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => {
+                        if app.is_searching() {
+                            app.clear_search();
+                        } else if app.is_filtering() {
+                            app.clear_filters();
+                        } else {
+                            app.should_quit = true;
+                        }
                     }
-                }
+                    // j/k move in the focused pane, else the table.
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if !app.pane_next() {
+                            app.next();
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        if !app.pane_previous() {
+                            app.previous();
+                        }
+                    }
+                    // One key, disambiguated by focus: `cycle_pane_value`
+                    // reporting false *is* the focus check.
+                    KeyCode::Enter => {
+                        if !app.cycle_pane_value(true) {
+                            app.open_detail();
+                        }
+                    }
+                    // Reverse cycle; without pane focus it does nothing.
+                    KeyCode::Char('-') => {
+                        app.cycle_pane_value(false);
+                    }
+                    KeyCode::Char('P') => app.toggle_pane(Pane::Projects),
+                    KeyCode::Char('T') => app.toggle_pane(Pane::Tags),
+                    KeyCode::Char('A') => app.toggle_marks(),
+                    // Capital `S` only; lowercase `s` stops the entry.
+                    KeyCode::Char('S') => app.toggle_summary(),
+                    KeyCode::Tab => app.cycle_focus(),
+                    // crossterm reports Shift-Tab as its own code.
+                    KeyCode::BackTab => app.cycle_focus_back(),
+                    KeyCode::Char('d') => app.request_confirm(ConfirmAction::Delete),
+                    KeyCode::Char('s') => app.stop_active()?,
+                    KeyCode::Char('r') => app.reload()?,
+                    KeyCode::Char('a') => app.start_adding(),
+                    KeyCode::Char('e') => app.start_editing(),
+                    KeyCode::Char('/') => app.start_search(),
+                    KeyCode::Char('1') => app.set_view_mode(ViewMode::Day),
+                    KeyCode::Char('2') => app.set_view_mode(ViewMode::Week),
+                    KeyCode::Char('3') => app.set_view_mode(ViewMode::All),
+                    KeyCode::Char('4') => app.set_view_mode(ViewMode::Overview),
+                    KeyCode::Char('h') | KeyCode::Left => app.previous_period(),
+                    KeyCode::Char('l') | KeyCode::Right => app.next_period(),
+                    KeyCode::Char('t') => app.go_to_today(),
+                    KeyCode::Char('o') => app.toggle_sort_order(),
+                    KeyCode::Char('?') => {
+                        app.help_scroll = 0;
+                        app.input_mode = InputMode::Help;
+                    }
+                    _ => {}
+                },
+                InputMode::Onboarding => match app.onboarding_step {
+                    OnboardingStep::Layout => match key.code {
+                        KeyCode::Char('j') | KeyCode::Down => app.onboarding_move(1),
+                        KeyCode::Char('k') | KeyCode::Up => app.onboarding_move(-1),
+                        KeyCode::Char(' ') | KeyCode::Enter => app.onboarding_toggle(),
+                        KeyCode::Char('s') => app.onboarding_apply_layout(),
+                        KeyCode::Esc => app.onboarding_skip()?,
+                        _ => {}
+                    },
+                    OnboardingStep::Skill => match key.code {
+                        KeyCode::Char('y') => {
+                            if npx_available() {
+                                app.onboarding_skill_error = None;
+                                app.request_skill_install = true;
+                            } else {
+                                app.onboarding_skill_error = Some(
+                                    "npx not found on PATH — install Node.js, or run \
+                                             this later yourself; see AGENTS.md."
+                                        .to_string(),
+                                );
+                            }
+                        }
+                        KeyCode::Char('n') | KeyCode::Enter => app.onboarding_finish()?,
+                        KeyCode::Esc => app.onboarding_skip()?,
+                        _ => {}
+                    },
+                },
+                InputMode::AddingEntry => match key.code {
+                    KeyCode::Esc => app.cancel_adding(),
+                    KeyCode::Enter => app.submit_entry()?,
+                    KeyCode::Tab => app.next_input_field(),
+                    KeyCode::BackTab => app.prev_input_field(),
+                    KeyCode::Backspace => app.handle_input_backspace(),
+                    KeyCode::Left => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            app.move_cursor_word_left();
+                        } else {
+                            app.move_cursor_left();
+                        }
+                    }
+                    KeyCode::Right => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            app.move_cursor_word_right();
+                        } else {
+                            app.move_cursor_right();
+                        }
+                    }
+                    KeyCode::Char(c) => app.handle_input_char(c),
+                    _ => {}
+                },
+                InputMode::EditingEntry => match key.code {
+                    KeyCode::Esc => app.cancel_adding(),
+                    KeyCode::Enter => app.submit_edit()?,
+                    KeyCode::Tab => app.next_input_field(),
+                    KeyCode::BackTab => app.prev_input_field(),
+                    KeyCode::Backspace => app.handle_input_backspace(),
+                    KeyCode::Left => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            app.move_cursor_word_left();
+                        } else {
+                            app.move_cursor_left();
+                        }
+                    }
+                    KeyCode::Right => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            app.move_cursor_word_right();
+                        } else {
+                            app.move_cursor_right();
+                        }
+                    }
+                    KeyCode::Char(c) => app.handle_input_char(c),
+                    _ => {}
+                },
+                InputMode::Searching => match key.code {
+                    KeyCode::Esc => app.clear_search(),
+                    KeyCode::Enter => app.confirm_search(),
+                    KeyCode::Backspace => app.handle_search_backspace(),
+                    KeyCode::Left => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            app.move_cursor_word_left();
+                        } else {
+                            app.move_cursor_left();
+                        }
+                    }
+                    KeyCode::Right => {
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            app.move_cursor_word_right();
+                        } else {
+                            app.move_cursor_right();
+                        }
+                    }
+                    KeyCode::Char(c) => app.handle_search_char(c),
+                    _ => {}
+                },
+                InputMode::Help => match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+                        app.help_scroll = 0;
+                        app.input_mode = InputMode::Normal;
+                    }
+                    KeyCode::Char('j') | KeyCode::Down => app.help_scroll += 1,
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        app.help_scroll = app.help_scroll.saturating_sub(1)
+                    }
+                    _ => {}
+                },
+                // Modal, but not inert: the popover renders whatever
+                // `selected_entry()` returns, so j/k alone make it follow.
+                InputMode::Detail => match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => {
+                        app.input_mode = InputMode::Normal;
+                    }
+                    // The table's own, so a focused pane cannot capture j/k.
+                    KeyCode::Char('j') | KeyCode::Down => app.next(),
+                    KeyCode::Char('k') | KeyCode::Up => app.previous(),
+                    // The form is modal too, so it replaces the popover.
+                    KeyCode::Char('e') => app.start_editing(),
+                    // Confirmed here as on the table: one key, one meaning.
+                    KeyCode::Char('d') => app.request_confirm(ConfirmAction::Delete),
+                    // `t` rather than `s`, so a slip outside this modal hits
+                    // `go_to_today()`. Bound here only.
+                    KeyCode::Char('t') => app.request_confirm(ConfirmAction::Trim),
+                    _ => {}
+                },
+                // Which key is a yes depends on the pending action, so the
+                // whole answer lives in `answer_confirm`.
+                InputMode::Confirm => app.answer_confirm(key.code)?,
             }
         }
 
@@ -1720,7 +1719,10 @@ mod tests {
             assert_eq!(column(needle), first, "{needle}");
         }
         let screen = lines.join("\n");
-        assert!(screen.contains("trim idle from the entry (asks first)"), "{screen}");
+        assert!(
+            screen.contains("trim idle from the entry (asks first)"),
+            "{screen}"
+        );
     }
 
     #[test]
@@ -1743,7 +1745,10 @@ mod tests {
 
         app.input_mode = InputMode::Help;
         let tall = frame_lines(&mut app, 100, 45).join("\n");
-        assert!(!tall.contains("▾ more") && !tall.contains("j/k scroll"), "{tall}");
+        assert!(
+            !tall.contains("▾ more") && !tall.contains("j/k scroll"),
+            "{tall}"
+        );
     }
 
     #[test]

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -20,7 +20,10 @@ impl App {
     }
 
     pub(crate) fn onboarding_is_checked(&self, surface: LayoutSurface) -> bool {
-        let idx = LayoutSurface::ALL.iter().position(|s| *s == surface).unwrap();
+        let idx = LayoutSurface::ALL
+            .iter()
+            .position(|s| *s == surface)
+            .unwrap();
         self.onboarding_checked[idx]
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -453,7 +453,10 @@ pub fn render_help_popup(f: &mut Frame, app: &mut App) {
         if i > 0 {
             lines.push(Line::from(""));
         }
-        lines.push(Line::from(Span::styled(format!("{INSET}{title}"), heading_style)));
+        lines.push(Line::from(Span::styled(
+            format!("{INSET}{title}"),
+            heading_style,
+        )));
         for (k, d) in rows.iter() {
             let pad = key_width - Span::raw(*k).width() + GAP;
             lines.push(Line::from(vec![
@@ -487,7 +490,11 @@ pub fn render_help_popup(f: &mut Frame, app: &mut App) {
     let max_offset = lines.len().saturating_sub(visible);
     app.help_scroll = app.help_scroll.min(max_offset);
     let more_below = app.help_scroll < max_offset;
-    let shown = if more_below { visible.saturating_sub(1) } else { visible };
+    let shown = if more_below {
+        visible.saturating_sub(1)
+    } else {
+        visible
+    };
     let mut page: Vec<Line> = lines
         .into_iter()
         .skip(app.help_scroll)

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -7,8 +7,8 @@ impl App {
         let mut entries = self.scope_entries();
 
         match self.sort_order {
-            SortOrder::NewestFirst => entries.sort_by(|a, b| b.start_time.cmp(&a.start_time)),
-            SortOrder::OldestFirst => entries.sort_by(|a, b| a.start_time.cmp(&b.start_time)),
+            SortOrder::NewestFirst => entries.sort_by_key(|e| std::cmp::Reverse(e.start_time)),
+            SortOrder::OldestFirst => entries.sort_by_key(|e| e.start_time),
         }
 
         // OR within a pane's includes, AND across the two; exclusions veto first.

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -50,8 +50,8 @@ impl Theme {
             duration_high: color(&cfg.duration_high, (239, 154, 154)), // Light red
             duration_med: color(&cfg.duration_med, (255, 224, 130)), // Light yellow
             duration_low: color(&cfg.duration_low, (165, 214, 167)), // Light green
-            border: color(&cfg.border, (88, 88, 88)), // Border gray
-            title: color(&cfg.title, (186, 186, 186)), // Light gray
+            border: color(&cfg.border, (88, 88, 88)),    // Border gray
+            title: color(&cfg.title, (186, 186, 186)),   // Light gray
 
             entry_duration_high_h: dur.entry_high_hours.unwrap_or(4),
             entry_duration_med_h: dur.entry_med_hours.unwrap_or(2),

--- a/src/update.rs
+++ b/src/update.rs
@@ -185,7 +185,10 @@ pub fn perform_update(check_only: bool, yes: bool) -> Result<()> {
                 Ok(())
             }
             Some(latest) => {
-                println!("tt {current_version} is up to date (latest: {}).", latest.version);
+                println!(
+                    "tt {current_version} is up to date (latest: {}).",
+                    latest.version
+                );
                 Ok(())
             }
             None => {

--- a/tests/agent_end.rs
+++ b/tests/agent_end.rs
@@ -9,7 +9,6 @@ mod common;
 #[cfg(unix)]
 use common::Mode;
 use common::{Case, StoreRow, clock, logged_duration, now};
-use std::fs;
 
 // --- item ------------------------------------------------------------------
 

--- a/tests/agent_end.rs
+++ b/tests/agent_end.rs
@@ -9,6 +9,10 @@ mod common;
 #[cfg(unix)]
 use common::Mode;
 use common::{Case, StoreRow, clock, logged_duration, now};
+// Only `an_entry_recorded_with_the_mark_left_behind_exits_74` uses this, and it
+// is unix-only — ungated, this import is dead code on Windows.
+#[cfg(unix)]
+use std::fs;
 
 // --- item ------------------------------------------------------------------
 

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -74,16 +74,31 @@ fn nu_returns_the_same_candidates_as_bash() {
     for name in ["start", "stop", "log", "report", "agent", "completions"] {
         assert!(sub.contains(&name.to_string()), "missing {name} in {sub:?}");
     }
-    assert_eq!(complete_nu(&case, &["start", "--project", ""]), complete(&case, 3, &["start", "--project", ""]));
-    assert_eq!(complete_nu(&case, &["agent", "begin", "alpha", ""]), complete(&case, 4, &["agent", "begin", "alpha", ""]));
-    assert_eq!(complete_nu(&case, &["agent", "begin", ""]), complete(&case, 3, &["agent", "begin", ""]));
-    assert_eq!(complete_nu(&case, &["agent", "begin", "alpha", "-", ""]), complete(&case, 5, &["agent", "begin", "alpha", "-", ""]));
+    assert_eq!(
+        complete_nu(&case, &["start", "--project", ""]),
+        complete(&case, 3, &["start", "--project", ""])
+    );
+    assert_eq!(
+        complete_nu(&case, &["agent", "begin", "alpha", ""]),
+        complete(&case, 4, &["agent", "begin", "alpha", ""])
+    );
+    assert_eq!(
+        complete_nu(&case, &["agent", "begin", ""]),
+        complete(&case, 3, &["agent", "begin", ""])
+    );
+    assert_eq!(
+        complete_nu(&case, &["agent", "begin", "alpha", "-", ""]),
+        complete(&case, 5, &["agent", "begin", "alpha", "-", ""])
+    );
 }
 
 #[test]
 fn nu_whitespace_span_completes_like_an_empty_span() {
     let case = seeded("completions-nu-space");
-    assert_eq!(complete_nu(&case, &["start", "--project", " "]), ["alpha", "beta", "gamma"]);
+    assert_eq!(
+        complete_nu(&case, &["start", "--project", " "]),
+        ["alpha", "beta", "gamma"]
+    );
 }
 
 #[test]
@@ -107,8 +122,14 @@ fn project_flag_completes_from_store_and_open_marks() {
 #[test]
 fn issue_positional_is_scoped_to_the_typed_project() {
     let case = seeded("completions-issues-scoped");
-    assert_eq!(complete(&case, 4, &["agent", "begin", "alpha", ""]), ["-", "10", "11"]);
-    assert_eq!(complete(&case, 4, &["agent", "begin", "gamma", ""]), ["-", "30"]);
+    assert_eq!(
+        complete(&case, 4, &["agent", "begin", "alpha", ""]),
+        ["-", "10", "11"]
+    );
+    assert_eq!(
+        complete(&case, 4, &["agent", "begin", "gamma", ""]),
+        ["-", "30"]
+    );
 }
 
 #[test]
@@ -123,7 +144,9 @@ fn phase_positional_completes_the_fixed_vocabulary() {
     let case = seeded("completions-phases");
     assert_eq!(
         complete(&case, 5, &["agent", "begin", "alpha", "10", ""]),
-        ["plan", "impl", "qa", "review", "docs", "spike", "explore", "ops"]
+        [
+            "plan", "impl", "qa", "review", "docs", "spike", "explore", "ops"
+        ]
     );
 }
 
@@ -141,7 +164,10 @@ fn a_completion_run_leaves_the_store_and_its_lock_untouched() {
 
     assert_eq!(fs::metadata(&store).unwrap().modified().unwrap(), before);
     assert_eq!(fs::read_to_string(&store).unwrap(), body_before);
-    assert!(!lock.exists(), "a completion run must not create the store lock");
+    assert!(
+        !lock.exists(),
+        "a completion run must not create the store lock"
+    );
 }
 
 #[test]
@@ -152,7 +178,10 @@ fn the_completions_subcommand_prints_the_same_hook_as_the_env_protocol() {
         sub.assert_status(0);
         let env = case.run_bare_with_env(&[], &[("COMPLETE", shell)]);
         env.assert_status(0);
-        assert!(sub.stdout.contains("COMPLETE"), "{shell}: no COMPLETE in hook");
+        assert!(
+            sub.stdout.contains("COMPLETE"),
+            "{shell}: no COMPLETE in hook"
+        );
         assert_eq!(sub.stdout, env.stdout, "{shell}: the two surfaces diverge");
     }
 }
@@ -162,7 +191,12 @@ fn an_unknown_shell_is_an_error_naming_the_choices() {
     let case = Case::new("completions-unknown-shell");
     let run = case.run_bare_with_env(&["completions"], &[("SHELL", "/bin/tcsh")]);
     assert_ne!(run.status, Some(0));
-    assert!(run.stderr.contains("bash, elvish, fish, nu, powershell, zsh"), "{}", run.stderr);
+    assert!(
+        run.stderr
+            .contains("bash, elvish, fish, nu, powershell, zsh"),
+        "{}",
+        run.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #32. Unblocks #33, #37, #39 and #54.

Nothing in CI ran the test suite, `cargo fmt --check` or `cargo clippy` — only `cargo build --release`, and only on the paths leading to a release. 322 tests and every lint were advisory.

## The gate

A `check` job on Ubuntu, running on every pull request and every push to main:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Ubuntu alone — `build` already covers cross-platform compilation and none of these three is platform-dependent. `--all-targets` so the lint covers `tests/` too.

## The drift it had allowed

Cleared in this PR so the job is green on its first run:

- **`cargo fmt` over 12 files.** The issue listed 9; the list had gone stale since #48/#51/#53 landed. `tracker.rs`, `search.rs` and `panes.rs` were already clean, while `completions.rs`, `agent.rs`, `tui/mod.rs`, `tui/render.rs` and `tests/completions.rs` had drifted in.
- **9 clippy findings** (issue said 8; the ninth is in `tests/agent_end.rs`, which `--all-targets` reaches):
  - 5 collapsible-`if` → let-chains, which edition 2024 allows
  - 2 `sort_by` → `sort_by_key` in `tui/search.rs`
  - unused `use std::fs` in `tests/agent_end.rs`
  - `build_entry_fields`'s four-tuple return → a named `EntryFields` alias

## Verification

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` exits 0, and **all 322 tests pass** — unchanged, none skipped.

No behaviour change. The collapsed `if`s short-circuit exactly as the nested ones did.

## One thing to look at

`src/tui/mod.rs` shows ~387 changed lines, but that is re-indentation from un-nesting the key dispatch. Under `git diff -w` it is **12 insertions, 7 deletions**. Reviewing that file with whitespace ignored will be much faster.

## Deliberately not done

**The `release` job is not gated on `check`.** This PR adds the gate the issue asked for and leaves the release path's trigger logic alone, since that `if:` chain is intricate and changing what can publish a release deserves its own decision. As it stands a `v*` tag can still produce a release without `check` having passed. Happy to wire `check` into `release`'s `needs` as a follow-up if you want that closed.