### PR TITLE
refactor(tui): table-drive the entry form field layout

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2002,6 +2002,75 @@ mod tests {
             .collect()
     }
 
+    /// One rendered frame plus the cursor it asked for.
+    fn frame_cursor(app: &mut App, width: u16, height: u16) -> (u16, u16) {
+        let mut terminal =
+            Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| render::ui(f, app)).unwrap();
+        let pos = terminal.get_cursor_position().unwrap();
+        (pos.x, pos.y)
+    }
+
+    #[test]
+    fn the_entry_form_stacks_its_fields_three_rows_apart() {
+        let _guard = env_guard();
+        sandbox("entry-form-layout");
+        seed(vec![], 1);
+
+        let mut app = App::new().unwrap();
+        app.start_adding();
+        let screen = frame_lines(&mut app, 100, 60);
+        let row_of = |needle: &str| {
+            screen
+                .iter()
+                .position(|line| line.contains(needle))
+                .unwrap_or_else(|| panic!("{needle} is missing:\n{}", screen.join("\n")))
+        };
+
+        let rows: Vec<usize> = [
+            " Description ",
+            " Project (optional",
+            " Tags (space-separated",
+            " Duration (optional",
+            " Start Time (",
+            " End Time (optional",
+            " Add Log Entry ", // the help row's own block title
+        ]
+        .iter()
+        .map(|label| row_of(label))
+        .collect();
+
+        for pair in rows.windows(2) {
+            assert_eq!(pair[1] - pair[0], 3, "form rows drifted: {rows:?}");
+        }
+        assert_eq!(
+            row_of(": switch field") - rows[rows.len() - 1],
+            1,
+            "the help text left its block"
+        );
+    }
+
+    #[test]
+    fn the_form_cursor_lands_on_the_active_field() {
+        let _guard = env_guard();
+        sandbox("entry-form-cursor");
+        seed(vec![], 1);
+
+        let mut app = App::new().unwrap();
+        app.start_adding();
+        // A multi-byte value: the cursor is placed by display width, not bytes.
+        app.input_description.set_from("héllo");
+        app.input_project.set_from("acme");
+
+        let first = frame_cursor(&mut app, 100, 60);
+        app.next_input_field();
+        let second = frame_cursor(&mut app, 100, 60);
+
+        assert_eq!(second.1 - first.1, 3, "cursor did not follow the Tab order");
+        // "héllo" is five columns wide, "acme" four — both share the chunk's x.
+        assert_eq!(first.0 - second.0, 1, "cursor column ignored display width");
+    }
+
     #[test]
     fn the_agents_panel_renders_the_unaccounted_section_when_flagged() {
         let _guard = env_guard();

--- a/src/tui/render/form.rs
+++ b/src/tui/render/form.rs
@@ -1,3 +1,4 @@
+use crate::tui::text_input::TextInput;
 use crate::tui::types::{InputField, InputMode};
 use crate::tui::{App, theme};
 use chrono::Local;
@@ -56,6 +57,53 @@ pub(super) fn render_search_bar(f: &mut Frame, app: &App, area: Rect) {
     }
 }
 
+/// One form row: the variant, its block label, and the buffer it edits.
+type FormField = (InputField, &'static str, fn(&App) -> &TextInput);
+
+/// Every form field in layout order. Row order here *is* the on-screen order,
+/// the Tab order and the order of the layout chunks, so adding or moving a
+/// field is one row.
+const FIELDS: &[FormField] = &[
+    (InputField::Description, " Description ", |a| {
+        &a.input_description
+    }),
+    (
+        InputField::Project,
+        " Project (optional: single name, e.g. acme) ",
+        |a| &a.input_project,
+    ),
+    (
+        InputField::Tags,
+        " Tags (space-separated, e.g., work meeting) ",
+        |a| &a.input_tags,
+    ),
+    (
+        InputField::Duration,
+        " Duration (optional: 1h30m, 45m, 2h) ",
+        |a| &a.input_duration,
+    ),
+    (
+        InputField::StartTime,
+        " Start Time (e.g. 9am, 14:30, 25/03 9.30am) ",
+        |a| &a.input_start_time,
+    ),
+    (
+        InputField::EndTime,
+        " End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ",
+        |a| &a.input_end_time,
+    ),
+];
+
+/// The chunk the help row sits in: straight after the last field.
+const HELP_CHUNK: usize = FIELDS.len();
+
+/// One three-line chunk per field, then the help row, then the slack.
+fn form_constraints() -> Vec<Constraint> {
+    let mut constraints = vec![Constraint::Length(3); FIELDS.len() + 1];
+    constraints.push(Constraint::Min(0));
+    constraints
+}
+
 pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
     let is_editing = app.input_mode == InputMode::EditingEntry;
     let form_title = if is_editing {
@@ -75,16 +123,7 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints([
-            Constraint::Length(3), // Description
-            Constraint::Length(3), // Project
-            Constraint::Length(3), // Tags
-            Constraint::Length(3), // Duration
-            Constraint::Length(3), // Start Time
-            Constraint::Length(3), // End Time
-            Constraint::Length(3), // Help
-            Constraint::Min(0),
-        ])
+        .constraints(form_constraints())
         .split(area);
 
     fn field_block(label: &'static str, active: bool) -> Block<'static> {
@@ -107,43 +146,9 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
 
     let active = app.input_field;
 
-    // In chunk order, which is also the Tab order.
-    let fields = [
-        (
-            InputField::Description,
-            &app.input_description,
-            " Description ",
-        ),
-        (
-            InputField::Project,
-            &app.input_project,
-            " Project (optional: single name, e.g. acme) ",
-        ),
-        (
-            InputField::Tags,
-            &app.input_tags,
-            " Tags (space-separated, e.g., work meeting) ",
-        ),
-        (
-            InputField::Duration,
-            &app.input_duration,
-            " Duration (optional: 1h30m, 45m, 2h) ",
-        ),
-        (
-            InputField::StartTime,
-            &app.input_start_time,
-            " Start Time (e.g. 9am, 14:30, 25/03 9.30am) ",
-        ),
-        (
-            InputField::EndTime,
-            &app.input_end_time,
-            " End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ",
-        ),
-    ];
-
-    for (i, (field, input, label)) in fields.into_iter().enumerate() {
+    for (i, (field, label, input)) in FIELDS.iter().copied().enumerate() {
         f.render_widget(
-            Paragraph::new(input.value())
+            Paragraph::new(input(app).value())
                 .style(Style::default().fg(Color::White))
                 .block(field_block(label, active == field)),
             chunks[i],
@@ -171,14 +176,49 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(theme::highlight()),
             )),
     );
-    f.render_widget(help, chunks[6]);
+    f.render_widget(help, chunks[HELP_CHUNK]);
 
-    if let Some((i, (_, input, _))) = fields
-        .into_iter()
+    if let Some((i, (_, _, input))) = FIELDS
+        .iter()
+        .copied()
         .enumerate()
         .find(|(_, (field, _, _))| *field == active)
     {
-        let width = Line::from(input.before_cursor()).width() as u16;
+        let width = Line::from(input(app).before_cursor()).width() as u16;
         f.set_cursor_position((chunks[i].x + width + 1, chunks[i].y + 1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_constraints_follow_the_field_table() {
+        let constraints = form_constraints();
+        // one chunk per field, then help, then the slack
+        assert_eq!(constraints.len(), FIELDS.len() + 2);
+        assert!(
+            constraints[..=HELP_CHUNK]
+                .iter()
+                .all(|c| *c == Constraint::Length(3))
+        );
+        assert_eq!(constraints[constraints.len() - 1], Constraint::Min(0));
+    }
+
+    #[test]
+    fn the_table_holds_every_field_in_tab_order() {
+        let rows: Vec<InputField> = FIELDS.iter().map(|(field, _, _)| *field).collect();
+        assert_eq!(
+            rows,
+            vec![
+                InputField::Description,
+                InputField::Project,
+                InputField::Tags,
+                InputField::Duration,
+                InputField::StartTime,
+                InputField::EndTime,
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #55

## What is left of #55

PR #61 (issue #33) already delivered two of the issue''s three halves: `render_entry_form` lost its six `render_widget` calls and its six-arm cursor `match`, both replaced by a loop and a `find` over an inline field array. This PR is the remaining piece: the layout `Constraint` list was still an independent hardcoded list of eight entries with trailing comments naming each field, so adding a field was still two edits.

## Changes

- `FIELDS` is now a declared `const &[FormField]` where `FormField = (InputField, &''static str, fn(&App) -> &TextInput)` — the const table the issue sketched, with the accessor column reading a `TextInput` as #33 left it. The function-pointer column coerces cleanly, so no borrow/lifetime workaround was needed; a `type` alias keeps `clippy::type_complexity` happy.
- The layout constraints are derived from the table (`form_constraints()`): one `Length(3)` per row plus the help row, then the trailing `Min(0)`. The per-field trailing comments are gone — the table names them.
- The help row''s chunk index is `HELP_CHUNK = FIELDS.len()`, not a hardcoded `chunks[6]`.

Adding or reordering a field is now one row in `FIELDS`.

## No visible change

Same labels, order, colours, chunk heights and cursor placement. New tests pin it:

- `form.rs`: the derived constraint list has one `Length(3)` per field plus the help row and a trailing `Min(0)`; the table holds every `InputField` in Tab order.
- `mod.rs`: a rendered frame — every field block sits exactly three rows below the previous, the help block follows, and the cursor moves down three rows and tracks display width (multi-byte value) across a Tab.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass.