### PR TITLE
feat(tui): persist the pane toggles across sessions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -335,9 +335,9 @@ round_minutes = 0           # 0 logs the actual minutes; N rounds `tt agent end`
 
 [layout]
 show_projects = true   # whether the Projects, Agent, Summary, and Tags panels
-show_agents = false    # start open. Their toggle keys (P/A/S/T) always work
-show_summary = false   # regardless of these defaults.
-show_tags = true
+show_agents = false    # start open. Pressing their toggle keys (P/A/S/T) writes
+show_summary = false   # this section back, so the panels come back next run the
+show_tags = true       # way you left them.
 
 [general]
 onboarding = true          # shown until answered; the app then sets this to false
@@ -346,7 +346,9 @@ auto_check_updates = true  # startup check for a newer release; see `tt update`
 
 `[layout]` and `[general].onboarding` are written automatically the first time
 the TUI runs and its onboarding popup is answered (`s` to move on, `Esc` to
-skip); neither needs to be hand-edited, though both can be. Onboarding's
+skip); `[layout]` is rewritten on every later `P`/`A`/`S`/`T` toggle too, which
+leaves `onboarding` alone. Neither needs to be hand-edited, though both can be.
+Onboarding's
 second screen offers to run `npx skills add linus-skold/timetracker-rs`,
 installing the `AGENTS.md` time-logging contract as a skill for whatever
 coding agent you use.

--- a/src/config.rs
+++ b/src/config.rs
@@ -378,11 +378,22 @@ pub fn updates_enabled(general: &GeneralConfig) -> bool {
 }
 
 /// Persists `[layout]` (replaced wholesale) and sets `[general].onboarding =
-/// false` so the popup stays quiet after running once; other sections pass
-/// through untouched. A parse failure warns and starts fresh rather than
-/// erroring, since an `Err` here would skip the TUI's terminal restore on
-/// the way out.
+/// false` so the popup stays quiet after running once.
 pub fn save_onboarding(layout: &LayoutConfig) -> Result<()> {
+    write_layout(layout, true)
+}
+
+/// Persists `[layout]` alone, leaving `[general].onboarding` as it is — what a
+/// `P`/`T`/`A`/`S` toggle writes, so the surfaces come back the way they were
+/// left without that also counting as having onboarded.
+pub fn save_layout(layout: &LayoutConfig) -> Result<()> {
+    write_layout(layout, false)
+}
+
+/// `[layout]` is replaced wholesale; other sections pass through untouched. A
+/// parse failure warns and starts fresh rather than erroring, since an `Err`
+/// here would skip the TUI's terminal restore on the way out.
+fn write_layout(layout: &LayoutConfig, mark_onboarded: bool) -> Result<()> {
     let Some(path) = config_path() else {
         anyhow::bail!("no config path available (no home/APPDATA directory found)");
     };
@@ -394,7 +405,7 @@ pub fn save_onboarding(layout: &LayoutConfig) -> Result<()> {
             Ok(doc) => doc,
             Err(e) => {
                 eprintln!(
-                    "Warning: config file {} failed to parse while saving onboarding's answer \
+                    "Warning: config file {} failed to parse while saving the layout \
                      ({e:#}); other sections in it will be lost.",
                     path.display()
                 );
@@ -422,25 +433,27 @@ pub fn save_onboarding(layout: &LayoutConfig) -> Result<()> {
         "layout".to_string(),
         toml::Value::try_from(layout).context("serializing layout config")?,
     );
-    match table
-        .entry("general".to_string())
-        .or_insert_with(|| toml::Value::Table(Default::default()))
-        .as_table_mut()
-    {
-        Some(general) => {
-            general.insert("onboarding".to_string(), toml::Value::Boolean(false));
-        }
-        None => {
-            // `general` exists but is not itself a table — replace just that
-            // key rather than failing the whole save.
-            table.insert(
-                "general".to_string(),
-                toml::Value::try_from(GeneralConfig {
-                    onboarding: Some(false),
-                    ..Default::default()
-                })
-                .context("serializing general config")?,
-            );
+    if mark_onboarded {
+        match table
+            .entry("general".to_string())
+            .or_insert_with(|| toml::Value::Table(Default::default()))
+            .as_table_mut()
+        {
+            Some(general) => {
+                general.insert("onboarding".to_string(), toml::Value::Boolean(false));
+            }
+            None => {
+                // `general` exists but is not itself a table — replace just that
+                // key rather than failing the whole save.
+                table.insert(
+                    "general".to_string(),
+                    toml::Value::try_from(GeneralConfig {
+                        onboarding: Some(false),
+                        ..Default::default()
+                    })
+                    .context("serializing general config")?,
+                );
+            }
         }
     }
 
@@ -533,6 +546,28 @@ mod tests {
         let saved = load();
         assert_eq!(saved.layout.show_projects, Some(true));
         assert_eq!(saved.general.onboarding, Some(false));
+        drop(dir);
+    }
+
+    /// A pane toggle saves the layout without also claiming onboarding ran,
+    /// so someone who never finished the popup still sees it next run.
+    #[test]
+    fn save_layout_leaves_the_onboarding_flag_alone() {
+        let _guard = crate::storage::env_guard();
+        let dir = crate::storage::env_sandbox("save-layout-no-onboarding");
+
+        save_layout(&LayoutConfig {
+            show_projects: Some(true),
+            show_agents: Some(true),
+            show_summary: Some(false),
+            show_tags: Some(false),
+        })
+        .unwrap();
+
+        let saved = load();
+        assert_eq!(saved.layout.show_agents, Some(true));
+        assert_eq!(saved.general.onboarding, None);
+        assert!(should_onboard(&saved.general));
         drop(dir);
     }
 

--- a/src/tui/marks_surface.rs
+++ b/src/tui/marks_surface.rs
@@ -64,5 +64,6 @@ impl App {
         self.show_marks = !self.show_marks;
         // Opening the surface must not show a second of nothing.
         self.liveness_at = None;
+        self.persist_layout();
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -234,6 +234,24 @@ impl App {
         Ok(result)
     }
 
+    /// Which surfaces are open right now, in config shape.
+    pub(crate) fn layout_config(&self) -> crate::config::LayoutConfig {
+        crate::config::LayoutConfig {
+            show_projects: Some(self.show_projects),
+            show_agents: Some(self.show_marks),
+            show_summary: Some(self.show_summary),
+            show_tags: Some(self.show_tags),
+        }
+    }
+
+    /// Write the open surfaces back to the config file, so the next run starts
+    /// the way this one was left. Best-effort: a failed write must not take the
+    /// session down, and the terminal is in raw mode so there is nowhere to
+    /// report it — the toggle still holds for the rest of the session.
+    pub(crate) fn persist_layout(&self) {
+        let _ = crate::config::save_layout(&self.layout_config());
+    }
+
     /// The one place `data` is replaced, by `mutate_store` and by `reload`.
     /// Bumping `data_revision` here is what makes the derived-view caches notice
     /// the new store, so a bare `self.data = …` elsewhere would go unseen.
@@ -1339,6 +1357,33 @@ mod tests {
         assert!(app.leases.is_empty(), "no beats read while hidden");
         assert!(app.unaccounted.is_empty(), "and nothing reconciled");
         assert!(app.liveness_at.is_none(), "the interval never started");
+    }
+
+    /// Toggling a surface writes it back, so the next run opens the same way.
+    /// Read off disk rather than through `config::load`, whose resolved value
+    /// is cached for the process once read.
+    #[test]
+    fn toggling_a_surface_persists_the_layout() {
+        let _guard = env_guard();
+        sandbox("layout-persist");
+        seed(vec![entry(0, "first")], 1);
+
+        let mut app = App::new().unwrap();
+        assert!(!app.show_tags && !app.show_marks, "hidden by default");
+        app.toggle_pane(Pane::Tags);
+        app.toggle_marks();
+        app.toggle_summary();
+
+        let path = std::env::var("TT_CONFIG_FILE").unwrap();
+        let text = std::fs::read_to_string(path).expect("a written config file");
+        let saved: toml::Value = toml::from_str(&text).expect("valid TOML");
+        let layout = &saved["layout"];
+        assert_eq!(layout["show_tags"].as_bool(), Some(true));
+        assert_eq!(layout["show_agents"].as_bool(), Some(true));
+        assert_eq!(layout["show_summary"].as_bool(), Some(true));
+        assert_eq!(layout["show_projects"].as_bool(), Some(false));
+        // A toggle is not an onboarding answer.
+        assert!(saved.get("general").is_none(), "onboarding left untouched");
     }
 
     #[test]

--- a/src/tui/panes.rs
+++ b/src/tui/panes.rs
@@ -273,6 +273,7 @@ impl App {
                 .copied()
                 .map_or(Focus::Table, Focus::Pane);
         }
+        self.persist_layout();
     }
 
     /// `Tab`: entries table → each visible pane, left to right → back.

--- a/src/tui/summary.rs
+++ b/src/tui/summary.rs
@@ -108,6 +108,7 @@ impl App {
     /// `Shift-S`: show or hide the surface.
     pub(crate) fn toggle_summary(&mut self) {
         self.show_summary = !self.show_summary;
+        self.persist_layout();
     }
 }
 


### PR DESCRIPTION
P/A/S/T now write [layout] back to the config file, so the Projects, Agent, Summary and Tags surfaces reopen the way they were left. Splits save_onboarding into a shared write_layout: save_layout writes only [layout], leaving [general].onboarding untouched, so a toggle is not mistaken for having answered the onboarding popup.