### PR TITLE
chore(mise): add a bump task for the crate version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,18 @@
 [tools]
 rust = "1.95.0"
+# Provides `cargo set-version`, which the `bump` task below drives.
+"cargo:cargo-edit" = "latest"
+
+# `mise bump patch` (also minor, major). mise appends the trailing argument to
+# the command, so the level reaches `--bump` as-is; cargo rejects anything that
+# is not a valid level.
+#
+# Rewrites `version` in Cargo.toml *and* the crate's own entry in Cargo.lock, so
+# the two stay in step without a build. CI reads the version straight out of
+# Cargo.toml and tags the release from it — see .github/workflows/build.yml.
+#
+# Leaves the change uncommitted on purpose: the bump goes to main as its own
+# `chore: version bump X.Y.Z` PR, and merging that is what cuts the release.
+[tasks.bump]
+description = "Bump the crate version in Cargo.toml and Cargo.lock: mise bump <major|minor|patch>"
+run = "cargo set-version --bump"

--- a/readme.md
+++ b/readme.md
@@ -41,3 +41,17 @@ tt today
 
 See [docs/usage.md](docs/usage.md) for the full command reference, duration
 format, tags, data storage location, and configuration file options.
+
+## Releasing
+
+Releases are cut from `Cargo.toml`: pushing a version to `main` that has no
+matching tag makes CI tag it and publish the binaries. To bump it, with
+[mise](https://mise.jdx.dev) installed:
+
+```sh
+mise bump patch   # or: minor, major
+```
+
+That rewrites the version in both `Cargo.toml` and `Cargo.lock` without a
+build. Commit the two files as `chore: version bump X.Y.Z` and open a PR;
+merging it is what releases.


### PR DESCRIPTION
`mise bump <major|minor|patch>` runs `cargo set-version --bump`, which rewrites the version in both Cargo.toml and Cargo.lock without a build — CI reads the version out of Cargo.toml and tags the release from it, so the two must not drift.

mise appends the trailing argument to the run command, so no template or shell expansion is involved and the task behaves the same on Windows and POSIX.