### PR TITLE
refactor(main): one preamble predicate and one dispatch table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,55 +39,27 @@ fn main() -> Result<()> {
         .then(|| update::maybe_check_and_notify(env!("CARGO_PKG_VERSION")))
         .flatten();
 
-    // Dispatched ahead of the preamble below because they must not take the store
-    // lock; the preamble runs before the dispatch table, not inside it. `tt report`
-    // migrates its own in-memory copy instead — see `AgentCommands::touches_store`.
-    match &cli.command {
-        Commands::Agent { command } if !command.touches_store() => {
-            return agent::run(command);
+    // The preamble runs before the dispatch table, not inside it, so the
+    // commands that must not take the store lock skip it — and with it the
+    // notice, which they have never printed.
+    if needs_store_preamble(&cli.command) {
+        if let Some(version) = &update_notice
+            && !matches!(cli.command, Commands::Tui)
+        {
+            eprintln!(
+                "Note: tt {version} is available (you have {}). Run `{}` to upgrade.",
+                env!("CARGO_PKG_VERSION"),
+                update::update_hint()
+            );
         }
-        Commands::Report {
-            all,
-            week,
-            since,
-            until,
-            project,
-            json,
-        } => {
-            return commands::report(commands::ReportRequest {
-                all: *all,
-                week: *week,
-                since: *since,
-                until: *until,
-                project: project.clone(),
-                json: *json,
-            });
-        }
-        Commands::Update { check, yes } => {
-            return commands::update(*check, *yes);
-        }
-        Commands::Completions { shell } => {
-            return commands::completions(shell.as_deref());
-        }
-        _ => {}
-    }
 
-    if let Some(version) = &update_notice
-        && !matches!(cli.command, Commands::Tui)
-    {
-        eprintln!(
-            "Note: tt {version} is available (you have {}). Run `{}` to upgrade.",
-            env!("CARGO_PKG_VERSION"),
-            update::update_hint()
-        );
+        // Migrate once under the store lock, never in `load_data`: a write from
+        // a loader would surprise every read-only path.
+        storage::with_data(|data| {
+            tracker::migrate(data);
+            Ok(())
+        })?;
     }
-
-    // Migrate once under the store lock, never in `load_data`: a write from a
-    // loader would surprise every read-only path.
-    storage::with_data(|data| {
-        tracker::migrate(data);
-        Ok(())
-    })?;
 
     match cli.command {
         Commands::Start {
@@ -132,9 +104,92 @@ fn main() -> Result<()> {
         Commands::Status => commands::status(),
         Commands::Active => commands::active(),
         Commands::Agent { command } => agent::run(&command),
-        // Dispatched ahead of the preamble above; unreachable in practice,
-        // kept for exhaustiveness (same shape as `Report` just above it).
         Commands::Update { check, yes } => commands::update(check, yes),
         Commands::Completions { shell } => commands::completions(shell.as_deref()),
+    }
+}
+
+/// Whether this command dispatches *after* the store-lock migrate preamble in
+/// [`main`]. The rest must not take the store lock: `tt report` migrates its own
+/// in-memory copy, and the agent hooks that only touch marks stay off it — see
+/// [`cli::AgentCommands::touches_store`].
+///
+/// Exhaustive on purpose: a new variant must decide.
+fn needs_store_preamble(command: &Commands) -> bool {
+    match command {
+        Commands::Report { .. } | Commands::Update { .. } | Commands::Completions { .. } => false,
+        Commands::Agent { command } => command.touches_store(),
+        Commands::Start { .. }
+        | Commands::Stop
+        | Commands::Log { .. }
+        | Commands::Today
+        | Commands::List { .. }
+        | Commands::Tui
+        | Commands::Status
+        | Commands::Active => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn command_of(args: &[&str]) -> Commands {
+        Cli::try_parse_from(args).expect("args parse").command
+    }
+
+    #[test]
+    fn the_store_locking_commands_take_the_preamble() {
+        for args in [
+            vec!["tt", "start", "x"],
+            vec!["tt", "stop"],
+            vec!["tt", "log", "-d", "x", "-t", "5m"],
+            vec!["tt", "today"],
+            vec!["tt", "list"],
+            vec!["tt", "tui"],
+            vec!["tt", "status"],
+            vec!["tt", "active"],
+        ] {
+            assert!(
+                needs_store_preamble(&command_of(&args)),
+                "{args:?} should migrate under the lock"
+            );
+        }
+    }
+
+    #[test]
+    fn report_update_and_completions_skip_the_preamble() {
+        for args in [
+            vec!["tt", "report", "--week"],
+            vec!["tt", "update", "--check"],
+            vec!["tt", "completions", "bash"],
+        ] {
+            assert!(
+                !needs_store_preamble(&command_of(&args)),
+                "{args:?} must not take the store lock"
+            );
+        }
+    }
+
+    /// The agent layer decides per subcommand, through `touches_store`.
+    #[test]
+    fn agent_follows_touches_store() {
+        for args in [
+            vec!["tt", "agent", "begin", "p", "-", "impl"],
+            vec!["tt", "agent", "touch", "p", "-", "impl"],
+            vec!["tt", "agent", "cancel", "p", "-", "impl"],
+            vec!["tt", "agent", "list"],
+            vec!["tt", "agent", "audit"],
+        ] {
+            assert!(!needs_store_preamble(&command_of(&args)), "{args:?}");
+        }
+        for args in [
+            vec!["tt", "agent", "end", "p", "-", "impl"],
+            vec!["tt", "agent", "item", "p", "-", "impl"],
+            vec!["tt", "agent", "audit", "--auto-log"],
+        ] {
+            assert!(needs_store_preamble(&command_of(&args)), "{args:?}");
+        }
     }
 }


### PR DESCRIPTION
Closes #38

`main` matched on `cli.command` twice: a first match that early-returned the
commands which must not take the store lock, and the real dispatch table that
repeated `Report`, `Update` and `Completions` — the `Update` arm carrying a
comment that it was unreachable in practice.

## Change
- Add `fn needs_store_preamble(command: &Commands) -> bool` in `src/main.rs`,
  exhaustive over `Commands` (mirroring `AgentCommands::touches_store`), so a
  new variant must state which side of the preamble it dispatches on.
- `main` runs the `storage::with_data(migrate)` preamble only when the
  predicate holds, then falls through to a single dispatch table.
- Drop the duplicated `Report`/`Update`/`Completions` arms and the
  documented-unreachable `Update` arm.

## Behaviour
The set of commands that skip the preamble is unchanged: `Report`, `Update`,
`Completions`, and `Agent` when `!command.touches_store()`.

Note that those commands also returned *before* the update-notice `eprintln!`,
so they never printed the notice. That is preserved: the notice block moved
inside the same `if`. (`wants_update_check()` already suppresses the check
itself for `Update`/`Active`/`Agent`/`Completions`; `Report` still performs the
check without printing, exactly as before.)

## Tests
Three new tests in `src/main.rs` parse real argv and assert which side of the
preamble each command lands on, including every `agent` subcommand.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass.