### PR TITLE
fix: make duration::parse fallible and validate tt log -t

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,7 +191,12 @@ Durations are used with `tt log -t`. Supported formats:
 | `2h`    | 2 hours         |
 | `45m`   | 45 minutes      |
 | `1h30m` | 1 hour 30 min   |
+| `1h 30m`| 1 hour 30 min   |
 | `90`    | 90 minutes      |
+
+`h`/`m` may be upper or lower case. Anything outside these forms — `hello`,
+`1x30`, `-45m`, `1h30` — is a usage error, not a zero-length or partially
+honoured entry.
 
 ---
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,7 +10,7 @@
 //! The messages are a contract: their caller is an agent following prose.
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Duration, Local};
 
 use crate::tracker::IdleInterval;
 
@@ -301,7 +301,7 @@ fn write_auto_log(item: &audit::Unaccounted) -> Result<()> {
     let minutes = item.end.signed_duration_since(item.start).num_minutes();
     commands::log(commands::LogRequest {
         description: "unattended activity #auto".to_string(),
-        time: format!("{}m", round_five(minutes)),
+        time: Duration::minutes(round_five(minutes)),
         extra_tags: Vec::new(),
         project: Some(item.project.clone()),
         idle: item.idle.clone(),
@@ -377,7 +377,7 @@ fn log_entry(
 ) -> Result<()> {
     commands::log(commands::LogRequest {
         description: description(project, issue, phase, summary),
-        time: format!("{}m", round_five(minutes)),
+        time: Duration::minutes(round_five(minutes)),
         extra_tags: Vec::new(),
         project: Some(project.to_string()),
         idle: span.idle,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! The clap surface: what `tt`'s arguments are. The command implementations
 //! they dispatch to live in `src/commands.rs`.
 
-use chrono::{Local, NaiveDate, TimeZone};
+use chrono::{Duration, Local, NaiveDate, TimeZone};
 use clap::builder::PossibleValuesParser;
 use clap::{Parser, Subcommand};
 use clap_complete::ArgValueCandidates;
@@ -34,9 +34,9 @@ pub enum Commands {
         /// Description of the task
         #[arg(short = 'd', long)]
         description: String,
-        /// Duration in format like "1h30m", "45m", "2h"
-        #[arg(short = 't', long)]
-        time: String,
+        /// Duration in format like "1h30m", "45m", "2h", or bare minutes "90"
+        #[arg(short = 't', long, value_parser = parse_duration)]
+        time: Duration,
         /// Comma-separated tags (e.g. tagA,tagB,tagC)
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
@@ -281,6 +281,17 @@ impl AgentCommands {
     }
 }
 
+/// Parse one `-t/--time` value. A malformed duration is a usage error, never a
+/// zero-length or partially honoured entry.
+fn parse_duration(value: &str) -> Result<Duration, String> {
+    crate::duration::parse(value).ok_or_else(|| {
+        format!(
+            "expected a duration like `1h30m`, `45m`, `2h` or bare minutes `90`, got `{}`",
+            value
+        )
+    })
+}
+
 /// Parse one `--idle` value: `<start>-<end>` in epoch seconds. A malformed value
 /// is an error, never a silently dropped interval.
 fn parse_idle(value: &str) -> Result<IdleInterval, String> {
@@ -369,6 +380,32 @@ mod tests {
                 &format!("--idle={}", bad),
             ]);
             assert!(parsed.is_err(), "`{bad}` parsed instead of failing");
+        }
+    }
+
+    /// #41: `-t` refuses what it cannot parse instead of logging zero.
+    #[test]
+    fn a_malformed_time_value_is_a_parse_error_not_a_zero_entry() {
+        for bad in ["garbage", "1x30", "-45m", "1h30", "1.5h", "90 minutes", ""] {
+            let parsed = Cli::try_parse_from(["tt", "log", "-d", "x", "-t", bad]);
+            assert!(parsed.is_err(), "`{bad}` parsed instead of failing");
+        }
+    }
+
+    #[test]
+    fn the_documented_time_forms_all_parse() {
+        for (raw, expected) in [
+            ("1h30m", Duration::minutes(90)),
+            ("45m", Duration::minutes(45)),
+            ("2h", Duration::hours(2)),
+            ("90", Duration::minutes(90)),
+        ] {
+            let cli = Cli::try_parse_from(["tt", "log", "-d", "x", "-t", raw])
+                .unwrap_or_else(|e| panic!("`{raw}` failed to parse: {e}"));
+            match cli.command {
+                Commands::Log { time, .. } => assert_eq!(time, expected, "`{raw}`"),
+                _ => panic!("not a log command"),
+            }
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,7 @@
 //! `cli.rs` defines what the arguments are; this module is what they do.
 
 use anyhow::Result;
-use chrono::{DateTime, Local, NaiveDate};
+use chrono::{DateTime, Duration, Local, NaiveDate};
 
 use crate::completions;
 use crate::config;
@@ -174,8 +174,9 @@ pub fn stop() -> Result<()> {
 /// One finished entry to record, as [`log`] takes it.
 pub struct LogRequest {
     pub description: String,
-    /// Duration in `tt log -t` form, e.g. "1h30m".
-    pub time: String,
+    /// How long the entry ran; already parsed, so `log` cannot be handed a
+    /// duration nobody validated.
+    pub time: Duration,
     /// Tags to add on top of the ones parsed out of the description.
     pub extra_tags: Vec<String>,
     pub project: Option<String>,
@@ -198,9 +199,8 @@ pub fn log(request: LogRequest) -> Result<()> {
         trim,
         ended_at,
     } = request;
-    let dur = duration::parse(&time);
     let end_time = ended_at.unwrap_or_else(Local::now);
-    let start_time = end_time - dur;
+    let start_time = end_time - time;
 
     let (desc, mut tags) = parse_tags(&description);
     for tag in extra_tags {
@@ -235,7 +235,7 @@ pub fn log(request: LogRequest) -> Result<()> {
             }
             // An empty vec is `trim_spans` declining, which leaves the entry whole.
         }
-        Ok(dur)
+        Ok(time)
     })?;
 
     println!(
@@ -426,7 +426,7 @@ mod tests {
         let entry = &data.entries[0];
         assert_eq!(
             entry.duration(),
-            duration::parse("90m"),
+            chrono::Duration::minutes(90),
             "--idle changed the logged duration"
         );
         assert_eq!(entry.idle.len(), 1);
@@ -494,7 +494,7 @@ mod tests {
             .fold(chrono::Duration::zero(), |acc, e| acc + e.duration());
         assert_eq!(
             logged,
-            duration::parse("2h") - chrono::Duration::seconds(idle_total),
+            chrono::Duration::hours(2) - chrono::Duration::seconds(idle_total),
             "the pieces do not sum to the span minus the idle stretches"
         );
         let ids: Vec<u64> = data.entries.iter().map(|e| e.id).collect();
@@ -532,7 +532,7 @@ mod tests {
 
         let data = storage::load_data().unwrap();
         assert_eq!(data.entries.len(), 1, "recording is not trimming");
-        assert_eq!(data.entries[0].duration(), duration::parse("60m"));
+        assert_eq!(data.entries[0].duration(), chrono::Duration::minutes(60));
         assert_eq!(data.entries[0].idle.len(), 1, "the interval is still there");
     }
 }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -7,31 +7,107 @@ pub fn format(dur: Duration) -> String {
     format!("{}h {}m", hours, minutes)
 }
 
-/// Parse a duration string like "1h30m", "45m", "2h", or bare minutes "45"
-pub fn parse(duration_str: &str) -> Duration {
-    let mut hours = 0i64;
-    let mut minutes = 0i64;
-    let mut current_num = String::new();
+/// Leading run of ASCII digits, plus what follows it.
+fn take_number(s: &str) -> Option<(i64, &str)> {
+    let end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
+    let value = s[..end].parse().ok()?;
+    Some((value, &s[end..]))
+}
 
-    for c in duration_str.chars() {
-        match c {
-            '0'..='9' => current_num.push(c),
-            'h' | 'H' => {
-                hours = current_num.parse().unwrap_or(0);
-                current_num.clear();
+/// Parse a duration string: `90` (bare minutes), `45m`, `2h`, or `1h30m`. The
+/// space [`format`] writes is allowed, so `1h 30m` round-trips.
+///
+/// Anything else — a sign, stray characters, an empty string, a number too big
+/// for a `Duration` — is `None`, never a silently truncated value.
+pub fn parse(duration_str: &str) -> Option<Duration> {
+    let input = duration_str.trim();
+    let (first, rest) = take_number(input)?;
+
+    match rest.as_bytes().first() {
+        None => Duration::try_minutes(first),
+        Some(b'h' | b'H') => {
+            let rest = rest[1..].trim_start();
+            if rest.is_empty() {
+                return Duration::try_hours(first);
             }
-            'm' | 'M' => {
-                minutes = current_num.parse().unwrap_or(0);
-                current_num.clear();
+            let (mins, rest) = take_number(rest)?;
+            if !matches!(rest, "m" | "M") {
+                return None;
             }
-            _ => {}
+            Duration::try_hours(first)?.checked_add(&Duration::try_minutes(mins)?)
+        }
+        Some(b'm' | b'M') if rest.len() == 1 => Duration::try_minutes(first),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_documented_forms_all_parse() {
+        assert_eq!(parse("2h"), Some(Duration::hours(2)));
+        assert_eq!(parse("45m"), Some(Duration::minutes(45)));
+        assert_eq!(parse("1h30m"), Some(Duration::minutes(90)));
+        assert_eq!(parse("90"), Some(Duration::minutes(90)), "bare = minutes");
+        assert_eq!(parse("0m"), Some(Duration::zero()));
+    }
+
+    #[test]
+    fn the_unit_letters_are_case_insensitive() {
+        assert_eq!(parse("2H"), Some(Duration::hours(2)));
+        assert_eq!(parse("45M"), Some(Duration::minutes(45)));
+        assert_eq!(parse("1H30M"), Some(Duration::minutes(90)));
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        assert_eq!(parse("  1h30m \n"), Some(Duration::minutes(90)));
+    }
+
+    /// The TUI seeds and rewrites its Duration field with `format` output, so
+    /// its spacing has to parse back.
+    #[test]
+    fn format_output_parses_back() {
+        for minutes in [0, 45, 60, 95, 1440] {
+            let dur = Duration::minutes(minutes);
+            assert_eq!(parse(&format(dur)), Some(dur), "{minutes}m round trip");
         }
     }
 
-    // Handle bare number as minutes
-    if !current_num.is_empty() && hours == 0 && minutes == 0 {
-        minutes = current_num.parse().unwrap_or(0);
+    #[test]
+    fn minutes_beyond_an_hour_are_kept_as_written() {
+        assert_eq!(parse("1h90m"), Some(Duration::minutes(150)));
     }
 
-    Duration::hours(hours) + Duration::minutes(minutes)
+    /// The point of #41: unparseable input is an error, not a zero or a
+    /// partially honoured value.
+    #[test]
+    fn unparseable_input_is_rejected_rather_than_truncated() {
+        for bad in [
+            "",
+            "   ",
+            "hello",
+            "1x30",
+            "-45m",
+            "+45m",
+            "1.5h",
+            "1h30",
+            "30mm",
+            "m",
+            "h",
+            "1m30h",
+            "1h30s",
+            "90 minutes",
+        ] {
+            assert_eq!(parse(bad), None, "`{bad}` parsed instead of failing");
+        }
+    }
+
+    #[test]
+    fn a_number_too_large_for_a_duration_is_rejected() {
+        assert_eq!(parse("999999999999999999999"), None, "overflows i64");
+        assert_eq!(parse("9223372036854775807h"), None, "overflows Duration");
+    }
 }

--- a/src/tui/entry_form.rs
+++ b/src/tui/entry_form.rs
@@ -208,12 +208,10 @@ impl App {
         } else {
             None
         };
-        let dur = if !self.input_duration.is_empty() {
-            let d = crate::duration::parse(self.input_duration.value());
-            if d.num_seconds() > 0 { Some(d) } else { None }
-        } else {
-            None
-        };
+        // A half-typed or unparseable duration is "not yet resolvable", the same
+        // as a zero-length one — never an error while the user is still typing.
+        let dur =
+            crate::duration::parse(self.input_duration.value()).filter(|d| d.num_seconds() > 0);
 
         match (start, end, dur) {
             (Some(s), _, Some(d)) => Some((s, Some(s + d))),
@@ -252,12 +250,7 @@ impl App {
         } else {
             None
         };
-        let dur = if !dur_str.is_empty() {
-            let d = crate::duration::parse(&dur_str);
-            if d.num_seconds() > 0 { Some(d) } else { None }
-        } else {
-            None
-        };
+        let dur = crate::duration::parse(&dur_str).filter(|d| d.num_seconds() > 0);
 
         match leaving_field {
             InputField::StartTime => {


### PR DESCRIPTION
Closes #41

`duration::parse` was infallible by construction, so `tt log -d x -t hello`
logged a zero-length entry with exit 0, `-t 1x30` logged 1 hour, and `-t -45m`
logged 45 minutes with the sign dropped. It now returns `Option<Duration>` and
`-t/--time` is a clap `value_parser`, so a malformed duration is a usage error
at parse time, exactly as `--idle` already was.

## Accepted grammar

```
duration := <digits>                       ; bare minutes
          | <digits> ("h"|"H")
          | <digits> ("m"|"M")
          | <digits> ("h"|"H") [ws] <digits> ("m"|"M")
```

Surrounding whitespace is trimmed. `h`/`m` are case-insensitive. The space in
`1h 30m` is accepted because that is what `duration::format` writes, and the TUI
seeds and rewrites its Duration field with `format` output — the round trip has
to hold. Minutes are not capped at 59: `1h90m` is still 150 minutes, as before.
Values that overflow `i64` or `chrono::Duration` are rejected instead of
panicking.

Rejected: `hello`, `1x30`, `-45m`, `+45m`, `1.5h`, `1h30`, `1h30s`, `30mm`,
`1m30h`, `m`, `h`, `90 minutes`, and the empty string.

## Bare-number policy

**A bare number stays valid and still means minutes** (`90` = 90 minutes). It is
documented in `docs/usage.md` and is a currently-valid form, so keeping it holds
to "keep all currently-valid forms working". Only genuinely unparseable input
changed behaviour.

## Behaviour change

Deliberate, per the issue: `-t garbage` is now a usage error (clap exit 2) and
`1x30` is rejected rather than partially honoured.

## Call sites

- `src/duration.rs` — `parse` -> `Option<Duration>`, plus unit tests.
- `src/cli.rs` — `Commands::Log { time }` is now `chrono::Duration` behind a new
  `parse_duration` value_parser, styled after `parse_idle`.
- `src/commands.rs` — `LogRequest.time` is a parsed `Duration`, so `log` can no
  longer be handed an unvalidated string; the internal re-parse is gone. Tests
  that used `duration::parse("90m")` as an expectation now say
  `Duration::minutes(90)`.
- `src/agent.rs` — the two `LogRequest` builders pass
  `Duration::minutes(round_five(minutes))` instead of formatting a string for
  `log` to re-parse.
- `src/tui/entry_form.rs` — `resolve_times` and `apply_time_calculations` treat
  `None` the same as a zero-length duration, so a half-typed `1` or `1h3` is
  "not yet resolvable" rather than an error state or a wrong derived end time.
- `docs/usage.md` — documents the grammar and that bad input is an error.

## Tests

- `duration`: accepted forms, case-insensitivity, whitespace, `format` round
  trip, overflow, and a table of rejected forms.
- `cli`: `a_malformed_time_value_is_a_parse_error_not_a_zero_entry` (mirrors the
  existing `--idle` test) and `the_documented_time_forms_all_parse`.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all
pass.
