### PR TITLE
refactor(config): cache the resolved config per path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,9 +9,10 @@
 /// shared/base config kept elsewhere.
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 #[derive(Debug, Default, Deserialize)]
 struct RawConfig {
@@ -115,18 +116,43 @@ pub struct Config {
     pub general: GeneralConfig,
 }
 
-/// Loads the user's config file, if any. Missing file -> defaults. A
+/// Resolved configs, keyed on the config path they were read from (`None` =
+/// no config path available). Keyed rather than a single `OnceLock` because
+/// tests repoint `TT_CONFIG_FILE` per sandbox — see `storage::env_sandbox` —
+/// and a process-global single slot would serve the first sandbox's config to
+/// every later one. Entries are leaked so callers get `&'static Config`; the
+/// key set is one path per process in a real run.
+static CACHE: OnceLock<Mutex<HashMap<Option<PathBuf>, &'static Config>>> = OnceLock::new();
+
+/// Loads the user's config file, if any, and caches the resolved result so
+/// repeat callers (the audit entry points, the TUI, `list`) do not re-read and
+/// re-parse the whole `include` chain. Missing file -> defaults. A
 /// present-but-invalid file prints a warning to stderr and falls back to
 /// defaults, rather than failing the whole command.
-pub fn load() -> Config {
-    let Some(path) = config_path() else {
+pub fn load() -> &'static Config {
+    let key = config_path();
+    let mut cache = CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(config) = cache.get(&key) {
+        return config;
+    }
+    let config: &'static Config = Box::leak(Box::new(read(key.as_deref())));
+    cache.insert(key, config);
+    config
+}
+
+/// The uncached read behind [`load`].
+fn read(path: Option<&Path>) -> Config {
+    let Some(path) = path else {
         return Config::default();
     };
     if !path.exists() {
         return Config::default();
     }
 
-    match load_raw(&path, &mut HashSet::new()) {
+    match load_raw(path, &mut HashSet::new()) {
         Ok(raw) => Config {
             theme: raw.theme.unwrap_or_default(),
             icons: raw.icons.unwrap_or_default(),
@@ -521,6 +547,33 @@ mod tests {
         let saved = load();
         assert_eq!(saved.general.onboarding, Some(false));
         drop(dir);
+    }
+
+    /// The cache is keyed on the resolved config path, not a single global
+    /// slot: repointing `TT_CONFIG_FILE` (as every sandboxed test does) must
+    /// still read the new file rather than serve the first one loaded.
+    #[test]
+    fn the_cache_is_keyed_on_the_config_path() {
+        let _guard = crate::storage::env_guard();
+
+        let first = crate::storage::env_sandbox("config-cache-key-first");
+        let path = config_path().expect("a config path");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "[list]\ndefault_limit = 7\n").unwrap();
+        assert_eq!(load().list.default_limit, Some(7));
+
+        let second = crate::storage::env_sandbox("config-cache-key-second");
+        let path = config_path().expect("a config path");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "[list]\ndefault_limit = 9\n").unwrap();
+        assert_eq!(load().list.default_limit, Some(9));
+
+        // Back to the first path: served from the cache, same value.
+        unsafe { std::env::set_var("TT_CONFIG_FILE", first.join("config.toml")) };
+        assert_eq!(load().list.default_limit, Some(7));
+
+        drop(first);
+        drop(second);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -103,7 +103,7 @@ impl App {
     /// `for_interactive_run` instead.
     #[cfg_attr(not(test), allow(dead_code))]
     fn new() -> Result<Self> {
-        Self::from_config(&crate::config::load())
+        Self::from_config(crate::config::load())
     }
 
     /// The blessed constructor for a real run: any future production entry
@@ -111,7 +111,7 @@ impl App {
     /// something each call site has to remember to bolt on.
     fn for_interactive_run(update_notice: Option<String>) -> Result<Self> {
         let config = crate::config::load();
-        let mut app = Self::from_config(&config)?;
+        let mut app = Self::from_config(config)?;
         if crate::config::should_onboard(&config.general) {
             app.input_mode = InputMode::Onboarding;
         }


### PR DESCRIPTION
Closes #36

## What

`config::load()` read the config file, parsed the TOML and walked/merged the whole `include` chain on every call, returning a fresh owned `Config`. `src/audit.rs` alone calls it from four entry points that call each other, so a single `tt agent audit` re-read and re-parsed the config several times; `cli::list`, `App::from_config`, `icons` and `theme` read it again.

`load()` now returns `&''static Config` from a cache.

## Approach: per-path cache, not a single OnceLock

The cache is `OnceLock<Mutex<HashMap<Option<PathBuf>, &''static Config>>>` keyed on the resolved config path (`None` = no config path available), with entries leaked via `Box::leak` so callers get `&''static`.

A single process-global slot would have been less code but would break the test suite: `storage::env_sandbox` (src/storage.rs:139) repoints `TT_CONFIG_FILE` at a fresh directory per sandbox, and several tests rely on `load()` picking that up. The first sandbox to load would then have served its config to every later one. A `#[cfg(test)] reset_cache()` escape hatch would have papered over that with test-only code; keying on the path is barely more code and keeps production and test behaviour identical. In a real run the key set is a single path, so the map costs one lookup.

A new test (`the_cache_is_keyed_on_the_config_path`) pins that: two sandboxes with different `default_limit` values each read their own file, and going back to the first serves its value again.

Known, accepted limitation: a config file rewritten at the same path within one process still serves the cached value. Nothing in the codebase re-reads after `save_onboarding` (which runs on the TUI''s way out), and no test does either.

## Call sites

All existing call sites took the value by reference or copied a `Copy` field, so `&''static Config` needed no churn beyond dropping two now-needless borrows in `src/tui/mod.rs`.

## Files changed

- `src/config.rs` — `CACHE` static, `load()` returns `&''static Config`, uncached body split into `read()`, new keying test
- `src/tui/mod.rs` — two `&config` -> `config`

## Status

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass (325 tests, 0 failed). No test was weakened or removed.