### PR TITLE
feat(install): add Git Bash support for Windows installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ set -eu
 
 REPO="linus-skold/timetracker-rs"
 INSTALL_DIR="${TT_INSTALL_DIR:-$HOME/.local/bin}"
+windows_target="pc-windows-msvc"
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -19,7 +20,7 @@ case "$os" in
   Linux) os_part="unknown-linux-gnu" ;;
   Darwin) os_part="apple-darwin" ;;
   MINGW*|MSYS*|CYGWIN*)
-    os_part="pc-windows-msvc"
+    os_part="$windows_target"
     bin_name="tt.exe"
     ;;
   *)
@@ -35,7 +36,7 @@ case "$arch" in
       echo "error: no prebuilt tt binary for Linux/$arch yet" >&2
       exit 1
     fi
-    if [ "$os_part" = "pc-windows-msvc" ]; then
+    if [ "$os_part" = "$windows_target" ]; then
       echo "error: no prebuilt tt binary for Windows/$arch yet" >&2
       exit 1
     fi
@@ -49,7 +50,7 @@ esac
 
 target="${arch_part}-${os_part}"
 asset="tt-${target}"
-if [ "$os_part" = "pc-windows-msvc" ]; then
+if [ "$os_part" = "$windows_target" ]; then
   asset="${asset}.exe"
 fi
 url="https://github.com/${REPO}/releases/latest/download/${asset}"
@@ -74,7 +75,7 @@ trap - EXIT
 
 echo "Installed tt to $INSTALL_DIR/$bin_name"
 
-if [ "$os_part" = "pc-windows-msvc" ]; then
+if [ "$os_part" = "$windows_target" ]; then
   bashrc="$HOME/.bashrc"
   case "$INSTALL_DIR" in
     "$HOME")

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Installs the latest tt (timetracker-rs) release for Linux/macOS.
+# Installs the latest tt (timetracker-rs) release for Linux/macOS/Git Bash on Windows x86_64.
 #
 #   curl -fsSL https://raw.githubusercontent.com/linus-skold/timetracker-rs/main/install.sh | sh
 #
@@ -13,10 +13,15 @@ INSTALL_DIR="${TT_INSTALL_DIR:-$HOME/.local/bin}"
 
 os="$(uname -s)"
 arch="$(uname -m)"
+bin_name="tt"
 
 case "$os" in
   Linux) os_part="unknown-linux-gnu" ;;
   Darwin) os_part="apple-darwin" ;;
+  MINGW*|MSYS*|CYGWIN*)
+    os_part="pc-windows-msvc"
+    bin_name="tt.exe"
+    ;;
   *)
     echo "error: unsupported OS: $os" >&2
     exit 1
@@ -30,6 +35,10 @@ case "$arch" in
       echo "error: no prebuilt tt binary for Linux/$arch yet" >&2
       exit 1
     fi
+    if [ "$os_part" = "pc-windows-msvc" ]; then
+      echo "error: no prebuilt tt binary for Windows/$arch yet" >&2
+      exit 1
+    fi
     arch_part="aarch64"
     ;;
   *)
@@ -40,6 +49,9 @@ esac
 
 target="${arch_part}-${os_part}"
 asset="tt-${target}"
+if [ "$os_part" = "pc-windows-msvc" ]; then
+  asset="${asset}.exe"
+fi
 url="https://github.com/${REPO}/releases/latest/download/${asset}"
 
 mkdir -p "$INSTALL_DIR"
@@ -57,10 +69,44 @@ else
 fi
 
 chmod +x "$tmp"
-mv "$tmp" "$INSTALL_DIR/tt"
+mv "$tmp" "$INSTALL_DIR/$bin_name"
 trap - EXIT
 
-echo "Installed tt to $INSTALL_DIR/tt"
+echo "Installed tt to $INSTALL_DIR/$bin_name"
+
+if [ "$os_part" = "pc-windows-msvc" ]; then
+  bashrc="$HOME/.bashrc"
+  case "$INSTALL_DIR" in
+    "$HOME")
+      path_export='export PATH="$HOME:$PATH"'
+      ;;
+    "$HOME"/*)
+      install_dir_suffix="${INSTALL_DIR#"$HOME"/}"
+      path_export="export PATH=\"\$HOME/$install_dir_suffix:\$PATH\""
+      ;;
+    *)
+      path_export="export PATH=\"$INSTALL_DIR:\$PATH\""
+      ;;
+  esac
+  bashrc_updated=0
+
+  if [ -f "$bashrc" ]; then
+    if ! grep -F "$path_export" "$bashrc" >/dev/null 2>&1; then
+      if printf '\n%s\n' "$path_export" >> "$bashrc"; then
+        bashrc_updated=1
+      fi
+    fi
+  else
+    if printf '%s\n' "$path_export" > "$bashrc"; then
+      bashrc_updated=1
+    fi
+  fi
+
+  if [ "$bashrc_updated" -eq 1 ]; then
+    echo "Added $INSTALL_DIR to $bashrc."
+    echo "Run: source $bashrc"
+  fi
+fi
 
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;
@@ -73,7 +119,7 @@ case ":$PATH:" in
 esac
 
 # Mirrors the per-shell hint table in src/commands.rs (`completions`).
-if "$INSTALL_DIR/tt" completions --help >/dev/null 2>&1; then
+if "$INSTALL_DIR/$bin_name" completions --help >/dev/null 2>&1; then
   echo
   echo "Shell completion is available. To enable it, run:"
   case "$(basename "${SHELL:-}")" in
@@ -86,4 +132,4 @@ if "$INSTALL_DIR/tt" completions --help >/dev/null 2>&1; then
   esac
 fi
 
-"$INSTALL_DIR/tt" --version || true
+"$INSTALL_DIR/$bin_name" --version || true


### PR DESCRIPTION
### Description

Installer now works when run from Git Bash on Windows. Script detects Git Bash/MSYS/Cygwin environments, resolves Windows release target, downloads Windows executable, installs as `tt.exe`, and ensures install directory is available in future Git Bash sessions via `~/.bashrc` update when needed. Linux and macOS paths remain same.

### Changes

- Added Windows shell detection for MINGW*|MSYS*|CYGWIN* so Git Bash resolves correctly.
- Mapped detected Windows environment to pc-windows-msvc target so release URL points to Windows artifact.
- Selected .exe artifact for Windows target and installed binary as tt.exe, required for executable resolution on Windows.
- Added Windows-only PATH persistence step to append export line to `~/.bashrc` only when missing, so new Git Bash sessions can run `tt` without manual reconfiguration.
- Kept existing Linux/macOS flow intact to avoid behavior drift outside Windows support.

### Test this PR

1. **Install from Git Bash (Windows x64)**

   ```bash
   curl -fsSL "https://raw.githubusercontent.com/<owner>/timetracker-rs/<branch>/install.sh" | sh
   ```

   **Expected result:**
   - Installer detects Windows Git Bash (`MINGW/MSYS/CYGWIN`)
   - Downloads Windows asset (`...-pc-windows-msvc.exe`)
   - Installs binary as `tt.exe` into `~/.local/bin` (or `$TT_INSTALL_DIR`)
   - Prints install success message

2. **Run installed binary directly**

   ```bash
   ~/.local/bin/tt.exe --version
   ```

   If using custom install directory:

   ```bash
   "$TT_INSTALL_DIR/tt.exe" --version
   ```

   **Expected result:**
   - Version printed
   - Exit code `0`

3. **Verify PATH persistence logic (`~/.bashrc`)**

   ```bash
   grep -F 'export PATH="$HOME/.local/bin:$PATH"' ~/.bashrc
   ```

   If using custom directory, check matching export line for that directory.

   Re-run installer:

   ```bash
   curl -fsSL "https://raw.githubusercontent.com/<owner>/timetracker-rs/<branch>/install.sh" | sh
   ```

   **Expected result:**
   - PATH export exists once
   - No duplicate line appended on re-run

4. **Verify PATH in new shell**

   Open new Git Bash window, then run:

   ```bash
   tt --version
   ```

   **Expected result:**
   - `tt` resolves from `PATH`
   - Version printed

5. **Smoke-check Linux/macOS behavior unchanged**

   ```bash
   curl -fsSL "https://raw.githubusercontent.com/<owner>/timetracker-rs/<branch>/install.sh" | sh
   tt --version
   ```

   **Expected result:**
   - Existing flow unchanged
   - Installs `tt` (not `.exe`)
   - Command runs normally