### PR TITLE
feat: json based custom data field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,7 +1782,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "timetracker"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
-# `preserve_order`: an entry's custom data keeps the order it was written in,
-# rather than being sorted alphabetically on the way to the detail view.
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = "1"
 directories = "5"
 anyhow = "1"
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timetracker"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 repository = "https://github.com/linus-skold/timetracker-rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# `preserve_order`: an entry's custom data keeps the order it was written in,
+# rather than being sorted alphabetically on the way to the detail view.
+serde_json = { version = "1", features = ["preserve_order"] }
 directories = "5"
 anyhow = "1"
 toml = "0.8"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -232,26 +232,9 @@ never recorded with the field silently dropped.
 
 `--data` is accepted by `tt start`, `tt log`, `tt agent item` and `tt agent
 end`. In the TUI, the entry form's **Data** field edits the same value as one
-line of compact JSON, and refuses to save what it cannot parse.
-
-The entry detail popover (`Enter`) lists the data under a **Data** header, in
-the order it was written — never sorted. Nested object keys are flattened to
-`review.by`; a list gets a heading and one bullet per item:
-
-```
-  Data
-
-  branch      feat/69
-  reviews:
-    -
-      by      linus
-      ok      true
-    - skipped
-  files:
-    - a.rs
-    - b.rs
-  pr          75
-```
+line of compact JSON, and refuses to save what it cannot parse; the entry detail
+popover (`Enter`) lists it as key/value rows under a **Data** header, with
+nested keys flattened to `review.by` and array elements to `files[0]`.
 
 Trimming an entry copies its data onto every piece.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,10 @@ Tags can be embedded inline using `#tag` syntax.
 ```sh
 tt start Working on login page
 tt start Fixing auth bug #backend #bugfix
+tt start Reviewing the PR --data '{"pr": 42}'
 ```
+
+`--data` hangs a JSON object on the entry — see [Custom data](#custom-data).
 
 ---
 
@@ -31,6 +34,7 @@ Log a completed task with an explicit duration. Useful for recording work after 
 - `-d` / `--description` — description of the task
 - `-t` / `--time` — duration (see [Duration Format](#duration-format))
 - `--tags` — comma-separated list of tags *(optional)*
+- `--data` — a JSON object of custom data *(optional; see [Custom data](#custom-data))*
 
 Tags can also be embedded inline in the description using `#tag` syntax. Both styles can be combined.
 
@@ -208,6 +212,31 @@ Tags can be added to any entry in two ways:
 2. **Explicit flag** with `tt log --tags tagA,tagB,tagC`
 
 Both methods can be combined and duplicates are automatically removed.
+
+---
+
+## Custom data
+
+Any entry can carry a JSON object of its own, for information tags and a
+description have nowhere to put — a PR number, a build id, whatever the caller
+wants to read back later.
+
+```sh
+tt log -d "Code review" -t 45m --data '{"pr": 42, "repo": "timetracker-rs"}'
+tt agent end tt 69 impl "json data field" --data '{"pr": 74}'
+```
+
+The value must be a **JSON object**. Invalid JSON, or valid JSON that is not an
+object (a bare number, a string, an array), is a usage error — the entry is
+never recorded with the field silently dropped.
+
+`--data` is accepted by `tt start`, `tt log`, `tt agent item` and `tt agent
+end`. In the TUI, the entry form's **Data** field edits the same value as one
+line of compact JSON, and refuses to save what it cannot parse; the entry detail
+popover (`Enter`) lists it as key/value rows under a **Data** header, with
+nested keys flattened to `review.by` and array elements to `files[0]`.
+
+Trimming an entry copies its data onto every piece.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -232,9 +232,26 @@ never recorded with the field silently dropped.
 
 `--data` is accepted by `tt start`, `tt log`, `tt agent item` and `tt agent
 end`. In the TUI, the entry form's **Data** field edits the same value as one
-line of compact JSON, and refuses to save what it cannot parse; the entry detail
-popover (`Enter`) lists it as key/value rows under a **Data** header, with
-nested keys flattened to `review.by` and array elements to `files[0]`.
+line of compact JSON, and refuses to save what it cannot parse.
+
+The entry detail popover (`Enter`) lists the data under a **Data** header, in
+the order it was written — never sorted. Nested object keys are flattened to
+`review.by`; a list gets a heading and one bullet per item:
+
+```
+  Data
+
+  branch      feat/69
+  reviews:
+    -
+      by      linus
+      ok      true
+    - skipped
+  files:
+    - a.rs
+    - b.rs
+  pr          75
+```
 
 Trimming an entry copies its data onto every piece.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -48,12 +48,14 @@ pub fn run(command: &AgentCommands) -> Result<()> {
             phase,
             summary,
             minutes,
+            data,
         } => item(
             project,
             issue,
             phase,
             summary.as_deref(),
             minutes.as_deref(),
+            data.clone(),
         ),
         AgentCommands::End {
             project,
@@ -63,14 +65,18 @@ pub fn run(command: &AgentCommands) -> Result<()> {
             minutes,
             full,
             trim,
+            data,
         } => end(
             project,
             issue,
             phase,
-            summary.as_deref(),
-            minutes.as_deref(),
-            *full,
-            *trim,
+            Close {
+                summary: summary.as_deref(),
+                minutes: minutes.as_deref(),
+                full: *full,
+                trim: *trim,
+                data: data.clone(),
+            },
         ),
         AgentCommands::Activity(command) => activity_command(command),
         AgentCommands::Audit { auto_log } => run_audit(*auto_log),
@@ -307,6 +313,7 @@ fn write_auto_log(item: &audit::Unaccounted) -> Result<()> {
         idle: item.idle.clone(),
         trim: true,
         ended_at: Some(item.end),
+        data: None,
     })
 }
 
@@ -321,13 +328,22 @@ fn item(
     phase: &str,
     summary: Option<&str>,
     minutes: Option<&str>,
+    data: Option<serde_json::Value>,
 ) -> Result<()> {
     let (Some(summary), Some(minutes)) = (summary, minutes) else {
         eprintln!("tt: usage: tt agent item <project> <issue|-> <phase> <summary> <minutes>");
         std::process::exit(64);
     };
     let minutes = whole_minutes(minutes);
-    log_entry(project, issue, phase, summary, minutes, Span::unmarked())
+    log_entry(
+        project,
+        issue,
+        phase,
+        summary,
+        minutes,
+        Span::unmarked(),
+        data,
+    )
 }
 
 /// A minutes argument, or exit 64 with `minutes must be a whole number, got
@@ -374,6 +390,7 @@ fn log_entry(
     summary: &str,
     minutes: i64,
     span: Span,
+    data: Option<serde_json::Value>,
 ) -> Result<()> {
     commands::log(commands::LogRequest {
         description: description(project, issue, phase, summary),
@@ -383,7 +400,19 @@ fn log_entry(
         idle: span.idle,
         trim: span.trim,
         ended_at: span.ended_at,
+        data,
     })
+}
+
+/// Everything `tt agent end` was asked to close a phase with, apart from which
+/// phase it is: the summary, the duration override, the two silence flags and
+/// the custom data. One struct, so the phase stays three plain arguments.
+struct Close<'a> {
+    summary: Option<&'a str>,
+    minutes: Option<&'a str>,
+    full: bool,
+    trim: bool,
+    data: Option<serde_json::Value>,
 }
 
 /// `tt agent end <project> <issue|-> <phase> <summary> [minutes|--full|--trim]`:
@@ -392,15 +421,14 @@ fn log_entry(
 ///
 /// Explicit minutes win over both flags and skip the mark's timestamps entirely;
 /// `--full` logs the measured span, `--trim` the span minus every flagged gap.
-fn end(
-    project: &str,
-    issue: &str,
-    phase: &str,
-    summary: Option<&str>,
-    minutes: Option<&str>,
-    full: bool,
-    trim: bool,
-) -> Result<()> {
+fn end(project: &str, issue: &str, phase: &str, close: Close) -> Result<()> {
+    let Close {
+        summary,
+        minutes,
+        full,
+        trim,
+        data,
+    } = close;
     let Some(summary) = summary else {
         // Hand-checked: a required positional would exit 2, not 64.
         eprintln!(
@@ -490,6 +518,7 @@ fn end(
             trim: split_at_idle,
             ended_at: anchor,
         },
+        data,
     )?;
     // Cleared only once the entry is recorded, on every successful close; a
     // refusal returned above with the mark and its beats left in place.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -226,6 +226,7 @@ mod tests {
             start_time: at(start),
             end_time: end.map(at),
             idle: Vec::new(),
+            data: None,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,9 @@ pub enum Commands {
         /// Project this entry belongs to
         #[arg(long, add = ArgValueCandidates::new(completions::projects))]
         project: Option<String>,
+        /// Custom data as a JSON object, e.g. `--data '{"pr": 42}'`
+        #[arg(long, value_parser = parse_data)]
+        data: Option<serde_json::Value>,
     },
     /// Stop the current active task
     Stop,
@@ -54,6 +57,9 @@ pub enum Commands {
         /// silent no-op.
         #[arg(long, requires = "idle")]
         trim: bool,
+        /// Custom data as a JSON object, e.g. `--data '{"pr": 42}'`
+        #[arg(long, value_parser = parse_data)]
+        data: Option<serde_json::Value>,
     },
     /// Show all entries for today
     Today,
@@ -185,6 +191,9 @@ pub enum AgentCommands {
         summary: Option<String>,
         /// Whole minutes, rounded up to the nearest 5 minutes
         minutes: Option<String>,
+        /// Custom data as a JSON object, e.g. `--data '{"pr": 42}'`
+        #[arg(long, value_parser = parse_data)]
+        data: Option<serde_json::Value>,
     },
     /// Close a marked phase, measuring it to its last heartbeat
     End {
@@ -208,6 +217,9 @@ pub enum AgentCommands {
         /// each one
         #[arg(long)]
         trim: bool,
+        /// Custom data as a JSON object, e.g. `--data '{"pr": 42}'`
+        #[arg(long, value_parser = parse_data)]
+        data: Option<serde_json::Value>,
     },
     /// Hook-only activity ledger, hidden from `--help` — never called by the
     /// model. See docs/decisions/0001-agent-activity-tracking.md.
@@ -290,6 +302,14 @@ fn parse_duration(value: &str) -> Result<Duration, String> {
             value
         )
     })
+}
+
+/// Parse one `--data` value into the entry's custom data. Invalid JSON — or JSON
+/// that isn't an object — is a usage error, never an entry that silently dropped
+/// the field. Passing the flag means meaning it, so an empty value is refused too.
+fn parse_data(value: &str) -> Result<serde_json::Value, String> {
+    crate::entry_data::parse(value)?
+        .ok_or_else(|| "expected a JSON object, got an empty value".to_string())
 }
 
 /// Parse one `--idle` value: `<start>-<end>` in epoch seconds. A malformed value
@@ -416,6 +436,55 @@ mod tests {
             parsed.is_err(),
             "--trim alone parsed, so it would be a silent no-op"
         );
+    }
+
+    /// #72: a `--data` value that is not a JSON object is a usage error, so no
+    /// command can record an entry whose custom data was silently dropped.
+    #[test]
+    fn a_malformed_data_value_is_a_usage_error() {
+        for bad in [r#"{"a": }"#, "{", "not json", "[1,2]", "42", ""] {
+            let parsed = Cli::try_parse_from(["tt", "log", "-d", "x", "-t", "5m", "--data", bad]);
+            assert!(parsed.is_err(), "`{bad}` parsed instead of failing");
+        }
+    }
+
+    #[test]
+    fn a_json_object_parses_on_every_command_that_takes_data() {
+        let object = r#"{"pr": 42, "nested": {"ok": true}}"#;
+        let expected: serde_json::Value = serde_json::from_str(object).unwrap();
+
+        for args in [
+            vec!["tt", "start", "x", "--data", object],
+            vec!["tt", "log", "-d", "x", "-t", "5m", "--data", object],
+            vec![
+                "tt", "agent", "item", "p", "-", "impl", "s", "5", "--data", object,
+            ],
+            vec![
+                "tt", "agent", "end", "p", "-", "impl", "s", "--data", object,
+            ],
+        ] {
+            let cli = Cli::try_parse_from(&args)
+                .unwrap_or_else(|e| panic!("{args:?} failed to parse: {e}"));
+            let data = match cli.command {
+                Commands::Start { data, .. } | Commands::Log { data, .. } => data,
+                Commands::Agent { command } => match command {
+                    AgentCommands::Item { data, .. } | AgentCommands::End { data, .. } => data,
+                    _ => panic!("not a data-carrying agent command"),
+                },
+                _ => panic!("not a data-carrying command"),
+            };
+            assert_eq!(data, Some(expected.clone()), "{args:?}");
+        }
+    }
+
+    /// Omitting the flag leaves the field unset, so nothing is written to it.
+    #[test]
+    fn data_is_none_when_the_flag_is_absent() {
+        let cli = Cli::try_parse_from(["tt", "log", "-d", "x", "-t", "5m"]).unwrap();
+        match cli.command {
+            Commands::Log { data, .. } => assert_eq!(data, None),
+            _ => panic!("not a log command"),
+        }
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -103,23 +103,32 @@ fn entry_line(entry: &TimeEntry, with_date: bool) -> String {
     )
 }
 
-pub fn start(description: Vec<String>, project: Option<String>) -> Result<()> {
+pub fn start(
+    description: Vec<String>,
+    project: Option<String>,
+    data: Option<serde_json::Value>,
+) -> Result<()> {
     let raw_desc = description.join(" ");
     let (desc, tags) = parse_tags(&raw_desc);
     let start_time = Local::now();
 
     // One lock for the check and the insert, so two starts cannot both see nothing.
-    let already_tracking = with_data(|data| {
-        if let Some(active) = data.active_entry() {
+    let already_tracking = with_data(|store| {
+        if let Some(active) = store.active_entry() {
             return Ok(Some((active.description.clone(), active.start_time)));
         }
-        data.add_entry(
-            desc.clone(),
-            project.clone(),
-            tags.clone(),
-            start_time,
-            None,
-        );
+        let id = store
+            .add_entry(
+                desc.clone(),
+                project.clone(),
+                tags.clone(),
+                start_time,
+                None,
+            )
+            .id;
+        if data.is_some() {
+            store.set_entry_data(id, data.clone());
+        }
         Ok(None)
     })?;
 
@@ -184,6 +193,8 @@ pub struct LogRequest {
     pub trim: bool,
     /// Pins the timeline; see [`log`].
     pub ended_at: Option<DateTime<Local>>,
+    /// Custom JSON data, already validated by [`crate::entry_data::parse`].
+    pub data: Option<serde_json::Value>,
 }
 
 /// Record a finished entry, back-dated from its end. `ended_at` pins the
@@ -198,6 +209,7 @@ pub fn log(request: LogRequest) -> Result<()> {
         idle,
         trim,
         ended_at,
+        data: custom_data,
     } = request;
     let end_time = ended_at.unwrap_or_else(Local::now);
     let start_time = end_time - time;
@@ -221,6 +233,10 @@ pub fn log(request: LogRequest) -> Result<()> {
             .id;
         if let Some(entry) = data.entries.iter_mut().find(|e| e.id == entry_id) {
             entry.idle = idle;
+        }
+        if custom_data.is_some() {
+            // Set before the split, so every piece inherits it.
+            data.set_entry_data(entry_id, custom_data.clone());
         }
         // Do not lift this out of the closure: the insert and the split are one
         // store transaction.
@@ -388,6 +404,7 @@ mod tests {
                 project,
                 idle,
                 trim,
+                data,
             } => log(LogRequest {
                 description,
                 time,
@@ -396,6 +413,7 @@ mod tests {
                 idle,
                 trim,
                 ended_at: None,
+                data,
             })
             .unwrap(),
             _ => panic!("parse_log produced something other than a Log command"),
@@ -512,6 +530,73 @@ mod tests {
         assert!(
             !store.with_extension("json.tmp").exists(),
             "a temp store file survived the command"
+        );
+    }
+
+    #[test]
+    fn data_is_stored_on_the_logged_entry() {
+        let _guard = env_guard();
+        sandbox("log-data");
+
+        run_log(parse_log(&[
+            "-d",
+            "with data",
+            "-t",
+            "30m",
+            "--data",
+            r#"{"pr": 42}"#,
+        ]));
+
+        let data = storage::load_data().unwrap();
+        assert_eq!(
+            data.entries[0].data,
+            Some(serde_json::json!({"pr": 42})),
+            "--data did not reach the store"
+        );
+    }
+
+    /// Trimming happens after the data is set, so each piece carries it.
+    #[test]
+    fn data_lands_on_every_piece_of_a_trimmed_entry() {
+        let _guard = env_guard();
+        sandbox("log-data-trim");
+        let end = Local::now().timestamp();
+        let start = end - 7200;
+
+        run_log(parse_log(&[
+            "-d",
+            "long session",
+            "-t",
+            "2h",
+            &format!("--idle={}-{}", start + 600, start + 1500),
+            "--trim",
+            "--data",
+            r#"{"issue": 69}"#,
+        ]));
+
+        let stored = storage::load_data().unwrap();
+        assert_eq!(stored.entries.len(), 2);
+        for entry in &stored.entries {
+            assert_eq!(entry.data, Some(serde_json::json!({"issue": 69})));
+        }
+    }
+
+    #[test]
+    fn start_stores_its_data_on_the_active_entry() {
+        let _guard = env_guard();
+        sandbox("start-data");
+
+        start(
+            vec!["writing".to_string(), "docs".to_string()],
+            Some("tt".to_string()),
+            Some(serde_json::json!({"branch": "feat/69"})),
+        )
+        .unwrap();
+
+        let stored = storage::load_data().unwrap();
+        assert_eq!(
+            stored.entries[0].data,
+            Some(serde_json::json!({"branch": "feat/69"}))
         );
     }
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -170,6 +170,7 @@ mod tests {
             start_time: Local::now(),
             end_time: None,
             idle: Vec::new(),
+            data: None,
         }
     }
 

--- a/src/entry_data.rs
+++ b/src/entry_data.rs
@@ -46,95 +46,45 @@ pub fn to_edit_string(data: Option<&Value>) -> String {
     data.map(|v| v.to_string()).unwrap_or_default()
 }
 
-/// One display row. Every label already carries its indentation, so the renderer
-/// only decides colour and where the value sits.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Row {
-    /// `key        value` — the value in the detail popover's value column,
-    /// aligned with every other field on the popover.
-    Field { label: String, value: String },
-    /// A label with nothing beside it: a list's name, or a bare bullet standing
-    /// over the fields of one list item.
-    Heading(String),
-    /// `- value` — a list item, its value tight against the bullet rather than
-    /// out in the value column, so a list reads as a list. The label is the
-    /// indented dash; the renderer puts one space between the two.
-    Bullet { label: String, value: String },
-}
-
-/// Two spaces per level of nesting, the same step the bullets are indented by.
-const INDENT: &str = "  ";
-
-/// Flatten the object into display rows, in the order the data was written.
-///
-/// Nested objects join their keys with `.`, so an object stays one row per leaf.
-/// A list instead gets a heading of its own and one indented `- value` bullet
-/// per item, which reads as a list rather than as `name[0]`, `name[1]`, …
-pub fn rows(data: &Value) -> Vec<Row> {
+/// Flatten the object into display rows, one `(key, value)` per leaf. Nested
+/// objects join their keys with `.` and arrays index with `[i]`, so every row is
+/// one line however deep the data goes.
+pub fn rows(data: &Value) -> Vec<(String, String)> {
     let mut out = Vec::new();
     // The top level is walked here rather than through `flatten`, so an empty
     // object is no rows at all instead of one `{}` row with no key.
     match data {
         Value::Object(map) => {
             for (key, child) in map {
-                flatten(key.clone(), child, 0, &mut out);
+                flatten(key.clone(), child, &mut out);
             }
         }
-        other => flatten(String::new(), other, 0, &mut out),
+        other => flatten(String::new(), other, &mut out),
     }
     out
 }
 
-fn field(label: String, value: String) -> Row {
-    Row::Field { label, value }
-}
-
-fn flatten(path: String, value: &Value, depth: usize, out: &mut Vec<Row>) {
+fn flatten(prefix: String, value: &Value, out: &mut Vec<(String, String)>) {
     match value {
         Value::Object(map) if !map.is_empty() => {
             for (key, child) in map {
-                let path = if path.is_empty() {
+                let path = if prefix.is_empty() {
                     key.clone()
                 } else {
-                    format!("{}.{}", path, key)
+                    format!("{}.{}", prefix, key)
                 };
-                flatten(path, child, depth, out);
+                flatten(path, child, out);
             }
         }
         Value::Array(items) if !items.is_empty() => {
-            // A list nested straight inside a list item has no name of its own;
-            // the bullet above it is heading enough, so its own bullets sit at
-            // that depth rather than under an empty heading.
-            let depth = if path.is_empty() {
-                depth.saturating_sub(1)
-            } else {
-                out.push(Row::Heading(label(&format!("{}:", path), depth)));
-                depth
-            };
-            for child in items {
-                match child {
-                    // A nested item gets a bare bullet, with its own rows
-                    // indented under it, so `-` always starts exactly one item.
-                    Value::Object(_) | Value::Array(_) => {
-                        out.push(Row::Heading(label("-", depth + 1)));
-                        flatten(String::new(), child, depth + 2, out);
-                    }
-                    // A scalar item is the bullet itself.
-                    _ => out.push(Row::Bullet {
-                        label: label("-", depth + 1),
-                        value: scalar(child),
-                    }),
-                }
+            for (i, child) in items.iter().enumerate() {
+                flatten(format!("{}[{}]", prefix, i), child, out);
             }
         }
         // A leaf, plus the two empty containers — shown as themselves rather
         // than vanishing from the listing.
-        _ => out.push(field(label(&path, depth), scalar(value))),
+        _ => out.push((prefix, scalar(value))),
     }
-}
-
-fn label(text: &str, depth: usize) -> String {
-    format!("{}{}", INDENT.repeat(depth), text)
 }
 
 /// A leaf as it reads on screen: strings unquoted, everything else as JSON.
@@ -190,71 +140,35 @@ mod tests {
         assert_eq!(to_edit_string(None), "");
     }
 
-    /// Rows as text: `label|value` for an aligned field, `label value` for a
-    /// bullet, so both the indentation and which shape each row took are visible.
-    fn shown(value: &Value) -> Vec<String> {
-        rows(value)
-            .into_iter()
-            .map(|row| match row {
-                Row::Field { label, value } => format!("{}|{}", label, value),
-                Row::Heading(label) => label,
-                Row::Bullet { label, value } => format!("{} {}", label, value),
-            })
-            .collect()
-    }
-
-    /// Objects stay one row per leaf, keyed by their dotted path.
     #[test]
-    fn rows_flatten_objects_into_one_line_each() {
+    fn rows_flatten_nesting_into_one_line_each() {
+        let value = json!({
+            "pr": 42,
+            "review": {"by": "linus", "approved": true},
+            "files": ["a.rs", "b.rs"],
+        });
         assert_eq!(
-            shown(&json!({"pr": 42, "review": {"by": "linus", "approved": true}})),
-            vec!["pr|42", "review.by|linus", "review.approved|true"]
-        );
-    }
-
-    /// Written order, not alphabetical: the keys above come back b-before-a.
-    #[test]
-    fn rows_keep_the_order_the_data_was_written_in() {
-        let value: Value = serde_json::from_str(r#"{"zebra": 1, "apple": 2}"#).unwrap();
-        assert_eq!(shown(&value), vec!["zebra|1", "apple|2"]);
-    }
-
-    /// A list is a heading plus one bullet per item, never `name[0]`.
-    #[test]
-    fn rows_render_an_array_as_a_heading_and_bullets() {
-        assert_eq!(
-            shown(&json!({"files": ["a.rs", "b.rs"], "pr": 42})),
-            vec!["files:", "  - a.rs", "  - b.rs", "pr|42"]
-        );
-    }
-
-    /// An item that is itself a container gets a bare bullet, with its own rows
-    /// under it, so one `-` always starts exactly one item.
-    #[test]
-    fn rows_indent_the_fields_of_a_nested_list_item() {
-        assert_eq!(
-            shown(&json!({"reviews": [{"by": "linus", "ok": true}, "skipped"]})),
+            rows(&value),
             vec![
-                "reviews:",
-                "  -",
-                "    by|linus",
-                "    ok|true",
-                "  - skipped",
-            ]
-        );
-    }
-
-    #[test]
-    fn rows_indent_a_list_inside_a_list() {
-        assert_eq!(
-            shown(&json!({"groups": [["a", "b"]]})),
-            vec!["groups:", "  -", "    - a", "    - b"]
+                ("files[0]".to_string(), "a.rs".to_string()),
+                ("files[1]".to_string(), "b.rs".to_string()),
+                ("pr".to_string(), "42".to_string()),
+                ("review.approved".to_string(), "true".to_string()),
+                ("review.by".to_string(), "linus".to_string()),
+            ],
+            "serde_json orders object keys alphabetically"
         );
     }
 
     #[test]
     fn empty_containers_still_get_a_row() {
-        assert_eq!(shown(&json!({"a": {}, "b": []})), vec!["a|{}", "b|[]"]);
+        assert_eq!(
+            rows(&json!({"a": {}, "b": []})),
+            vec![
+                ("a".to_string(), "{}".to_string()),
+                ("b".to_string(), "[]".to_string()),
+            ]
+        );
         assert!(rows(&json!({})).is_empty(), "nothing to show at all");
     }
 }

--- a/src/entry_data.rs
+++ b/src/entry_data.rs
@@ -1,0 +1,174 @@
+//! The optional `data` field on an entry: free-form JSON that users and agents
+//! can hang extra information on. Parsed once at every boundary — `--data`, the
+//! TUI form — so nothing downstream ever holds a string that isn't valid JSON.
+
+use serde_json::Value;
+
+/// Parse one `--data` / form value. Blank means "no data"; anything else must be
+/// a JSON **object**, since the detail view renders it as key/value rows and a
+/// bare scalar or array has no keys to render.
+pub fn parse(raw: &str) -> Result<Option<Value>, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    let value: Value =
+        serde_json::from_str(raw).map_err(|e| format!("invalid JSON: {}", first_line(&e)))?;
+    if !value.is_object() {
+        return Err(format!(
+            "expected a JSON object like {{\"key\": \"value\"}}, got {}",
+            kind(&value)
+        ));
+    }
+    Ok(Some(value))
+}
+
+/// serde_json errors are single-line already, but stay defensive: a message with
+/// a newline in it would break the one-line form error row.
+fn first_line(error: &serde_json::Error) -> String {
+    error.to_string().lines().next().unwrap_or("").to_string()
+}
+
+fn kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+/// The stored data as compact JSON, for the single-line editor. Empty when unset,
+/// so an untouched field round-trips back through [`parse`] as `None`.
+pub fn to_edit_string(data: Option<&Value>) -> String {
+    data.map(|v| v.to_string()).unwrap_or_default()
+}
+
+/// Flatten the object into display rows, one `(key, value)` per leaf. Nested
+/// objects join their keys with `.` and arrays index with `[i]`, so every row is
+/// one line however deep the data goes.
+pub fn rows(data: &Value) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    // The top level is walked here rather than through `flatten`, so an empty
+    // object is no rows at all instead of one `{}` row with no key.
+    match data {
+        Value::Object(map) => {
+            for (key, child) in map {
+                flatten(key.clone(), child, &mut out);
+            }
+        }
+        other => flatten(String::new(), other, &mut out),
+    }
+    out
+}
+
+fn flatten(prefix: String, value: &Value, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            for (key, child) in map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{}.{}", prefix, key)
+                };
+                flatten(path, child, out);
+            }
+        }
+        Value::Array(items) if !items.is_empty() => {
+            for (i, child) in items.iter().enumerate() {
+                flatten(format!("{}[{}]", prefix, i), child, out);
+            }
+        }
+        // A leaf, plus the two empty containers — shown as themselves rather
+        // than vanishing from the listing.
+        _ => out.push((prefix, scalar(value))),
+    }
+}
+
+/// A leaf as it reads on screen: strings unquoted, everything else as JSON.
+fn scalar(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_blank_value_is_no_data_not_an_error() {
+        assert_eq!(parse(""), Ok(None));
+        assert_eq!(parse("   "), Ok(None));
+    }
+
+    #[test]
+    fn an_object_parses_to_itself() {
+        assert_eq!(
+            parse(r#"{"pr": 42, "reviewed": true}"#),
+            Ok(Some(json!({"pr": 42, "reviewed": true})))
+        );
+    }
+
+    #[test]
+    fn malformed_json_is_an_error_not_a_dropped_field() {
+        for bad in [r#"{"a": }"#, "{", "not json", r#"{"a": 1,}"#] {
+            assert!(parse(bad).is_err(), "`{bad}` parsed instead of failing");
+        }
+    }
+
+    /// A scalar or array is valid JSON but has no keys to render.
+    #[test]
+    fn a_non_object_is_rejected_by_name() {
+        assert_eq!(
+            parse("[1, 2]"),
+            Err("expected a JSON object like {\"key\": \"value\"}, got an array".to_string())
+        );
+        assert!(parse("42").unwrap_err().ends_with("got a number"));
+        assert!(parse("\"hi\"").unwrap_err().ends_with("got a string"));
+    }
+
+    #[test]
+    fn an_edit_string_round_trips_through_parse() {
+        let value = json!({"issue": 69, "tags": ["a", "b"]});
+        let edited = to_edit_string(Some(&value));
+        assert_eq!(parse(&edited), Ok(Some(value)));
+        assert_eq!(to_edit_string(None), "");
+    }
+
+    #[test]
+    fn rows_flatten_nesting_into_one_line_each() {
+        let value = json!({
+            "pr": 42,
+            "review": {"by": "linus", "approved": true},
+            "files": ["a.rs", "b.rs"],
+        });
+        assert_eq!(
+            rows(&value),
+            vec![
+                ("files[0]".to_string(), "a.rs".to_string()),
+                ("files[1]".to_string(), "b.rs".to_string()),
+                ("pr".to_string(), "42".to_string()),
+                ("review.approved".to_string(), "true".to_string()),
+                ("review.by".to_string(), "linus".to_string()),
+            ],
+            "serde_json orders object keys alphabetically"
+        );
+    }
+
+    #[test]
+    fn empty_containers_still_get_a_row() {
+        assert_eq!(
+            rows(&json!({"a": {}, "b": []})),
+            vec![
+                ("a".to_string(), "{}".to_string()),
+                ("b".to_string(), "[]".to_string()),
+            ]
+        );
+        assert!(rows(&json!({})).is_empty(), "nothing to show at all");
+    }
+}

--- a/src/entry_data.rs
+++ b/src/entry_data.rs
@@ -46,45 +46,95 @@ pub fn to_edit_string(data: Option<&Value>) -> String {
     data.map(|v| v.to_string()).unwrap_or_default()
 }
 
-/// Flatten the object into display rows, one `(key, value)` per leaf. Nested
-/// objects join their keys with `.` and arrays index with `[i]`, so every row is
-/// one line however deep the data goes.
-pub fn rows(data: &Value) -> Vec<(String, String)> {
+/// One display row. Every label already carries its indentation, so the renderer
+/// only decides colour and where the value sits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Row {
+    /// `key        value` — the value in the detail popover's value column,
+    /// aligned with every other field on the popover.
+    Field { label: String, value: String },
+    /// A label with nothing beside it: a list's name, or a bare bullet standing
+    /// over the fields of one list item.
+    Heading(String),
+    /// `- value` — a list item, its value tight against the bullet rather than
+    /// out in the value column, so a list reads as a list. The label is the
+    /// indented dash; the renderer puts one space between the two.
+    Bullet { label: String, value: String },
+}
+
+/// Two spaces per level of nesting, the same step the bullets are indented by.
+const INDENT: &str = "  ";
+
+/// Flatten the object into display rows, in the order the data was written.
+///
+/// Nested objects join their keys with `.`, so an object stays one row per leaf.
+/// A list instead gets a heading of its own and one indented `- value` bullet
+/// per item, which reads as a list rather than as `name[0]`, `name[1]`, …
+pub fn rows(data: &Value) -> Vec<Row> {
     let mut out = Vec::new();
     // The top level is walked here rather than through `flatten`, so an empty
     // object is no rows at all instead of one `{}` row with no key.
     match data {
         Value::Object(map) => {
             for (key, child) in map {
-                flatten(key.clone(), child, &mut out);
+                flatten(key.clone(), child, 0, &mut out);
             }
         }
-        other => flatten(String::new(), other, &mut out),
+        other => flatten(String::new(), other, 0, &mut out),
     }
     out
 }
 
-fn flatten(prefix: String, value: &Value, out: &mut Vec<(String, String)>) {
+fn field(label: String, value: String) -> Row {
+    Row::Field { label, value }
+}
+
+fn flatten(path: String, value: &Value, depth: usize, out: &mut Vec<Row>) {
     match value {
         Value::Object(map) if !map.is_empty() => {
             for (key, child) in map {
-                let path = if prefix.is_empty() {
+                let path = if path.is_empty() {
                     key.clone()
                 } else {
-                    format!("{}.{}", prefix, key)
+                    format!("{}.{}", path, key)
                 };
-                flatten(path, child, out);
+                flatten(path, child, depth, out);
             }
         }
         Value::Array(items) if !items.is_empty() => {
-            for (i, child) in items.iter().enumerate() {
-                flatten(format!("{}[{}]", prefix, i), child, out);
+            // A list nested straight inside a list item has no name of its own;
+            // the bullet above it is heading enough, so its own bullets sit at
+            // that depth rather than under an empty heading.
+            let depth = if path.is_empty() {
+                depth.saturating_sub(1)
+            } else {
+                out.push(Row::Heading(label(&format!("{}:", path), depth)));
+                depth
+            };
+            for child in items {
+                match child {
+                    // A nested item gets a bare bullet, with its own rows
+                    // indented under it, so `-` always starts exactly one item.
+                    Value::Object(_) | Value::Array(_) => {
+                        out.push(Row::Heading(label("-", depth + 1)));
+                        flatten(String::new(), child, depth + 2, out);
+                    }
+                    // A scalar item is the bullet itself.
+                    _ => out.push(Row::Bullet {
+                        label: label("-", depth + 1),
+                        value: scalar(child),
+                    }),
+                }
             }
         }
         // A leaf, plus the two empty containers — shown as themselves rather
         // than vanishing from the listing.
-        _ => out.push((prefix, scalar(value))),
+        _ => out.push(field(label(&path, depth), scalar(value))),
     }
+}
+
+fn label(text: &str, depth: usize) -> String {
+    format!("{}{}", INDENT.repeat(depth), text)
 }
 
 /// A leaf as it reads on screen: strings unquoted, everything else as JSON.
@@ -140,35 +190,71 @@ mod tests {
         assert_eq!(to_edit_string(None), "");
     }
 
+    /// Rows as text: `label|value` for an aligned field, `label value` for a
+    /// bullet, so both the indentation and which shape each row took are visible.
+    fn shown(value: &Value) -> Vec<String> {
+        rows(value)
+            .into_iter()
+            .map(|row| match row {
+                Row::Field { label, value } => format!("{}|{}", label, value),
+                Row::Heading(label) => label,
+                Row::Bullet { label, value } => format!("{} {}", label, value),
+            })
+            .collect()
+    }
+
+    /// Objects stay one row per leaf, keyed by their dotted path.
     #[test]
-    fn rows_flatten_nesting_into_one_line_each() {
-        let value = json!({
-            "pr": 42,
-            "review": {"by": "linus", "approved": true},
-            "files": ["a.rs", "b.rs"],
-        });
+    fn rows_flatten_objects_into_one_line_each() {
         assert_eq!(
-            rows(&value),
+            shown(&json!({"pr": 42, "review": {"by": "linus", "approved": true}})),
+            vec!["pr|42", "review.by|linus", "review.approved|true"]
+        );
+    }
+
+    /// Written order, not alphabetical: the keys above come back b-before-a.
+    #[test]
+    fn rows_keep_the_order_the_data_was_written_in() {
+        let value: Value = serde_json::from_str(r#"{"zebra": 1, "apple": 2}"#).unwrap();
+        assert_eq!(shown(&value), vec!["zebra|1", "apple|2"]);
+    }
+
+    /// A list is a heading plus one bullet per item, never `name[0]`.
+    #[test]
+    fn rows_render_an_array_as_a_heading_and_bullets() {
+        assert_eq!(
+            shown(&json!({"files": ["a.rs", "b.rs"], "pr": 42})),
+            vec!["files:", "  - a.rs", "  - b.rs", "pr|42"]
+        );
+    }
+
+    /// An item that is itself a container gets a bare bullet, with its own rows
+    /// under it, so one `-` always starts exactly one item.
+    #[test]
+    fn rows_indent_the_fields_of_a_nested_list_item() {
+        assert_eq!(
+            shown(&json!({"reviews": [{"by": "linus", "ok": true}, "skipped"]})),
             vec![
-                ("files[0]".to_string(), "a.rs".to_string()),
-                ("files[1]".to_string(), "b.rs".to_string()),
-                ("pr".to_string(), "42".to_string()),
-                ("review.approved".to_string(), "true".to_string()),
-                ("review.by".to_string(), "linus".to_string()),
-            ],
-            "serde_json orders object keys alphabetically"
+                "reviews:",
+                "  -",
+                "    by|linus",
+                "    ok|true",
+                "  - skipped",
+            ]
+        );
+    }
+
+    #[test]
+    fn rows_indent_a_list_inside_a_list() {
+        assert_eq!(
+            shown(&json!({"groups": [["a", "b"]]})),
+            vec!["groups:", "  -", "    - a", "    - b"]
         );
     }
 
     #[test]
     fn empty_containers_still_get_a_row() {
-        assert_eq!(
-            rows(&json!({"a": {}, "b": []})),
-            vec![
-                ("a".to_string(), "{}".to_string()),
-                ("b".to_string(), "[]".to_string()),
-            ]
-        );
+        assert_eq!(shown(&json!({"a": {}, "b": []})), vec!["a|{}", "b|[]"]);
         assert!(rows(&json!({})).is_empty(), "nothing to show at all");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod commands;
 mod completions;
 mod config;
 mod duration;
+mod entry_data;
 mod icons;
 mod marks;
 mod paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,8 @@ fn main() -> Result<()> {
         Commands::Start {
             description,
             project,
-        } => commands::start(description, project),
+            data,
+        } => commands::start(description, project, data),
         Commands::Stop => commands::stop(),
         Commands::Log {
             description,
@@ -75,6 +76,7 @@ fn main() -> Result<()> {
             project,
             idle,
             trim,
+            data,
         } => commands::log(commands::LogRequest {
             description,
             time,
@@ -83,6 +85,7 @@ fn main() -> Result<()> {
             idle,
             trim,
             ended_at: None,
+            data,
         }),
         Commands::Today => commands::today(),
         Commands::Report {

--- a/src/report.rs
+++ b/src/report.rs
@@ -365,6 +365,7 @@ mod tests {
             start_time: start,
             end_time: Some(start + Duration::minutes(minutes)),
             idle: Vec::new(),
+            data: None,
         }
     }
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -18,6 +18,11 @@ pub struct TimeEntry {
     /// Silent stretches inside this entry's span, as `tt log --idle` recorded them.
     #[serde(default)]
     pub idle: Vec<IdleInterval>,
+    /// Free-form JSON hung on the entry by `--data` or the form's Data field.
+    /// Always an object; see [`crate::entry_data`], which is the only thing that
+    /// builds one. Skipped when unset, so entries without it are unchanged on disk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
 }
 
 /// One silent stretch inside an entry.
@@ -295,6 +300,7 @@ impl TimeData {
             start_time,
             end_time,
             idle: Vec::new(),
+            data: None,
         };
         self.next_id += 1;
         self.entries.push(entry);
@@ -387,6 +393,19 @@ impl TimeData {
         }
     }
 
+    /// Set (or with `None`, clear) an entry's custom data. Separate from
+    /// `add_entry`/`update_entry` so every writer — `--data`, the form — goes
+    /// through one place, and `None` always means "clear it".
+    pub fn set_entry_data(&mut self, id: u64, data: Option<serde_json::Value>) -> bool {
+        match self.entries.iter_mut().find(|e| e.id == id) {
+            Some(entry) => {
+                entry.data = data;
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Get an entry by ID
     pub fn get_entry(&self, id: u64) -> Option<&TimeEntry> {
         self.entries.iter().find(|e| e.id == id)
@@ -397,7 +416,8 @@ impl TimeData {
     /// first, or an empty vec when nothing changed.
     ///
     /// The earliest piece keeps the original id in place, later pieces take fresh
-    /// ids from `next_id`, and every piece inherits description, project and tags.
+    /// ids from `next_id`, and every piece inherits description, project, tags
+    /// and custom data.
     ///
     /// [`TimeEntry::trim_spans`] owns the arithmetic; this is the mutation and the
     /// id policy only, pure over `&mut self` so the caller owns the transaction.
@@ -441,6 +461,7 @@ impl TimeData {
                     start_time: piece_start,
                     end_time: Some(piece_end),
                     idle: inside,
+                    data: template.data.clone(),
                 });
                 ids.push(new_id);
             }
@@ -466,6 +487,7 @@ mod tests {
             start_time: Local::now(),
             end_time: None,
             idle: Vec::new(),
+            data: None,
         }
     }
 
@@ -557,6 +579,7 @@ mod tests {
                         )
                     })
                     .collect(),
+                data: None,
             }],
             next_id: 8,
             schema_version: 1,
@@ -768,6 +791,66 @@ mod tests {
     }
 
     #[test]
+    fn custom_data_is_absent_from_the_json_until_it_is_set() {
+        let mut data = TimeData {
+            entries: vec![entry(1, None, &["tt"])],
+            next_id: 2,
+            schema_version: 1,
+        };
+        assert!(
+            !serde_json::to_string(&data).unwrap().contains("\"data\""),
+            "an unset field must not appear on disk"
+        );
+
+        assert!(data.set_entry_data(1, Some(serde_json::json!({"pr": 69}))));
+        assert!(!data.set_entry_data(999, None), "an unknown id");
+
+        let round_tripped: TimeData =
+            serde_json::from_str(&serde_json::to_string(&data).unwrap()).unwrap();
+        assert_eq!(
+            round_tripped.entries[0].data,
+            Some(serde_json::json!({"pr": 69}))
+        );
+
+        assert!(data.set_entry_data(1, None));
+        assert_eq!(data.entries[0].data, None, "None clears it");
+    }
+
+    #[test]
+    fn a_store_written_before_custom_data_existed_loads_with_none() {
+        let json = r#"{
+            "entries": [
+                {
+                    "id": 1,
+                    "description": "an older entry",
+                    "tags": [],
+                    "start_time": "2026-08-18T09:00:00+02:00",
+                    "end_time": "2026-08-18T10:00:00+02:00"
+                }
+            ],
+            "next_id": 2,
+            "schema_version": 1
+        }"#;
+
+        let data: TimeData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.entries[0].data, None, "absent means none");
+    }
+
+    /// Trimming copies the data onto every piece, the way it copies the tags.
+    #[test]
+    fn split_pieces_inherit_the_custom_data() {
+        let mut data = logged_with_idle(120, &[(50, 80)]);
+        data.set_entry_data(7, Some(serde_json::json!({"issue": 69})));
+
+        data.split_at_idle(7);
+
+        assert_eq!(data.entries.len(), 2);
+        for entry in &data.entries {
+            assert_eq!(entry.data, Some(serde_json::json!({"issue": 69})));
+        }
+    }
+
+    #[test]
     fn migrate_is_idempotent() {
         let mut data = TimeData {
             entries: vec![entry(1, None, &["tt", "impl"])],
@@ -806,6 +889,7 @@ mod tests {
             start_time: start,
             end_time: Some(start + Duration::minutes(minutes)),
             idle: Vec::new(),
+            data: None,
         }
     }
 

--- a/src/tui/entry_form.rs
+++ b/src/tui/entry_form.rs
@@ -4,14 +4,16 @@ use super::types::{InputField, InputMode, ViewMode};
 use anyhow::Result;
 use chrono::{DateTime, Local, NaiveDate};
 
-/// A submittable form resolved into the fields `add_entry` takes: description,
-/// tags, start, and the end an open entry does not have.
-type EntryFields = (
-    String,
-    Vec<String>,
-    DateTime<Local>,
-    Option<DateTime<Local>>,
-);
+/// A submittable form resolved into what the store takes: description, tags,
+/// start, the end an open entry does not have, and the custom JSON.
+struct EntryFields {
+    description: String,
+    tags: Vec<String>,
+    start_time: DateTime<Local>,
+    end_time: Option<DateTime<Local>>,
+    /// `None` for a blank Data field, which clears the entry's data on an edit.
+    data: Option<serde_json::Value>,
+}
 
 impl App {
     pub(crate) fn start_adding(&mut self) {
@@ -39,6 +41,8 @@ impl App {
         self.input_start_time.clear();
         self.input_end_time.clear();
         self.input_duration.clear();
+        self.input_data.clear();
+        self.form_error = None;
     }
 
     pub(crate) fn start_editing(&mut self) {
@@ -56,13 +60,18 @@ impl App {
                             .end_time
                             .map(|t| t.format("%Y-%m-%d %H:%M").to_string()),
                         entry.end_time.map(|_| entry.format_duration()),
+                        crate::entry_data::to_edit_string(entry.data.as_ref()),
                     )
                 })
             })
         };
 
-        if let Some((id, description, project, tags, start_time, end_time, duration)) = entry_data {
+        if let Some((id, description, project, tags, start_time, end_time, duration, data)) =
+            entry_data
+        {
             self.editing_entry_id = Some(id);
+            self.input_data.set_from(&data);
+            self.form_error = None;
             self.input_description.set_from(&description);
             self.input_project.set_from(&project);
             self.input_tags.set_from(&tags);
@@ -75,29 +84,60 @@ impl App {
     }
 
     /// Validates the current form input and resolves it into entry fields.
-    /// Returns `None` if the form isn't currently submittable (empty
-    /// description, unresolvable start/end times).
-    fn build_entry_fields(&self) -> Option<EntryFields> {
+    /// `Ok(None)` is "not submittable yet" — an empty description or
+    /// unresolvable start/end times, both of which the user is still typing
+    /// their way out of. `Err` is a value that will never resolve however much
+    /// more is typed: today only invalid JSON in the Data field.
+    fn build_entry_fields(&self) -> Result<Option<EntryFields>, String> {
         if self.input_description.is_empty() {
-            return None;
+            return Ok(None);
         }
-        let (start_time, end_time) = self.resolve_times()?;
-        Some((
-            self.input_description.value().to_string(),
-            self.parse_tags(),
+        // Parsed before the times, so a bad Data field is reported even while the
+        // times are still half-typed.
+        let data = crate::entry_data::parse(self.input_data.value())?;
+        let Some((start_time, end_time)) = self.resolve_times() else {
+            return Ok(None);
+        };
+        Ok(Some(EntryFields {
+            description: self.input_description.value().to_string(),
+            tags: self.parse_tags(),
             start_time,
             end_time,
-        ))
+            data,
+        }))
+    }
+
+    /// The fields to save, or `None` when there is nothing to save yet. A
+    /// rejected value is left on screen with `form_error` set, so nothing is
+    /// written and the form stays open on what the user typed.
+    fn fields_to_save(&mut self) -> Option<EntryFields> {
+        match self.build_entry_fields() {
+            Ok(fields) => fields,
+            Err(message) => {
+                self.form_error = Some(message);
+                None
+            }
+        }
     }
 
     pub(crate) fn submit_entry(&mut self) -> Result<()> {
-        let Some((description, tags, start_time, end_time)) = self.build_entry_fields() else {
+        let Some(fields) = self.fields_to_save() else {
             return Ok(());
         };
+        let EntryFields {
+            description,
+            tags,
+            start_time,
+            end_time,
+            data,
+        } = fields;
         let project = self.parse_project();
         // Added against the freshly loaded store, so the id is the current `next_id`.
-        self.mutate_store(|data| {
-            data.add_entry(description, project, tags, start_time, end_time);
+        self.mutate_store(|store| {
+            let id = store
+                .add_entry(description, project, tags, start_time, end_time)
+                .id;
+            store.set_entry_data(id, data);
         })?;
         self.cancel_adding();
         Ok(())
@@ -107,13 +147,22 @@ impl App {
         let Some(entry_id) = self.editing_entry_id else {
             return Ok(());
         };
-        let Some((description, tags, start_time, end_time)) = self.build_entry_fields() else {
+        let Some(fields) = self.fields_to_save() else {
             return Ok(());
         };
+        let EntryFields {
+            description,
+            tags,
+            start_time,
+            end_time,
+            data,
+        } = fields;
         let project = self.parse_project();
         // Updating an id that is no longer in the store returns false, not an error.
-        self.mutate_store(|data| {
-            data.update_entry(entry_id, description, project, tags, start_time, end_time)
+        self.mutate_store(|store| {
+            // A blank Data field clears the entry's data, so an edit can remove it.
+            store.set_entry_data(entry_id, data);
+            store.update_entry(entry_id, description, project, tags, start_time, end_time)
         })?;
         self.cancel_adding();
         Ok(())
@@ -128,7 +177,8 @@ impl App {
             InputField::Tags => InputField::Duration,
             InputField::Duration => InputField::StartTime,
             InputField::StartTime => InputField::EndTime,
-            InputField::EndTime => InputField::Description,
+            InputField::EndTime => InputField::Data,
+            InputField::Data => InputField::Description,
         };
         self.field_mut().cursor_to_end();
     }
@@ -137,21 +187,25 @@ impl App {
         let leaving = self.input_field;
         self.apply_time_calculations(leaving);
         self.input_field = match self.input_field {
-            InputField::Description => InputField::EndTime,
+            InputField::Description => InputField::Data,
             InputField::Project => InputField::Description,
             InputField::Tags => InputField::Project,
             InputField::Duration => InputField::Tags,
             InputField::StartTime => InputField::Duration,
             InputField::EndTime => InputField::StartTime,
+            InputField::Data => InputField::EndTime,
         };
         self.field_mut().cursor_to_end();
     }
 
     pub(crate) fn handle_input_char(&mut self, c: char) {
+        // Typing is the fix for whatever the last save was refused over.
+        self.form_error = None;
         self.field_mut().insert(c);
     }
 
     pub(crate) fn handle_input_backspace(&mut self) {
+        self.form_error = None;
         self.field_mut().backspace();
     }
 
@@ -166,6 +220,7 @@ impl App {
             InputField::StartTime => &mut self.input_start_time,
             InputField::EndTime => &mut self.input_end_time,
             InputField::Duration => &mut self.input_duration,
+            InputField::Data => &mut self.input_data,
         }
     }
 

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -247,6 +247,7 @@ mod tests {
             start_time: Local::now() - chrono::Duration::hours(2),
             end_time: Some(Local::now() - chrono::Duration::hours(1)),
             idle: Vec::new(),
+            data: None,
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2098,6 +2098,50 @@ mod tests {
         assert_eq!(first.0 - second.0, 1, "cursor column ignored display width");
     }
 
+    /// #70: the popover lists the custom JSON as key/value rows under a Data
+    /// header, flattening nesting rather than printing raw JSON.
+    #[test]
+    fn the_detail_popover_renders_custom_data_as_key_value_rows() {
+        let _guard = env_guard();
+        sandbox("detail-data");
+        let mut with_data = entry(0, "has data");
+        with_data.data = Some(serde_json::json!({
+            "pr": 42,
+            "review": {"by": "linus"},
+        }));
+        seed(vec![with_data], 1);
+
+        let mut app = App::new().unwrap();
+        app.table_state.select(Some(0));
+        app.open_detail();
+        let screen = frame_lines(&mut app, 100, 40).join("\n");
+
+        assert!(screen.contains("Data"), "no Data header:\n{screen}");
+        assert!(screen.contains("pr"), "no key row:\n{screen}");
+        assert!(screen.contains("42"), "no value:\n{screen}");
+        assert!(
+            screen.contains("review.by") && screen.contains("linus"),
+            "nesting was not flattened:\n{screen}"
+        );
+        assert!(!screen.contains('{'), "raw JSON leaked in:\n{screen}");
+    }
+
+    /// An entry without data is rendered exactly as it was before the field existed.
+    #[test]
+    fn the_detail_popover_has_no_data_section_without_data() {
+        let _guard = env_guard();
+        sandbox("detail-no-data");
+        seed(vec![entry(0, "plain")], 1);
+
+        let mut app = App::new().unwrap();
+        app.table_state.select(Some(0));
+        app.open_detail();
+        let screen = frame_lines(&mut app, 100, 40).join("\n");
+
+        assert!(screen.contains("Description"), "the popover did draw");
+        assert!(!screen.contains("Data"), "an empty Data header:\n{screen}");
+    }
+
     #[test]
     fn the_agents_panel_renders_the_unaccounted_section_when_flagged() {
         let _guard = env_guard();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -412,6 +412,7 @@ mod tests {
             start_time: Local::now(),
             end_time: None,
             idle: Vec::new(),
+            data: None,
         }
     }
 
@@ -817,6 +818,7 @@ mod tests {
             start_time: start,
             end_time: Some(start + chrono::Duration::minutes(minutes)),
             idle: Vec::new(),
+            data: None,
         }
     }
 
@@ -2858,6 +2860,7 @@ mod tests {
                     start_time: start,
                     end_time: Some(start + chrono::Duration::hours(2)),
                     idle: Vec::new(),
+                    data: None,
                 },
                 dated(7, "unrelated", "vinge", &["ops"], today),
             ],

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2210,22 +2210,75 @@ mod tests {
         with_data.data = Some(serde_json::json!({
             "pr": 42,
             "review": {"by": "linus"},
+            "files": ["a.rs", "b.rs"],
         }));
         seed(vec![with_data], 1);
 
         let mut app = App::new().unwrap();
         app.table_state.select(Some(0));
         app.open_detail();
-        let screen = frame_lines(&mut app, 100, 40).join("\n");
+        let screen = frame_lines(&mut app, 100, 40);
+        let joined = screen.join("\n");
+        let row_of = |needle: &str| {
+            screen
+                .iter()
+                .position(|line| line.contains(needle))
+                .unwrap_or_else(|| panic!("{needle} is missing:\n{joined}"))
+        };
 
-        assert!(screen.contains("Data"), "no Data header:\n{screen}");
-        assert!(screen.contains("pr"), "no key row:\n{screen}");
-        assert!(screen.contains("42"), "no value:\n{screen}");
+        // One popover row's text, with the frame it is drawn inside removed.
+        let inner = |row: usize| screen[row].trim_matches(['│', ' ']).to_string();
+        let header = screen
+            .iter()
+            .position(|line| line.trim_matches(['│', ' ']) == "Data")
+            .unwrap_or_else(|| panic!("no Data header:\n{joined}"));
         assert!(
-            screen.contains("review.by") && screen.contains("linus"),
-            "nesting was not flattened:\n{screen}"
+            inner(header + 1).is_empty(),
+            "no blank row under the Data header:\n{joined}"
         );
-        assert!(!screen.contains('{'), "raw JSON leaked in:\n{screen}");
+        assert!(joined.contains("pr"), "no key row:\n{joined}");
+        assert!(joined.contains("42"), "no value:\n{joined}");
+        assert!(
+            joined.contains("review.by") && joined.contains("linus"),
+            "nesting was not flattened:\n{joined}"
+        );
+        // The list reads as a list: a heading, then one bullet per item.
+        assert_eq!(
+            inner(row_of("files:")),
+            "files:",
+            "the list heading carried a value:\n{joined}"
+        );
+        for (item, row) in [("a.rs", row_of("a.rs")), ("b.rs", row_of("b.rs"))] {
+            let shown = inner(row);
+            assert!(
+                shown.starts_with('-') && shown.ends_with(item),
+                "`{shown}` is not a bullet for {item}:\n{joined}"
+            );
+        }
+        assert!(!joined.contains("files[0]"), "indexed rows:\n{joined}");
+        assert!(!joined.contains('{'), "raw JSON leaked in:\n{joined}");
+    }
+
+    /// The written order is the rendered order, whatever the alphabet says.
+    #[test]
+    fn the_detail_popover_keeps_the_data_in_written_order() {
+        let _guard = env_guard();
+        sandbox("detail-data-order");
+        let mut with_data = entry(0, "has data");
+        with_data.data = Some(serde_json::from_str(r#"{"zebra": 1, "apple": 2}"#).unwrap());
+        seed(vec![with_data], 1);
+
+        let mut app = App::new().unwrap();
+        app.table_state.select(Some(0));
+        app.open_detail();
+        let screen = frame_lines(&mut app, 100, 40);
+        let row_of = |needle: &str| screen.iter().position(|l| l.contains(needle)).unwrap();
+
+        assert!(
+            row_of("zebra") < row_of("apple"),
+            "the rows were sorted:\n{}",
+            screen.join("\n")
+        );
     }
 
     /// An entry without data is rendered exactly as it was before the field existed.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -62,6 +62,11 @@ pub(crate) struct App {
     pub(crate) input_start_time: TextInput,
     pub(crate) input_end_time: TextInput,
     pub(crate) input_duration: TextInput,
+    /// The Data field's raw text: compact JSON, or empty for no data.
+    pub(crate) input_data: TextInput,
+    /// Why the last save was refused, shown in the form's help row and cleared
+    /// by the next keystroke. Only invalid JSON raises one today.
+    pub(crate) form_error: Option<String>,
     pub(crate) search_term: TextInput,
     /// Each pane's tri-state filter. OR within a pane's includes, AND across the two.
     pub(crate) project_filter: panes::PaneFilter,
@@ -162,6 +167,8 @@ impl App {
             input_start_time: TextInput::default(),
             input_end_time: TextInput::default(),
             input_duration: TextInput::default(),
+            input_data: TextInput::default(),
+            form_error: None,
             search_term: TextInput::default(),
             project_filter: panes::PaneFilter::default(),
             tag_filter: panes::PaneFilter::default(),
@@ -2061,6 +2068,7 @@ mod tests {
             " Duration (optional",
             " Start Time (",
             " End Time (optional",
+            " Data (optional",
             " Add Log Entry ", // the help row's own block title
         ]
         .iter()
@@ -2096,6 +2104,100 @@ mod tests {
         assert_eq!(second.1 - first.1, 3, "cursor did not follow the Tab order");
         // "héllo" is five columns wide, "acme" four — both share the chunk's x.
         assert_eq!(first.0 - second.0, 1, "cursor column ignored display width");
+    }
+
+    /// #73: what the Data field holds is parsed and stored on save.
+    #[test]
+    fn the_form_saves_the_data_field_as_json() {
+        let _guard = env_guard();
+        sandbox("form-data-save");
+        seed(vec![], 0);
+
+        let mut app = App::new().unwrap();
+        app.start_adding();
+        app.input_description.set_from("with data");
+        app.input_duration.set_from("30m");
+        app.input_data.set_from(r#"{"pr": 42}"#);
+        app.submit_entry().unwrap();
+
+        assert_eq!(app.input_mode, InputMode::Normal, "the form stayed open");
+        let stored = storage::load_data().unwrap();
+        assert_eq!(stored.entries[0].data, Some(serde_json::json!({"pr": 42})));
+    }
+
+    /// #72: invalid JSON refuses the save, says so, and writes nothing.
+    #[test]
+    fn invalid_json_refuses_the_save_and_reports_it() {
+        let _guard = env_guard();
+        sandbox("form-data-invalid");
+        seed(vec![], 0);
+
+        let mut app = App::new().unwrap();
+        app.start_adding();
+        app.input_description.set_from("with data");
+        app.input_duration.set_from("30m");
+        app.input_data.set_from("{not json");
+        app.submit_entry().unwrap();
+
+        assert_eq!(
+            app.input_mode,
+            InputMode::AddingEntry,
+            "the form closed over a value it never saved"
+        );
+        assert!(app.form_error.is_some(), "no reason was given");
+        assert!(
+            storage::load_data().unwrap().entries.is_empty(),
+            "a refused save still wrote an entry"
+        );
+        // The message reaches the screen, in the help row.
+        let screen = frame_lines(&mut app, 120, 40).join("\n");
+        assert!(screen.contains("invalid JSON"), "not shown:\n{screen}");
+
+        // Typing clears it, and a valid value then saves.
+        app.input_field = InputField::Data;
+        app.handle_input_backspace();
+        assert_eq!(app.form_error, None, "the error outlived the edit");
+        app.input_data.set_from(r#"{"ok": true}"#);
+        app.submit_entry().unwrap();
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert_eq!(
+            storage::load_data().unwrap().entries[0].data,
+            Some(serde_json::json!({"ok": true}))
+        );
+    }
+
+    /// Editing round-trips the stored JSON through the field, and blanking it
+    /// clears the entry's data rather than leaving the old value behind.
+    #[test]
+    fn editing_round_trips_the_data_field_and_a_blank_clears_it() {
+        let _guard = env_guard();
+        sandbox("form-data-edit");
+        let mut with_data = entry(0, "has data");
+        with_data.end_time = Some(with_data.start_time + chrono::Duration::hours(1));
+        with_data.data = Some(serde_json::json!({"pr": 42}));
+        seed(vec![with_data], 1);
+
+        let mut app = App::new().unwrap();
+        app.table_state.select(Some(0));
+        app.start_editing();
+        assert_eq!(app.input_data.value(), r#"{"pr":42}"#);
+
+        app.input_data.set_from(r#"{"pr":43}"#);
+        app.submit_edit().unwrap();
+        assert_eq!(
+            storage::load_data().unwrap().entries[0].data,
+            Some(serde_json::json!({"pr": 43}))
+        );
+
+        app.table_state.select(Some(0));
+        app.start_editing();
+        app.input_data.clear();
+        app.submit_edit().unwrap();
+        assert_eq!(
+            storage::load_data().unwrap().entries[0].data,
+            None,
+            "a blank field left the old data in place"
+        );
     }
 
     /// #70: the popover lists the custom JSON as key/value rows under a Data

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2210,75 +2210,22 @@ mod tests {
         with_data.data = Some(serde_json::json!({
             "pr": 42,
             "review": {"by": "linus"},
-            "files": ["a.rs", "b.rs"],
         }));
         seed(vec![with_data], 1);
 
         let mut app = App::new().unwrap();
         app.table_state.select(Some(0));
         app.open_detail();
-        let screen = frame_lines(&mut app, 100, 40);
-        let joined = screen.join("\n");
-        let row_of = |needle: &str| {
-            screen
-                .iter()
-                .position(|line| line.contains(needle))
-                .unwrap_or_else(|| panic!("{needle} is missing:\n{joined}"))
-        };
+        let screen = frame_lines(&mut app, 100, 40).join("\n");
 
-        // One popover row's text, with the frame it is drawn inside removed.
-        let inner = |row: usize| screen[row].trim_matches(['│', ' ']).to_string();
-        let header = screen
-            .iter()
-            .position(|line| line.trim_matches(['│', ' ']) == "Data")
-            .unwrap_or_else(|| panic!("no Data header:\n{joined}"));
+        assert!(screen.contains("Data"), "no Data header:\n{screen}");
+        assert!(screen.contains("pr"), "no key row:\n{screen}");
+        assert!(screen.contains("42"), "no value:\n{screen}");
         assert!(
-            inner(header + 1).is_empty(),
-            "no blank row under the Data header:\n{joined}"
+            screen.contains("review.by") && screen.contains("linus"),
+            "nesting was not flattened:\n{screen}"
         );
-        assert!(joined.contains("pr"), "no key row:\n{joined}");
-        assert!(joined.contains("42"), "no value:\n{joined}");
-        assert!(
-            joined.contains("review.by") && joined.contains("linus"),
-            "nesting was not flattened:\n{joined}"
-        );
-        // The list reads as a list: a heading, then one bullet per item.
-        assert_eq!(
-            inner(row_of("files:")),
-            "files:",
-            "the list heading carried a value:\n{joined}"
-        );
-        for (item, row) in [("a.rs", row_of("a.rs")), ("b.rs", row_of("b.rs"))] {
-            let shown = inner(row);
-            assert!(
-                shown.starts_with('-') && shown.ends_with(item),
-                "`{shown}` is not a bullet for {item}:\n{joined}"
-            );
-        }
-        assert!(!joined.contains("files[0]"), "indexed rows:\n{joined}");
-        assert!(!joined.contains('{'), "raw JSON leaked in:\n{joined}");
-    }
-
-    /// The written order is the rendered order, whatever the alphabet says.
-    #[test]
-    fn the_detail_popover_keeps_the_data_in_written_order() {
-        let _guard = env_guard();
-        sandbox("detail-data-order");
-        let mut with_data = entry(0, "has data");
-        with_data.data = Some(serde_json::from_str(r#"{"zebra": 1, "apple": 2}"#).unwrap());
-        seed(vec![with_data], 1);
-
-        let mut app = App::new().unwrap();
-        app.table_state.select(Some(0));
-        app.open_detail();
-        let screen = frame_lines(&mut app, 100, 40);
-        let row_of = |needle: &str| screen.iter().position(|l| l.contains(needle)).unwrap();
-
-        assert!(
-            row_of("zebra") < row_of("apple"),
-            "the rows were sorted:\n{}",
-            screen.join("\n")
-        );
+        assert!(!screen.contains('{'), "raw JSON leaked in:\n{screen}");
     }
 
     /// An entry without data is rendered exactly as it was before the field existed.

--- a/src/tui/render/form.rs
+++ b/src/tui/render/form.rs
@@ -92,6 +92,11 @@ const FIELDS: &[FormField] = &[
         " End Time (optional: e.g. 9am, 14:30, 25/03 9.30am) ",
         |a| &a.input_end_time,
     ),
+    (
+        InputField::Data,
+        " Data (optional: a JSON object, e.g. {\"pr\": 42}) ",
+        |a| &a.input_data,
+    ),
 ];
 
 /// The chunk the help row sits in: straight after the last field.
@@ -155,6 +160,19 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
         );
     }
 
+    // A refused save replaces the hint: the row says why nothing was written
+    // rather than the form appearing to ignore Enter.
+    let trailing = match &app.form_error {
+        // The same colour onboarding reports its own failure in.
+        Some(message) => Span::styled(
+            message.clone(),
+            Style::default().fg(theme::theme().duration_high).bold(),
+        ),
+        None => Span::styled(
+            "Need ≥2 of: Start, End, Duration".to_string(),
+            Style::default().fg(theme::border()),
+        ),
+    };
     let help = Paragraph::new(Line::from(vec![
         Span::styled("Tab", Style::default().fg(theme::accent())),
         Span::styled(": switch field | ", Style::default().fg(theme::inactive())),
@@ -162,10 +180,7 @@ pub(super) fn render_entry_form(f: &mut Frame, app: &App, area: Rect) {
         Span::styled(": save | ", Style::default().fg(theme::inactive())),
         Span::styled("Esc", Style::default().fg(theme::accent())),
         Span::styled(": cancel  ", Style::default().fg(theme::inactive())),
-        Span::styled(
-            "Need ≥2 of: Start, End, Duration",
-            Style::default().fg(theme::border()),
-        ),
+        trailing,
     ]))
     .block(
         Block::default()
@@ -218,6 +233,7 @@ mod tests {
                 InputField::Duration,
                 InputField::StartTime,
                 InputField::EndTime,
+                InputField::Data,
             ]
         );
     }

--- a/src/tui/render/popups.rs
+++ b/src/tui/render/popups.rs
@@ -308,36 +308,14 @@ pub(super) fn render_detail_popup(f: &mut Frame, app: &App) {
         .map(crate::entry_data::rows)
         .unwrap_or_default();
     if !data_rows.is_empty() {
-        let data_style = Style::default().fg(theme::highlight());
         lines.push(Line::from(label("Data")));
-        lines.push(Line::from(Span::raw("")));
-        for row in &data_rows {
-            match row {
-                // Aligned with every other field on the popover.
-                crate::entry_data::Row::Field { label: key, value } => {
-                    lines.extend(field(key, value, data_style, value_width));
-                }
-                crate::entry_data::Row::Heading(key) => lines.push(Line::from(label(key))),
-                // Tight against the bullet, so a list reads as a list; wrapped
-                // with a hanging indent under its own first character.
-                crate::entry_data::Row::Bullet { label: dash, value } => {
-                    let head = format!("  {} ", dash);
-                    let hanging = " ".repeat(head.chars().count());
-                    for (i, text) in wrap(value, value_width).into_iter().enumerate() {
-                        lines.push(Line::from(vec![
-                            Span::styled(
-                                if i == 0 {
-                                    head.clone()
-                                } else {
-                                    hanging.clone()
-                                },
-                                Style::default().fg(theme::title()),
-                            ),
-                            Span::styled(text, data_style),
-                        ]));
-                    }
-                }
-            }
+        for (key, item) in &data_rows {
+            lines.extend(field(
+                key,
+                item,
+                Style::default().fg(theme::highlight()),
+                value_width,
+            ));
         }
         lines.push(Line::from(Span::raw("")));
     }

--- a/src/tui/render/popups.rs
+++ b/src/tui/render/popups.rs
@@ -308,14 +308,36 @@ pub(super) fn render_detail_popup(f: &mut Frame, app: &App) {
         .map(crate::entry_data::rows)
         .unwrap_or_default();
     if !data_rows.is_empty() {
+        let data_style = Style::default().fg(theme::highlight());
         lines.push(Line::from(label("Data")));
-        for (key, item) in &data_rows {
-            lines.extend(field(
-                key,
-                item,
-                Style::default().fg(theme::highlight()),
-                value_width,
-            ));
+        lines.push(Line::from(Span::raw("")));
+        for row in &data_rows {
+            match row {
+                // Aligned with every other field on the popover.
+                crate::entry_data::Row::Field { label: key, value } => {
+                    lines.extend(field(key, value, data_style, value_width));
+                }
+                crate::entry_data::Row::Heading(key) => lines.push(Line::from(label(key))),
+                // Tight against the bullet, so a list reads as a list; wrapped
+                // with a hanging indent under its own first character.
+                crate::entry_data::Row::Bullet { label: dash, value } => {
+                    let head = format!("  {} ", dash);
+                    let hanging = " ".repeat(head.chars().count());
+                    for (i, text) in wrap(value, value_width).into_iter().enumerate() {
+                        lines.push(Line::from(vec![
+                            Span::styled(
+                                if i == 0 {
+                                    head.clone()
+                                } else {
+                                    hanging.clone()
+                                },
+                                Style::default().fg(theme::title()),
+                            ),
+                            Span::styled(text, data_style),
+                        ]));
+                    }
+                }
+            }
         }
         lines.push(Line::from(Span::raw("")));
     }

--- a/src/tui/render/popups.rs
+++ b/src/tui/render/popups.rs
@@ -300,6 +300,26 @@ pub(super) fn render_detail_popup(f: &mut Frame, app: &App) {
     }
     lines.push(Line::from(Span::raw("")));
 
+    // The custom JSON, flattened to one labelled row per leaf. Absent entirely
+    // when there is no data, so the popover is unchanged for entries without it.
+    let data_rows = entry
+        .data
+        .as_ref()
+        .map(crate::entry_data::rows)
+        .unwrap_or_default();
+    if !data_rows.is_empty() {
+        lines.push(Line::from(label("Data")));
+        for (key, item) in &data_rows {
+            lines.extend(field(
+                key,
+                item,
+                Style::default().fg(theme::highlight()),
+                value_width,
+            ));
+        }
+        lines.push(Line::from(Span::raw("")));
+    }
+
     let (marker, marker_style) = if entry.is_active() {
         (" active ", Style::default().fg(theme::active()).bold())
     } else {

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -97,6 +97,9 @@ pub enum InputField {
     StartTime,
     EndTime,
     Duration,
+    /// Custom JSON, edited as one line of compact JSON. Validated on save, never
+    /// while typing — see `App::submit_entry`.
+    Data,
 }
 
 /// One of the two collapsible value pickers above the tabs row.


### PR DESCRIPTION
Implements #69 and its sub-issues, one commit per piece.

## What

An entry can carry a JSON object of its own, written from the CLI or the TUI
form and read back as key/value rows in the detail popover.

- `TimeEntry.data: Option<serde_json::Value>` — always an object, skipped when
  unset so existing stores are byte-identical on disk. `src/entry_data.rs` is
  the only thing that parses, validates or formats it.
- `--data ''{"pr": 42}''` on `tt start`, `tt log`, `tt agent item` and
  `tt agent end`. Invalid JSON, or valid JSON that is not an object, is a
  usage error. On `tt log --trim` the data is set before the split, so every
  piece carries it.
- The detail popover gains a **Data** section: one row per leaf, nesting
  flattened to `review.by` and arrays to `files[0]`. Absent entirely for
  entries without data.
- The entry form gains a **Data** field, last in the Tab order, editing the
  same value as one line of compact JSON. Blank clears it. A value that will
  not parse refuses the save, keeps the form open on what was typed and states
  the reason in the help row until the next keystroke.

## Closes

- Closes #70 — json renderer in the details view
- Closes #71 — `--data` flag on the commands
- Closes #72 — invalid json is refused on save and on the command line
- Closes #73 — json editor in the edit view

## Notes

The TUI editor is a single-line compact-JSON field rather than a multi-line
editor: `TextInput` is single-line, and a real multi-line widget is a bigger
change than this issue asks for. If a wrapping editor is wanted, that is worth
its own issue.

Verified with `cargo test`, `cargo clippy --all-targets -- -D warnings`,
`cargo fmt --check`, and a manual round-trip against a sandboxed store
confirming `data` is written only where set.