### PR TITLE
perf(tui): cache filtered_entries and pane_values behind view keys

### DIFF
--- a/src/tui/cache.rs
+++ b/src/tui/cache.rs
@@ -1,0 +1,63 @@
+//! Keys for the derived-view caches.
+//!
+//! [`App::filtered_entries`](super::App::filtered_entries) and
+//! [`App::pane_values`](super::App::pane_values) are recomputed only when the
+//! state they read has actually moved. A cached value is reused while the *key*
+//! it was computed under still compares equal, and that key holds **every**
+//! input the view reads — so validity is decided by construction rather than by
+//! remembering to call an `invalidate()` at each mutation site. A new mutator,
+//! or a test writing `app.view_mode` directly, is covered for free.
+//!
+//! Adding an input to either derived view means adding it here too; forgetting
+//! is the one way to get a stale cache.
+
+use chrono::NaiveDate;
+
+use super::App;
+use super::panes::PaneFilter;
+use super::types::{SortOrder, ViewMode};
+
+/// Every input to [`App::scope_entries`](super::App::scope_entries), and so to
+/// [`App::pane_values`](super::App::pane_values), which reads no filters.
+#[derive(Clone, PartialEq)]
+pub(crate) struct ScopeKey {
+    /// Stands in for `data` itself, which is far too big to compare per call.
+    /// See [`App::set_data`](super::App::set_data).
+    revision: u64,
+    view_mode: ViewMode,
+    selected_date: NaiveDate,
+}
+
+impl ScopeKey {
+    pub(crate) fn of(app: &App) -> Self {
+        Self {
+            revision: app.data_revision,
+            view_mode: app.view_mode,
+            selected_date: app.selected_date,
+        }
+    }
+}
+
+/// Every input to [`App::filtered_entries`](super::App::filtered_entries): the
+/// scope, plus the sort order and the two pane filters and the search term.
+#[derive(Clone, PartialEq)]
+pub(crate) struct FilterKey {
+    scope: ScopeKey,
+    sort_order: SortOrder,
+    project_filter: PaneFilter,
+    tag_filter: PaneFilter,
+    search: String,
+}
+
+impl FilterKey {
+    pub(crate) fn of(app: &App) -> Self {
+        Self {
+            scope: ScopeKey::of(app),
+            sort_order: app.sort_order,
+            project_filter: app.project_filter.clone(),
+            tag_filter: app.tag_filter.clone(),
+            // Only the text matters; the cursor does not filter anything.
+            search: app.search_term.value().to_string(),
+        }
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2848,4 +2848,169 @@ mod tests {
         app.submit_edit().unwrap();
         assert_eq!(on_disk().entries[0].project, None);
     }
+    // --- derived-view cache invalidation -------------------------------------
+    //
+    // `filtered_entries` and `pane_values` are cached against a key holding every
+    // input they read (see `tui::cache`). The tests below warm both caches, cross
+    // one mutation boundary, and assert the derived view moved with it — a cache
+    // that failed to notice that boundary goes stale here.
+
+    /// Fill both caches, so the assertion after a mutation is a real re-read.
+    fn warm(app: &App) {
+        let _ = app.filtered_entries();
+        let _ = app.pane_values(Pane::Projects);
+        let _ = app.pane_values(Pane::Tags);
+    }
+
+    /// The rows in view by description, name-sorted so the assertion does not
+    /// also pin the sort order.
+    fn in_view_sorted(app: &App) -> Vec<String> {
+        let mut rows = in_view(app);
+        rows.sort();
+        rows
+    }
+
+    /// `mutate_store` — add, edit and delete all replace `data` through it.
+    #[test]
+    fn the_derived_views_follow_a_store_mutation() {
+        let _guard = env_guard();
+        sandbox("cache-mutate");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = App::new().unwrap();
+        app.view_mode = ViewMode::All;
+        warm(&app);
+
+        app.mutate_store(|data| {
+            data.add_entry(
+                "second".to_string(),
+                Some("acme".to_string()),
+                vec!["new".to_string()],
+                Local::now(),
+                Some(Local::now()),
+            );
+        })
+        .unwrap();
+        assert_eq!(in_view_sorted(&app), vec!["first", "second"]);
+        assert_eq!(values(&app, Pane::Projects), "acme=1");
+        assert_eq!(values(&app, Pane::Tags), "new=1");
+
+        warm(&app);
+        app.mutate_store(|data| data.entries[0].description = "renamed".to_string())
+            .unwrap();
+        assert_eq!(in_view_sorted(&app), vec!["renamed", "second"]);
+
+        warm(&app);
+        app.delete_entry(0).unwrap();
+        assert_eq!(in_view_sorted(&app), vec!["second"]);
+        assert_eq!(values(&app, Pane::Projects), "acme=1");
+    }
+
+    /// `set_view_mode`, `previous_period`/`next_period` and `go_to_today`.
+    #[test]
+    fn the_derived_views_follow_the_view_mode_and_period() {
+        let _guard = env_guard();
+        sandbox("cache-scope");
+        let mut app = seed_panes();
+
+        app.set_view_mode(ViewMode::Day);
+        assert_eq!(in_view_sorted(&app), vec!["a", "b", "c", "f"]);
+
+        warm(&app);
+        app.set_view_mode(ViewMode::Week);
+        assert_eq!(in_view_sorted(&app), vec!["a", "b", "c", "d", "f"]);
+        assert_eq!(values(&app, Pane::Projects), "tt=2 loremind=1 vinge=1");
+
+        warm(&app);
+        app.previous_period();
+        assert_eq!(in_view_sorted(&app), vec!["e"]);
+        assert_eq!(values(&app, Pane::Projects), "vinge=1");
+
+        warm(&app);
+        app.next_period();
+        assert_eq!(in_view_sorted(&app), vec!["a", "b", "c", "d", "f"]);
+
+        warm(&app);
+        app.previous_period();
+        app.go_to_today();
+        assert_eq!(in_view_sorted(&app), vec!["a", "b", "c", "d", "f"]);
+    }
+
+    /// `toggle_sort_order` — same rows, reversed.
+    #[test]
+    fn the_entries_view_follows_the_sort_order() {
+        let _guard = env_guard();
+        sandbox("cache-sort");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::All;
+        let newest_first = in_view(&app);
+        warm(&app);
+
+        app.toggle_sort_order();
+        let oldest_first = in_view(&app);
+        // Same rows, ends swapped. Not an exact reverse: same-second ties keep
+        // their order under a stable sort.
+        assert_ne!(newest_first, oldest_first);
+        assert_eq!(oldest_first.first(), newest_first.last());
+        assert_eq!(oldest_first.last(), newest_first.first());
+    }
+
+    /// `cycle_pane_value` and `clear_filters`, which move the rows but never the
+    /// pane values — those are offered before any filter.
+    #[test]
+    fn the_entries_view_follows_a_pane_filter() {
+        let _guard = env_guard();
+        sandbox("cache-filter");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        warm(&app);
+
+        point_at(&mut app, Pane::Projects, "tt");
+        app.cycle_pane_value(true);
+        assert_eq!(in_view_sorted(&app), vec!["a", "b"]);
+        assert_eq!(values(&app, Pane::Projects), "tt=2 loremind=1");
+
+        warm(&app);
+        app.clear_filters();
+        assert_eq!(in_view_sorted(&app), vec!["a", "b", "c", "f"]);
+    }
+
+    /// `handle_search_char`, `handle_search_backspace` and `clear_search`.
+    #[test]
+    fn the_entries_view_follows_the_search_term() {
+        let _guard = env_guard();
+        sandbox("cache-search");
+        let mut app = seed_panes();
+        app.view_mode = ViewMode::Day;
+        warm(&app);
+
+        for c in "loremind".chars() {
+            app.handle_search_char(c);
+        }
+        assert_eq!(in_view_sorted(&app), vec!["c"]);
+
+        warm(&app);
+        app.handle_search_backspace();
+        assert_eq!(in_view_sorted(&app), vec!["c"]);
+
+        warm(&app);
+        app.clear_search();
+        assert_eq!(in_view_sorted(&app), vec!["a", "b", "c", "f"]);
+    }
+
+    /// `sync_from_store` — a write from outside the TUI, which reloads `data`.
+    #[test]
+    fn the_derived_views_follow_an_outside_write() {
+        let _guard = env_guard();
+        sandbox("cache-sync");
+        seed(vec![entry(0, "first")], 1);
+        let mut app = App::new().unwrap();
+        app.view_mode = ViewMode::All;
+        warm(&app);
+
+        agent_write("outside");
+        app.sync_from_store().unwrap();
+        assert_eq!(in_view_sorted(&app), vec!["first", "outside"]);
+        assert_eq!(values(&app, Pane::Projects), "probe=1");
+        assert_eq!(values(&app, Pane::Tags), "probe=1");
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,6 +4,7 @@ use crate::marks::Mark;
 use crate::storage::{PathStamp, load_data};
 use crate::tracker::TimeData;
 use anyhow::Result;
+use cache::{FilterKey, ScopeKey};
 use chrono::{Local, NaiveDate};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind},
@@ -11,9 +12,11 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend, widgets::TableState};
+use std::cell::RefCell;
 use std::io::{self, Stdout};
 use text_input::TextInput;
 
+mod cache;
 mod entry_form;
 mod keys;
 mod marks_surface;
@@ -33,7 +36,18 @@ pub use types::{
 };
 
 pub(crate) struct App {
+    /// The store snapshot. **Never assign this directly** — go through
+    /// [`App::set_data`], which bumps `data_revision`.
     pub(crate) data: TimeData,
+    /// Bumped on every replacement of `data`, so the cache keys can stand in for
+    /// its contents without comparing them.
+    pub(crate) data_revision: u64,
+    /// `filtered_entries` as indices into `data.entries` — indices, not
+    /// references, so the cache does not borrow `data` — with the key they hold
+    /// for. `RefCell` because nearly every reader is a `&self` method.
+    filtered_cache: RefCell<Option<(FilterKey, Vec<usize>)>>,
+    /// `pane_values` for `[Projects, Tags]`, with the key they hold for.
+    pane_cache: RefCell<Option<(ScopeKey, panes::PaneValues)>>,
     pub(crate) table_state: TableState,
     pub(crate) should_quit: bool,
     pub(crate) view_mode: ViewMode,
@@ -126,6 +140,9 @@ impl App {
         let layout = &config.layout;
         let mut app = Self {
             data: load_data()?,
+            data_revision: 0,
+            filtered_cache: RefCell::new(None),
+            pane_cache: RefCell::new(None),
             store_stamp,
             marks: Vec::new(),
             marks_stamp: None,
@@ -186,10 +203,18 @@ impl App {
             let result = edit(data);
             Ok((result, data.clone()))
         })?;
-        self.data = fresh;
+        self.set_data(fresh);
         // Our own write moved the file on; stamp it so the next tick skips it.
         self.store_stamp = crate::storage::store_stamp();
         Ok(result)
+    }
+
+    /// The one place `data` is replaced, by `mutate_store` and by `reload`.
+    /// Bumping `data_revision` here is what makes the derived-view caches notice
+    /// the new store, so a bare `self.data = …` elsewhere would go unseen.
+    pub(crate) fn set_data(&mut self, data: TimeData) {
+        self.data = data;
+        self.data_revision = self.data_revision.wrapping_add(1);
     }
 }
 

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -10,7 +10,7 @@ impl App {
     /// stamping after records a fingerprint newer than the data and loses the update.
     pub(crate) fn reload(&mut self) -> Result<()> {
         self.store_stamp = crate::storage::store_stamp();
-        self.data = crate::storage::load_data()?;
+        self.set_data(crate::storage::load_data()?);
         Ok(())
     }
 
@@ -107,7 +107,7 @@ impl App {
     }
 
     pub(crate) fn next(&mut self) {
-        let len = self.filtered_entries().len();
+        let len = self.filtered_len();
         if len == 0 {
             return;
         }
@@ -119,7 +119,7 @@ impl App {
     }
 
     pub(crate) fn previous(&mut self) {
-        let len = self.filtered_entries().len();
+        let len = self.filtered_len();
         if len == 0 {
             return;
         }
@@ -154,7 +154,7 @@ impl App {
         // An id that is already gone matches nothing — not an error.
         self.mutate_store(|data| data.entries.retain(|e| e.id != entry_id))?;
 
-        let new_len = self.filtered_entries().len();
+        let new_len = self.filtered_len();
         let past_the_end = self
             .table_state
             .selected()

--- a/src/tui/panes.rs
+++ b/src/tui/panes.rs
@@ -4,11 +4,26 @@
 use std::collections::HashMap;
 
 use super::App;
+use super::cache::ScopeKey;
 use super::types::{Focus, Pane};
 use crate::tracker::TimeEntry;
 
 /// Most value rows a pane shows before it starts scrolling.
 const MAX_VISIBLE_VALUES: usize = 6;
+
+/// One pane's rows: distinct value and its match count.
+pub(crate) type PaneRows = Vec<(String, usize)>;
+
+/// Both panes' rows, in `[Projects, Tags]` order — the cached unit.
+pub(crate) type PaneValues = [PaneRows; 2];
+
+/// A pane's slot in the cached `[Projects, Tags]` pair.
+fn pane_index(pane: Pane) -> usize {
+    match pane {
+        Pane::Projects => 0,
+        Pane::Tags => 1,
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Polarity {
@@ -17,7 +32,8 @@ pub(crate) enum Polarity {
 }
 
 /// A pane's filter. One vec, so a value is include or exclude, never both.
-#[derive(Debug, Default)]
+/// `Clone`/`PartialEq` so [`FilterKey`](super::cache::FilterKey) can hold it.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct PaneFilter(Vec<(String, Polarity)>);
 
 impl PaneFilter {
@@ -137,7 +153,39 @@ impl App {
 
     /// Distinct values with match counts, most used first, ties broken by name. No
     /// project contributes no row; a tag repeated within one entry counts once.
-    pub(crate) fn pane_values(&self, pane: Pane) -> Vec<(String, usize)> {
+    /// Cached against [`ScopeKey`] — pane values read no filter, so only the
+    /// store and the view scope can move them.
+    pub(crate) fn pane_values(&self, pane: Pane) -> PaneRows {
+        self.with_pane_values(|values| values[pane_index(pane)].clone())
+    }
+
+    /// A pane's row count, without cloning its values.
+    pub(crate) fn pane_value_count(&self, pane: Pane) -> usize {
+        self.with_pane_values(|values| values[pane_index(pane)].len())
+    }
+
+    /// Run `f` over both panes' cached values, recomputing them first if the
+    /// scope has moved. Both panes are built together: a frame reads both, and
+    /// one cache entry means one staleness question instead of two.
+    fn with_pane_values<T>(&self, f: impl FnOnce(&PaneValues) -> T) -> T {
+        let key = ScopeKey::of(self);
+        let stale = match &*self.pane_cache.borrow() {
+            Some((cached, _)) => *cached != key,
+            None => true,
+        };
+        if stale {
+            let values = [
+                self.compute_pane_values(Pane::Projects),
+                self.compute_pane_values(Pane::Tags),
+            ];
+            *self.pane_cache.borrow_mut() = Some((key, values));
+        }
+        let cache = self.pane_cache.borrow();
+        let (_, values) = cache.as_ref().expect("filled just above");
+        f(values)
+    }
+
+    fn compute_pane_values(&self, pane: Pane) -> PaneRows {
         let entries = self.scope_entries();
         let mut counts: HashMap<&str, usize> = HashMap::new();
         for entry in &entries {
@@ -162,7 +210,7 @@ impl App {
             }
         }
 
-        let mut values: Vec<(String, usize)> = counts
+        let mut values: PaneRows = counts
             .into_iter()
             .map(|(value, count)| (value.to_string(), count))
             .collect();
@@ -178,7 +226,7 @@ impl App {
         }
         let longest = panes
             .iter()
-            .map(|pane| self.pane_values(*pane).len())
+            .map(|pane| self.pane_value_count(*pane))
             .max()
             .unwrap_or(0);
         2 + longest.clamp(1, MAX_VISIBLE_VALUES) as u16
@@ -189,7 +237,7 @@ impl App {
             Pane::Projects => self.project_cursor,
             Pane::Tags => self.tag_cursor,
         };
-        let len = self.pane_values(pane).len();
+        let len = self.pane_value_count(pane);
         cursor.min(len.saturating_sub(1))
     }
 
@@ -197,7 +245,7 @@ impl App {
     pub(crate) fn pane_scroll_indicator(&self, pane: Pane, visible_rows: usize) -> Option<String> {
         surface_count(
             Some(self.pane_cursor(pane)),
-            self.pane_values(pane).len(),
+            self.pane_value_count(pane),
             visible_rows,
         )
     }
@@ -288,7 +336,7 @@ impl App {
         let Some(pane) = self.focused_pane() else {
             return false;
         };
-        let len = self.pane_values(pane).len();
+        let len = self.pane_value_count(pane);
         if len == 0 {
             return true;
         }

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -1,9 +1,47 @@
 use super::App;
+use super::cache::FilterKey;
 use super::types::{InputMode, SortOrder};
 use chrono::Duration;
+use std::collections::HashMap;
 
 impl App {
+    /// The rows the entries table shows, in sort order. Cached against
+    /// [`FilterKey`], so the many calls a single frame makes cost one walk.
     pub(crate) fn filtered_entries(&self) -> Vec<&crate::tracker::TimeEntry> {
+        self.with_filtered_indices(|indices| {
+            indices
+                .iter()
+                .filter_map(|i| self.data.entries.get(*i))
+                .collect()
+        })
+    }
+
+    /// How many rows [`filtered_entries`](Self::filtered_entries) would return,
+    /// without materialising them.
+    pub(crate) fn filtered_len(&self) -> usize {
+        self.with_filtered_indices(<[usize]>::len)
+    }
+
+    /// Run `f` over the cached row indices, recomputing them first if any input
+    /// the [`FilterKey`] covers has moved since they were built.
+    fn with_filtered_indices<T>(&self, f: impl FnOnce(&[usize]) -> T) -> T {
+        let key = FilterKey::of(self);
+        let stale = match &*self.filtered_cache.borrow() {
+            Some((cached, _)) => *cached != key,
+            None => true,
+        };
+        if stale {
+            let indices = self.compute_filtered_indices();
+            *self.filtered_cache.borrow_mut() = Some((key, indices));
+        }
+        let cache = self.filtered_cache.borrow();
+        let (_, indices) = cache.as_ref().expect("filled just above");
+        f(indices)
+    }
+
+    /// The uncached walk — scope, sort, then the filters — resolved to indices
+    /// into `data.entries` so the cache holds no borrow of `data`.
+    fn compute_filtered_indices(&self) -> Vec<usize> {
         let mut entries = self.scope_entries();
 
         match self.sort_order {
@@ -18,7 +56,7 @@ impl App {
             .filter(|e| self.tag_filter.allows(|v| e.has_tag(v)))
             .collect();
 
-        if self.search_term.is_empty() {
+        let entries = if self.search_term.is_empty() {
             entries
         } else {
             let search_lower = self.search_term.value().to_lowercase();
@@ -26,7 +64,19 @@ impl App {
                 .into_iter()
                 .filter(|e| e.matches_search(&search_lower))
                 .collect()
-        }
+        };
+
+        let position: HashMap<u64, usize> = self
+            .data
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.id, i))
+            .collect();
+        entries
+            .iter()
+            .filter_map(|e| position.get(&e.id).copied())
+            .collect()
     }
 
     pub(crate) fn filtered_total(&self) -> Duration {


### PR DESCRIPTION
Closes #35

`filtered_entries` and `pane_values` were recomputed from scratch on every call — several times per frame, and again on every `j`/`k`. Both are now cached on `App`.

## Design: validity by key, not by `invalidate()`

A cached value is reused only while the **key** it was computed under still compares equal, and that key holds *every* input the view reads (`src/tui/cache.rs`):

- `ScopeKey` — `data_revision`, `view_mode`, `selected_date`. Covers `scope_entries`, and so `pane_values`, which reads no filter.
- `FilterKey` — `ScopeKey` plus `sort_order`, `project_filter`, `tag_filter`, `search_term`. Covers `filtered_entries`.

This is deliberately not a list of `invalidate()` calls at ~15 mutation sites. Any state change invalidates by construction, including ones the issue''s proposed list missed (`entry_form.rs` writes `selected_date` directly) and the many tests that set `app.view_mode` / `app.search_term` as plain fields. Adding an input to either derived view means adding it to the key — that is the single thing to get right.

The one input too big to compare is the store, so it is represented by a `data_revision` counter. `data` is now replaced in exactly one place, `App::set_data`, which bumps it; `reload` and `mutate_store` both go through it, and the field carries a doc comment saying never to assign it directly.

## Invalidation points (all covered by the keys)

- Store replacement — `mutate_store` (add, edit, delete, stop, trim) and `reload` / `sync_from_store`, via `set_data` bumping `data_revision`.
- Scope — `set_view_mode`, `next_period`, `previous_period`, `go_to_today`, plus the direct `self.selected_date = date` in `entry_form::start_adding`, and any test writing `view_mode` / `selected_date`.
- Sort — `toggle_sort_order`.
- Filters — `cycle_pane_value`, `clear_filters`, and `PaneFilter::cycle` / `clear` however reached.
- Search — `handle_search_char`, `handle_search_backspace`, `clear_search`, and `search_term.set_from`.

Deliberately **not** in the keys, because neither derived view reads them: `input_mode`, `focus`, `table_state`, the pane cursors, `show_projects` / `show_tags` (visibility, not content), `marks`, `activity_sessions`, `unaccounted`, the form inputs, and `pending_confirm`.

## Notes

- The filtered cache stores **indices into `data.entries`**, not references, so it borrows nothing; `RefCell` because nearly every reader is a `&self` method.
- Both panes are computed together as one cache unit — a frame reads both, and it makes staleness one question instead of two.
- New `filtered_len` and `pane_value_count` serve the length-only call sites without materialising the rows.
- No behaviour change: the computation itself is untouched, only moved into `compute_filtered_indices` / `compute_pane_values`.

## Tests

New `tui::tests` block, one test per boundary — each warms both caches, crosses the boundary, and asserts the derived view moved: store add/edit/delete, view mode, period forward/back, `go_to_today`, sort toggle, pane filter cycle and clear, search type/backspace/clear, and an outside write through `sync_from_store`. Removing the `data_revision` bump fails three of them plus two pre-existing tests.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test` (366 tests) all pass.
