### PR TITLE
refactor(tui): extract a shared TextInput for form fields and search

### DIFF
--- a/src/tui/entry_form.rs
+++ b/src/tui/entry_form.rs
@@ -1,4 +1,5 @@
 use super::App;
+use super::text_input::TextInput;
 use super::types::{InputField, InputMode, ViewMode};
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate};
@@ -22,25 +23,22 @@ impl App {
         }
         self.input_mode = InputMode::AddingEntry;
         self.input_field = InputField::Description;
-        self.input_description.clear();
-        self.input_project.clear();
-        self.input_tags.clear();
-        self.input_start_time.clear();
-        self.input_end_time.clear();
-        self.input_duration.clear();
-        self.cursor_pos = 0;
+        self.clear_form_fields();
     }
 
     pub(crate) fn cancel_adding(&mut self) {
         self.input_mode = InputMode::Normal;
+        self.clear_form_fields();
+        self.editing_entry_id = None;
+    }
+
+    fn clear_form_fields(&mut self) {
         self.input_description.clear();
         self.input_project.clear();
         self.input_tags.clear();
         self.input_start_time.clear();
         self.input_end_time.clear();
         self.input_duration.clear();
-        self.editing_entry_id = None;
-        self.cursor_pos = 0;
     }
 
     pub(crate) fn start_editing(&mut self) {
@@ -65,15 +63,14 @@ impl App {
 
         if let Some((id, description, project, tags, start_time, end_time, duration)) = entry_data {
             self.editing_entry_id = Some(id);
-            self.input_description = description;
-            self.input_project = project;
-            self.input_tags = tags;
-            self.input_start_time = start_time;
-            self.input_end_time = end_time.unwrap_or_default();
-            self.input_duration = duration.unwrap_or_default();
+            self.input_description.set_from(&description);
+            self.input_project.set_from(&project);
+            self.input_tags.set_from(&tags);
+            self.input_start_time.set_from(&start_time);
+            self.input_end_time.set_from(&end_time.unwrap_or_default());
+            self.input_duration.set_from(&duration.unwrap_or_default());
             self.input_mode = InputMode::EditingEntry;
             self.input_field = InputField::Description;
-            self.cursor_pos = self.input_description.chars().count();
         }
     }
 
@@ -86,7 +83,7 @@ impl App {
         }
         let (start_time, end_time) = self.resolve_times()?;
         Some((
-            self.input_description.clone(),
+            self.input_description.value().to_string(),
             self.parse_tags(),
             start_time,
             end_time,
@@ -133,7 +130,7 @@ impl App {
             InputField::StartTime => InputField::EndTime,
             InputField::EndTime => InputField::Description,
         };
-        self.cursor_pos = self.active_field_input().chars().count();
+        self.field_mut().cursor_to_end();
     }
 
     pub(crate) fn prev_input_field(&mut self) {
@@ -147,112 +144,53 @@ impl App {
             InputField::StartTime => InputField::Duration,
             InputField::EndTime => InputField::StartTime,
         };
-        self.cursor_pos = self.active_field_input().chars().count();
+        self.field_mut().cursor_to_end();
     }
 
     pub(crate) fn handle_input_char(&mut self, c: char) {
-        let pos = self.cursor_pos;
-        let s = match self.input_field {
-            InputField::Description => &mut self.input_description,
-            InputField::Project => &mut self.input_project,
-            InputField::Tags => &mut self.input_tags,
-            InputField::StartTime => &mut self.input_start_time,
-            InputField::EndTime => &mut self.input_end_time,
-            InputField::Duration => &mut self.input_duration,
-        };
-        let byte_idx = s.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(s.len());
-        s.insert(byte_idx, c);
-        self.cursor_pos += 1;
+        self.field_mut().insert(c);
     }
 
     pub(crate) fn handle_input_backspace(&mut self) {
-        let pos = self.cursor_pos;
-        let s = match self.input_field {
-            InputField::Description => &mut self.input_description,
-            InputField::Project => &mut self.input_project,
-            InputField::Tags => &mut self.input_tags,
-            InputField::StartTime => &mut self.input_start_time,
-            InputField::EndTime => &mut self.input_end_time,
-            InputField::Duration => &mut self.input_duration,
-        };
-        let actual_pos = pos.min(s.chars().count());
-        if actual_pos == 0 {
-            return;
-        }
-        let byte_start = s
-            .char_indices()
-            .nth(actual_pos - 1)
-            .map(|(i, _)| i)
-            .unwrap_or(s.len());
-        let byte_end = s
-            .char_indices()
-            .nth(actual_pos)
-            .map(|(i, _)| i)
-            .unwrap_or(s.len());
-        s.drain(byte_start..byte_end);
-        self.cursor_pos = actual_pos - 1;
+        self.field_mut().backspace();
     }
 
     // ── Cursor movement ───────────────────────────────────────────────────────
 
-    /// Returns the text of the currently active form field (not search).
-    pub(crate) fn active_field_input(&self) -> &str {
+    /// The one place the `InputField` -> field mapping lives.
+    pub(crate) fn field_mut(&mut self) -> &mut TextInput {
         match self.input_field {
-            InputField::Description => &self.input_description,
-            InputField::Project => &self.input_project,
-            InputField::Tags => &self.input_tags,
-            InputField::StartTime => &self.input_start_time,
-            InputField::EndTime => &self.input_end_time,
-            InputField::Duration => &self.input_duration,
+            InputField::Description => &mut self.input_description,
+            InputField::Project => &mut self.input_project,
+            InputField::Tags => &mut self.input_tags,
+            InputField::StartTime => &mut self.input_start_time,
+            InputField::EndTime => &mut self.input_end_time,
+            InputField::Duration => &mut self.input_duration,
         }
     }
 
-    /// The active input's text in any mode — form field or search bar.
-    fn active_input(&self) -> &str {
+    /// The active input in any mode — form field or search bar.
+    pub(crate) fn active_input(&mut self) -> &mut TextInput {
         match self.input_mode {
-            super::types::InputMode::Searching => &self.search_term,
-            _ => self.active_field_input(),
+            InputMode::Searching => &mut self.search_term,
+            _ => self.field_mut(),
         }
     }
 
     pub(crate) fn move_cursor_left(&mut self) {
-        let clamped = self.cursor_pos.min(self.active_input().chars().count());
-        self.cursor_pos = clamped.saturating_sub(1);
+        self.active_input().left();
     }
 
     pub(crate) fn move_cursor_right(&mut self) {
-        let len = self.active_input().chars().count();
-        let clamped = self.cursor_pos.min(len);
-        self.cursor_pos = (clamped + 1).min(len);
+        self.active_input().right();
     }
 
-    /// Jump left past whitespace/punctuation, then past the preceding word.
     pub(crate) fn move_cursor_word_left(&mut self) {
-        let input = self.active_input().to_string();
-        let chars: Vec<char> = input.chars().collect();
-        let mut pos = self.cursor_pos.min(chars.len());
-        while pos > 0 && !chars[pos - 1].is_alphanumeric() {
-            pos -= 1;
-        }
-        while pos > 0 && chars[pos - 1].is_alphanumeric() {
-            pos -= 1;
-        }
-        self.cursor_pos = pos;
+        self.active_input().word_left();
     }
 
-    /// Jump right past the current word, then past any trailing whitespace/punctuation.
     pub(crate) fn move_cursor_word_right(&mut self) {
-        let input = self.active_input().to_string();
-        let chars: Vec<char> = input.chars().collect();
-        let len = chars.len();
-        let mut pos = self.cursor_pos.min(len);
-        while pos < len && chars[pos].is_alphanumeric() {
-            pos += 1;
-        }
-        while pos < len && !chars[pos].is_alphanumeric() {
-            pos += 1;
-        }
-        self.cursor_pos = pos;
+        self.active_input().word_right();
     }
 
     // ── Time resolution ──────────────────────────────────────────────────────
@@ -261,17 +199,17 @@ impl App {
     /// Start+End, End+Duration, Duration only (ends now), Start only (still active).
     pub(crate) fn resolve_times(&self) -> Option<(DateTime<Local>, Option<DateTime<Local>>)> {
         let start = if !self.input_start_time.is_empty() {
-            self.parse_time_str(&self.input_start_time)
+            self.parse_time_str(self.input_start_time.value())
         } else {
             None
         };
         let end = if !self.input_end_time.is_empty() {
-            self.parse_time_str(&self.input_end_time)
+            self.parse_time_str(self.input_end_time.value())
         } else {
             None
         };
         let dur = if !self.input_duration.is_empty() {
-            let d = crate::duration::parse(&self.input_duration);
+            let d = crate::duration::parse(self.input_duration.value());
             if d.num_seconds() > 0 { Some(d) } else { None }
         } else {
             None
@@ -300,9 +238,9 @@ impl App {
     /// Tabbing off Start / End / Duration derives whichever of the other two is still
     /// blank, preferring to adjust the field the user did not just leave.
     pub(crate) fn apply_time_calculations(&mut self, leaving_field: InputField) {
-        let start_str = self.input_start_time.clone();
-        let end_str = self.input_end_time.clone();
-        let dur_str = self.input_duration.clone();
+        let start_str = self.input_start_time.value().to_string();
+        let end_str = self.input_end_time.value().to_string();
+        let dur_str = self.input_duration.value().to_string();
 
         let start = if !start_str.is_empty() {
             self.parse_time_str(&start_str)
@@ -324,31 +262,36 @@ impl App {
         match leaving_field {
             InputField::StartTime => {
                 if let (Some(s), Some(d)) = (start, dur) {
-                    self.input_end_time = (s + d).format("%Y-%m-%d %H:%M").to_string();
+                    self.input_end_time
+                        .set_from(&(s + d).format("%Y-%m-%d %H:%M").to_string());
                 } else if let (Some(s), Some(e), None) = (start, end, dur) {
                     let diff = e.signed_duration_since(s);
                     if diff.num_seconds() > 0 {
-                        self.input_duration = crate::duration::format(diff);
+                        self.input_duration.set_from(&crate::duration::format(diff));
                     }
                 }
             }
             InputField::EndTime => {
                 if let (Some(_s), Some(e), Some(d)) = (start, end, dur) {
-                    self.input_start_time = (e - d).format("%Y-%m-%d %H:%M").to_string();
+                    self.input_start_time
+                        .set_from(&(e - d).format("%Y-%m-%d %H:%M").to_string());
                 } else if let (Some(s), Some(e), None) = (start, end, dur) {
                     let diff = e.signed_duration_since(s);
                     if diff.num_seconds() > 0 {
-                        self.input_duration = crate::duration::format(diff);
+                        self.input_duration.set_from(&crate::duration::format(diff));
                     }
                 } else if let (None, Some(e), Some(d)) = (start, end, dur) {
-                    self.input_start_time = (e - d).format("%Y-%m-%d %H:%M").to_string();
+                    self.input_start_time
+                        .set_from(&(e - d).format("%Y-%m-%d %H:%M").to_string());
                 }
             }
             InputField::Duration => {
                 if let (Some(s), Some(d)) = (start, dur) {
-                    self.input_end_time = (s + d).format("%Y-%m-%d %H:%M").to_string();
+                    self.input_end_time
+                        .set_from(&(s + d).format("%Y-%m-%d %H:%M").to_string());
                 } else if let (None, Some(e), Some(d)) = (start, end, dur) {
-                    self.input_start_time = (e - d).format("%Y-%m-%d %H:%M").to_string();
+                    self.input_start_time
+                        .set_from(&(e - d).format("%Y-%m-%d %H:%M").to_string());
                 }
             }
             _ => {}
@@ -456,7 +399,7 @@ impl App {
 
     /// The project as typed, trimmed; an empty field means "no project".
     fn parse_project(&self) -> Option<String> {
-        let project = self.input_project.trim();
+        let project = self.input_project.value().trim();
         if project.is_empty() {
             None
         } else {
@@ -466,6 +409,7 @@ impl App {
 
     fn parse_tags(&self) -> Vec<String> {
         self.input_tags
+            .value()
             .split_whitespace()
             .map(|s| s.trim_start_matches('#').to_string())
             .filter(|s| !s.is_empty())

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,6 +14,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend, widgets::TableState};
 use std::io::{self, Stdout};
+use text_input::TextInput;
 
 mod entry_form;
 mod marks_surface;
@@ -23,6 +24,7 @@ mod panes;
 mod render;
 mod search;
 mod summary;
+mod text_input;
 pub mod theme;
 pub mod types;
 
@@ -41,13 +43,13 @@ pub(crate) struct App {
     /// Top row of the help popup; clamped by the renderer, so it may run ahead.
     pub(crate) help_scroll: usize,
     pub(crate) input_field: InputField,
-    pub(crate) input_description: String,
-    pub(crate) input_project: String,
-    pub(crate) input_tags: String,
-    pub(crate) input_start_time: String,
-    pub(crate) input_end_time: String,
-    pub(crate) input_duration: String,
-    pub(crate) search_term: String,
+    pub(crate) input_description: TextInput,
+    pub(crate) input_project: TextInput,
+    pub(crate) input_tags: TextInput,
+    pub(crate) input_start_time: TextInput,
+    pub(crate) input_end_time: TextInput,
+    pub(crate) input_duration: TextInput,
+    pub(crate) search_term: TextInput,
     /// Each pane's tri-state filter. OR within a pane's includes, AND across the two.
     pub(crate) project_filter: panes::PaneFilter,
     pub(crate) tag_filter: panes::PaneFilter,
@@ -55,8 +57,6 @@ pub(crate) struct App {
     /// What `InputMode::Confirm` is asking about: the action, entry and origin mode.
     pub(crate) pending_confirm: Option<PendingConfirm>,
     pub(crate) sort_order: SortOrder,
-    /// Cursor position in the active input field — a char index, not a byte index.
-    pub(crate) cursor_pos: usize,
     /// Fingerprint of the store as of the last load, so a tick can skip the read.
     pub(crate) store_stamp: Option<PathStamp>,
     /// The open agent phase marks, newest first, so a frame never reads the directory.
@@ -140,19 +140,18 @@ impl App {
             input_mode: InputMode::Normal,
             help_scroll: 0,
             input_field: InputField::Description,
-            input_description: String::new(),
-            input_project: String::new(),
-            input_tags: String::new(),
-            input_start_time: String::new(),
-            input_end_time: String::new(),
-            input_duration: String::new(),
-            search_term: String::new(),
+            input_description: TextInput::default(),
+            input_project: TextInput::default(),
+            input_tags: TextInput::default(),
+            input_start_time: TextInput::default(),
+            input_end_time: TextInput::default(),
+            input_duration: TextInput::default(),
+            search_term: TextInput::default(),
             project_filter: panes::PaneFilter::default(),
             tag_filter: panes::PaneFilter::default(),
             editing_entry_id: None,
             pending_confirm: None,
             sort_order: SortOrder::NewestFirst,
-            cursor_pos: 0,
             show_projects: layout.show_projects.unwrap_or(false),
             show_tags: layout.show_tags.unwrap_or(false),
             show_marks: layout.show_agents.unwrap_or(false),
@@ -704,8 +703,8 @@ mod tests {
         assert_eq!(agent_id, 1);
 
         app.start_adding();
-        app.input_description = "from the tui".to_string();
-        app.input_duration = "15m".to_string();
+        app.input_description.set_from("from the tui");
+        app.input_duration.set_from("15m");
         app.submit_entry().unwrap();
 
         let data = on_disk();
@@ -763,10 +762,10 @@ mod tests {
             InputMode::Searching,
         ] {
             app.input_mode = mode;
-            app.input_description = "half typed".to_string();
+            app.input_description.set_from("half typed");
             app.sync_from_store().unwrap();
             assert_eq!(descriptions(&app.data), vec!["first"]);
-            assert_eq!(app.input_description, "half typed");
+            assert_eq!(app.input_description.value(), "half typed");
         }
 
         // …and the change is picked up once the mode is Normal again.
@@ -897,7 +896,7 @@ mod tests {
         agent_write("probe");
         select(&mut app, "before");
         app.start_editing();
-        app.input_description = "after".to_string();
+        app.input_description.set_from("after");
         app.submit_edit().unwrap();
 
         let data = on_disk();
@@ -914,15 +913,15 @@ mod tests {
 
         let mut app = App::new().unwrap();
         app.start_adding();
-        app.input_description = "with a project".to_string();
-        app.input_project = "  acme  ".to_string();
-        app.input_duration = "15m".to_string();
+        app.input_description.set_from("with a project");
+        app.input_project.set_from("  acme  ");
+        app.input_duration.set_from("15m");
         app.submit_entry().unwrap();
 
         app.start_adding();
-        app.input_description = "without one".to_string();
-        app.input_project = "   ".to_string();
-        app.input_duration = "15m".to_string();
+        app.input_description.set_from("without one");
+        app.input_project.set_from("   ");
+        app.input_duration.set_from("15m");
         app.submit_entry().unwrap();
 
         let data = on_disk();
@@ -1067,7 +1066,7 @@ mod tests {
         let before = app.pane_values(Pane::Tags);
 
         app.tag_filter.cycle("plan", true);
-        app.search_term = "nothing matches this".to_string();
+        app.search_term.set_from("nothing matches this");
         assert!(app.filtered_entries().is_empty(), "filter did not bite");
         assert_eq!(app.pane_values(Pane::Tags), before);
         assert_eq!(app.pane_values(Pane::Projects).len(), 2);
@@ -2770,7 +2769,7 @@ mod tests {
         );
         assert_eq!(app.project_summary(), before);
 
-        app.search_term = "nothing matches this".to_string();
+        app.search_term.set_from("nothing matches this");
         assert!(app.filtered_entries().is_empty());
         assert_eq!(app.project_summary(), before);
     }
@@ -2972,7 +2971,7 @@ mod tests {
             "2h 0m",     // the formatted duration
             &today.format("%Y-%m-%d").to_string(),
         ] {
-            app.search_term = needle.to_string();
+            app.search_term.set_from(needle);
             let view = in_view(&app);
             assert!(
                 view.contains(&"wrote the migration".to_string()),
@@ -2981,9 +2980,9 @@ mod tests {
         }
 
         // The date matches both entries; every other needle above is unique to one.
-        app.search_term = "loremind".to_string();
+        app.search_term.set_from("loremind");
         assert_eq!(in_view(&app), vec!["wrote the migration"]);
-        app.search_term = "no such thing".to_string();
+        app.search_term.set_from("no such thing");
         assert!(in_view(&app).is_empty());
     }
 
@@ -2999,9 +2998,9 @@ mod tests {
         let mut app = App::new().unwrap();
         select(&mut app, "has a project");
         app.start_editing();
-        assert_eq!(app.input_project, "acme");
+        assert_eq!(app.input_project.value(), "acme");
 
-        app.input_project = "beta".to_string();
+        app.input_project.set_from("beta");
         app.submit_edit().unwrap();
         assert_eq!(on_disk().entries[0].project, Some("beta".to_string()));
 

--- a/src/tui/render/form.rs
+++ b/src/tui/render/form.rs
@@ -36,7 +36,7 @@ pub(super) fn render_search_bar(f: &mut Frame, app: &App, area: Rect) {
     let search_text = if is_active && app.search_term.is_empty() {
         "Type to search... (Enter to confirm, Esc to clear)"
     } else {
-        &app.search_term
+        app.search_term.value()
     };
 
     let search_input = Paragraph::new(search_text)
@@ -49,14 +49,8 @@ pub(super) fn render_search_bar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(search_input, area);
 
     if is_active {
-        let byte_idx = app
-            .search_term
-            .char_indices()
-            .nth(app.cursor_pos)
-            .map(|(i, _)| i)
-            .unwrap_or(app.search_term.len());
         f.set_cursor_position((
-            area.x + Line::from(&app.search_term[..byte_idx]).width() as u16 + 1,
+            area.x + Line::from(app.search_term.before_cursor()).width() as u16 + 1,
             area.y + 1,
         ));
     }
@@ -113,60 +107,48 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
 
     let active = app.input_field;
 
-    f.render_widget(
-        Paragraph::new(app.input_description.as_str())
-            .style(Style::default().fg(Color::White))
-            .block(field_block(
-                " Description ",
-                active == InputField::Description,
-            )),
-        chunks[0],
-    );
-    f.render_widget(
-        Paragraph::new(app.input_project.as_str())
-            .style(Style::default().fg(Color::White))
-            .block(field_block(
-                " Project (optional: single name, e.g. acme) ",
-                active == InputField::Project,
-            )),
-        chunks[1],
-    );
-    f.render_widget(
-        Paragraph::new(app.input_tags.as_str())
-            .style(Style::default().fg(Color::White))
-            .block(field_block(
-                " Tags (space-separated, e.g., work meeting) ",
-                active == InputField::Tags,
-            )),
-        chunks[2],
-    );
-    f.render_widget(
-        Paragraph::new(app.input_duration.as_str())
-            .style(Style::default().fg(Color::White))
-            .block(field_block(
-                " Duration (optional: 1h30m, 45m, 2h) ",
-                active == InputField::Duration,
-            )),
-        chunks[3],
-    );
-    f.render_widget(
-        Paragraph::new(app.input_start_time.as_str())
-            .style(Style::default().fg(Color::White))
-            .block(field_block(
-                " Start Time (e.g. 9am, 14:30, 25/03 9.30am) ",
-                active == InputField::StartTime,
-            )),
-        chunks[4],
-    );
-    f.render_widget(
-        Paragraph::new(app.input_end_time.as_str())
-            .style(Style::default().fg(Color::White))
-            .block(field_block(
-                " End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ",
-                active == InputField::EndTime,
-            )),
-        chunks[5],
-    );
+    // In chunk order, which is also the Tab order.
+    let fields = [
+        (
+            InputField::Description,
+            &app.input_description,
+            " Description ",
+        ),
+        (
+            InputField::Project,
+            &app.input_project,
+            " Project (optional: single name, e.g. acme) ",
+        ),
+        (
+            InputField::Tags,
+            &app.input_tags,
+            " Tags (space-separated, e.g., work meeting) ",
+        ),
+        (
+            InputField::Duration,
+            &app.input_duration,
+            " Duration (optional: 1h30m, 45m, 2h) ",
+        ),
+        (
+            InputField::StartTime,
+            &app.input_start_time,
+            " Start Time (e.g. 9am, 14:30, 25/03 9.30am) ",
+        ),
+        (
+            InputField::EndTime,
+            &app.input_end_time,
+            " End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ",
+        ),
+    ];
+
+    for (i, (field, input, label)) in fields.into_iter().enumerate() {
+        f.render_widget(
+            Paragraph::new(input.value())
+                .style(Style::default().fg(Color::White))
+                .block(field_block(label, active == field)),
+            chunks[i],
+        );
+    }
 
     let help = Paragraph::new(Line::from(vec![
         Span::styled("Tab", Style::default().fg(theme::accent())),
@@ -191,39 +173,12 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
     );
     f.render_widget(help, chunks[6]);
 
-    let cursor_text_width = |text: &str, pos: usize| -> u16 {
-        let byte_idx = text
-            .char_indices()
-            .nth(pos)
-            .map(|(i, _)| i)
-            .unwrap_or(text.len());
-        Line::from(&text[..byte_idx]).width() as u16
-    };
-    let (cursor_x, cursor_y) = match app.input_field {
-        InputField::Description => (
-            chunks[0].x + cursor_text_width(&app.input_description, app.cursor_pos) + 1,
-            chunks[0].y + 1,
-        ),
-        InputField::Project => (
-            chunks[1].x + cursor_text_width(&app.input_project, app.cursor_pos) + 1,
-            chunks[1].y + 1,
-        ),
-        InputField::Tags => (
-            chunks[2].x + cursor_text_width(&app.input_tags, app.cursor_pos) + 1,
-            chunks[2].y + 1,
-        ),
-        InputField::Duration => (
-            chunks[3].x + cursor_text_width(&app.input_duration, app.cursor_pos) + 1,
-            chunks[3].y + 1,
-        ),
-        InputField::StartTime => (
-            chunks[4].x + cursor_text_width(&app.input_start_time, app.cursor_pos) + 1,
-            chunks[4].y + 1,
-        ),
-        InputField::EndTime => (
-            chunks[5].x + cursor_text_width(&app.input_end_time, app.cursor_pos) + 1,
-            chunks[5].y + 1,
-        ),
-    };
-    f.set_cursor_position((cursor_x, cursor_y));
+    if let Some((i, (_, input, _))) = fields
+        .into_iter()
+        .enumerate()
+        .find(|(_, (field, _, _))| *field == active)
+    {
+        let width = Line::from(input.before_cursor()).width() as u16;
+        f.set_cursor_position((chunks[i].x + width + 1, chunks[i].y + 1));
+    }
 }

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -21,7 +21,7 @@ impl App {
         if self.search_term.is_empty() {
             entries
         } else {
-            let search_lower = self.search_term.to_lowercase();
+            let search_lower = self.search_term.value().to_lowercase();
             entries
                 .into_iter()
                 .filter(|e| e.matches_search(&search_lower))
@@ -58,49 +58,22 @@ impl App {
 
     pub(crate) fn start_search(&mut self) {
         self.input_mode = InputMode::Searching;
-        self.cursor_pos = self.search_term.chars().count();
+        self.search_term.cursor_to_end();
     }
 
     pub(crate) fn clear_search(&mut self) {
         self.search_term.clear();
         self.input_mode = InputMode::Normal;
-        self.cursor_pos = 0;
         self.table_state.select(Some(0));
     }
 
     pub(crate) fn handle_search_char(&mut self, c: char) {
-        let pos = self.cursor_pos;
-        let byte_idx = self
-            .search_term
-            .char_indices()
-            .nth(pos)
-            .map(|(i, _)| i)
-            .unwrap_or(self.search_term.len());
-        self.search_term.insert(byte_idx, c);
-        self.cursor_pos += 1;
+        self.search_term.insert(c);
         self.table_state.select(Some(0));
     }
 
     pub(crate) fn handle_search_backspace(&mut self) {
-        let pos = self.cursor_pos;
-        let actual_pos = pos.min(self.search_term.chars().count());
-        if actual_pos == 0 {
-            return;
-        }
-        let byte_start = self
-            .search_term
-            .char_indices()
-            .nth(actual_pos - 1)
-            .map(|(i, _)| i)
-            .unwrap_or(self.search_term.len());
-        let byte_end = self
-            .search_term
-            .char_indices()
-            .nth(actual_pos)
-            .map(|(i, _)| i)
-            .unwrap_or(self.search_term.len());
-        self.search_term.drain(byte_start..byte_end);
-        self.cursor_pos = actual_pos - 1;
+        self.search_term.backspace();
         self.table_state.select(Some(0));
     }
 

--- a/src/tui/text_input.rs
+++ b/src/tui/text_input.rs
@@ -1,0 +1,219 @@
+/// A single-line editable string with a cursor held as a *char* index.
+/// Shared by the six entry-form fields and the search bar.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TextInput {
+    value: String,
+    /// Char index, not a byte index; clamped to the value's length on use.
+    cursor: usize,
+}
+
+impl TextInput {
+    pub(crate) fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.value.is_empty()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.value.clear();
+        self.cursor = 0;
+    }
+
+    /// Replace the text, leaving the cursor at the end.
+    pub(crate) fn set_from(&mut self, s: &str) {
+        self.value.clear();
+        self.value.push_str(s);
+        self.cursor_to_end();
+    }
+
+    pub(crate) fn cursor_to_end(&mut self) {
+        self.cursor = self.value.chars().count();
+    }
+
+    /// The text left of the cursor — what the renderer measures to place it.
+    pub(crate) fn before_cursor(&self) -> &str {
+        &self.value[..self.byte_idx(self.cursor)]
+    }
+
+    pub(crate) fn insert(&mut self, c: char) {
+        let at = self.byte_idx(self.cursor);
+        self.value.insert(at, c);
+        self.cursor += 1;
+    }
+
+    pub(crate) fn backspace(&mut self) {
+        let pos = self.clamped();
+        if pos == 0 {
+            return;
+        }
+        let start = self.byte_idx(pos - 1);
+        let end = self.byte_idx(pos);
+        self.value.drain(start..end);
+        self.cursor = pos - 1;
+    }
+
+    pub(crate) fn left(&mut self) {
+        self.cursor = self.clamped().saturating_sub(1);
+    }
+
+    pub(crate) fn right(&mut self) {
+        let len = self.value.chars().count();
+        self.cursor = (self.clamped() + 1).min(len);
+    }
+
+    /// Jump left past whitespace/punctuation, then past the preceding word.
+    pub(crate) fn word_left(&mut self) {
+        let chars: Vec<char> = self.value.chars().collect();
+        let mut pos = self.cursor.min(chars.len());
+        while pos > 0 && !chars[pos - 1].is_alphanumeric() {
+            pos -= 1;
+        }
+        while pos > 0 && chars[pos - 1].is_alphanumeric() {
+            pos -= 1;
+        }
+        self.cursor = pos;
+    }
+
+    /// Jump right past the current word, then past any trailing whitespace/punctuation.
+    pub(crate) fn word_right(&mut self) {
+        let chars: Vec<char> = self.value.chars().collect();
+        let len = chars.len();
+        let mut pos = self.cursor.min(len);
+        while pos < len && chars[pos].is_alphanumeric() {
+            pos += 1;
+        }
+        while pos < len && !chars[pos].is_alphanumeric() {
+            pos += 1;
+        }
+        self.cursor = pos;
+    }
+
+    fn clamped(&self) -> usize {
+        self.cursor.min(self.value.chars().count())
+    }
+
+    /// Byte offset of char index `pos`, or the end of the string past the last char.
+    fn byte_idx(&self, pos: usize) -> usize {
+        self.value
+            .char_indices()
+            .nth(pos)
+            .map(|(i, _)| i)
+            .unwrap_or(self.value.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TextInput;
+
+    fn input(s: &str, cursor: usize) -> TextInput {
+        let mut t = TextInput::default();
+        t.set_from(s);
+        t.cursor = cursor;
+        t
+    }
+
+    #[test]
+    fn set_from_puts_cursor_at_end() {
+        let t = input("hello", 5);
+        assert_eq!(t.value(), "hello");
+        assert_eq!(t.cursor, 5);
+    }
+
+    #[test]
+    fn insert_at_cursor() {
+        let mut t = input("ac", 1);
+        t.insert('b');
+        assert_eq!(t.value(), "abc");
+        assert_eq!(t.cursor, 2);
+    }
+
+    #[test]
+    fn insert_between_multibyte_chars() {
+        let mut t = input("åä", 1);
+        t.insert('x');
+        assert_eq!(t.value(), "åxä");
+        assert_eq!(t.cursor, 2);
+    }
+
+    #[test]
+    fn backspace_removes_multibyte_char() {
+        let mut t = input("åäö", 2);
+        t.backspace();
+        assert_eq!(t.value(), "åö");
+        assert_eq!(t.cursor, 1);
+    }
+
+    #[test]
+    fn backspace_at_start_is_a_no_op() {
+        let mut t = input("abc", 0);
+        t.backspace();
+        assert_eq!(t.value(), "abc");
+        assert_eq!(t.cursor, 0);
+    }
+
+    #[test]
+    fn backspace_clamps_an_overrun_cursor() {
+        let mut t = input("ab", 9);
+        t.backspace();
+        assert_eq!(t.value(), "a");
+        assert_eq!(t.cursor, 1);
+    }
+
+    #[test]
+    fn left_and_right_clamp_at_the_ends() {
+        let mut t = input("日本語", 0);
+        t.left();
+        assert_eq!(t.cursor, 0);
+        t.right();
+        t.right();
+        t.right();
+        t.right();
+        assert_eq!(t.cursor, 3);
+        t.left();
+        assert_eq!(t.cursor, 2);
+    }
+
+    #[test]
+    fn word_left_skips_separators_then_the_word() {
+        let mut t = input("hello world", 11);
+        t.word_left();
+        assert_eq!(t.cursor, 6);
+        t.word_left();
+        assert_eq!(t.cursor, 0);
+    }
+
+    #[test]
+    fn word_right_skips_the_word_then_separators() {
+        let mut t = input("hello world", 0);
+        t.word_right();
+        assert_eq!(t.cursor, 6);
+        t.word_right();
+        assert_eq!(t.cursor, 11);
+    }
+
+    #[test]
+    fn word_jumps_count_chars_not_bytes() {
+        let mut t = input("héllo wörld", 11);
+        t.word_left();
+        assert_eq!(t.cursor, 6);
+        t.word_right();
+        assert_eq!(t.cursor, 11);
+    }
+
+    #[test]
+    fn before_cursor_splits_on_a_char_boundary() {
+        let t = input("åäö", 2);
+        assert_eq!(t.before_cursor(), "åä");
+    }
+
+    #[test]
+    fn clear_resets_the_cursor() {
+        let mut t = input("abc", 3);
+        t.clear();
+        assert!(t.is_empty());
+        assert_eq!(t.cursor, 0);
+    }
+}


### PR DESCRIPTION
## What

The six entry-form fields and the search bar each hand-rolled the same
char-index -> byte-index arithmetic, the same `pos.min(chars().count())`
clamp and the same two-`char_indices` walk for backspace.

`TextInput { value, cursor }` now owns a string and its cursor:
`insert`, `backspace`, `left`, `right`, `word_left`, `word_right`,
`set_from` (cursor to end), `clear`, `cursor_to_end`, `before_cursor`.

`App` holds one per input, so:

- `App::cursor_pos` is gone; each input carries its own cursor.
- The three six-arm `match self.input_field` blocks in `entry_form.rs`
  collapse into `field_mut`, the only place the `InputField` mapping lives.
- `active_input` no longer switches on `input_mode` to pick a `&str`.
- `render/form.rs` iterates the fields instead of matching them twice.

Behaviour is unchanged: tabbing between fields still parks the cursor at
the end, word-jump semantics are identical, and the renderer places the
cursor from the same measured prefix.

## Tests

New unit tests in `src/tui/text_input.rs` cover insert/backspace/left/
right/word jumps over multi-byte UTF-8 (`åäö`, `日本語`, `héllo wörld`)
and an over-run cursor.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test`
all pass.

Closes #33